### PR TITLE
feat: Add feed-based episode fetching with --latest and --episode flags

### DIFF
--- a/src/inkwell/cli.py
+++ b/src/inkwell/cli.py
@@ -685,6 +685,9 @@ def fetch_command(
             # Resolve feed name to episode URL if needed
             url = url_or_feed
             resolved_category = category
+            # Auth credentials for private feeds (passed to audio downloader)
+            auth_username: str | None = None
+            auth_password: str | None = None
 
             # Check if url_or_feed is a configured feed name (not a URL)
             is_url = url_or_feed.startswith(("http://", "https://", "www."))
@@ -747,6 +750,11 @@ def fetch_command(
                     if not resolved_category and feed_config.category:
                         resolved_category = feed_config.category
 
+                    # Extract auth credentials for audio download (basic auth only)
+                    if feed_config.auth and feed_config.auth.type == "basic":
+                        auth_username = feed_config.auth.username
+                        auth_password = feed_config.auth.password
+
             # Determine total steps for progress display
             will_interview = interview or config.interview.auto_start
             total_steps = 5 if will_interview else 4
@@ -769,6 +777,8 @@ def fetch_command(
                 interview_template=interview_template,
                 interview_format=interview_format,
                 max_questions=max_questions,
+                auth_username=auth_username,
+                auth_password=auth_password,
             )
 
             # Create orchestrator and progress callback

--- a/src/inkwell/pipeline/models.py
+++ b/src/inkwell/pipeline/models.py
@@ -27,6 +27,9 @@ class PipelineOptions:
     interview_template: str | None = None
     interview_format: str | None = None
     max_questions: int | None = None
+    # Audio download authentication (for private feeds)
+    auth_username: str | None = None
+    auth_password: str | None = None
 
 
 @dataclass

--- a/src/inkwell/pipeline/orchestrator.py
+++ b/src/inkwell/pipeline/orchestrator.py
@@ -98,7 +98,11 @@ class PipelineOrchestrator:
         if progress_callback:
             progress_callback("transcription_start", {})
 
-        transcript_result = await self._transcribe(options.url)
+        transcript_result = await self._transcribe(
+            options.url,
+            auth_username=options.auth_username,
+            auth_password=options.auth_password,
+        )
 
         if progress_callback:
             progress_callback("transcription_complete", {
@@ -256,11 +260,18 @@ class PipelineOrchestrator:
             interview_cost_usd=interview_cost,
         )
 
-    async def _transcribe(self, url: str) -> "TranscriptionResult":
+    async def _transcribe(
+        self,
+        url: str,
+        auth_username: str | None = None,
+        auth_password: str | None = None,
+    ) -> "TranscriptionResult":
         """Transcribe episode from URL.
 
         Args:
             url: Episode URL
+            auth_username: Username for authenticated audio downloads (private feeds)
+            auth_password: Password for authenticated audio downloads (private feeds)
 
         Returns:
             TranscriptionResult
@@ -272,7 +283,13 @@ class PipelineOrchestrator:
             config=self.config.transcription,
             cost_tracker=self.cost_tracker
         )
-        result = await manager.transcribe(url, use_cache=True, skip_youtube=False)
+        result = await manager.transcribe(
+            url,
+            use_cache=True,
+            skip_youtube=False,
+            auth_username=auth_username,
+            auth_password=auth_password,
+        )
 
         if not result.success:
             raise InkwellError(f"Transcription failed: {result.error}")

--- a/src/inkwell/transcription/manager.py
+++ b/src/inkwell/transcription/manager.py
@@ -120,6 +120,8 @@ class TranscriptionManager:
         episode_url: str,
         use_cache: bool = True,
         skip_youtube: bool = False,
+        auth_username: str | None = None,
+        auth_password: str | None = None,
     ) -> TranscriptionResult:
         """Transcribe episode using multi-tier strategy.
 
@@ -133,6 +135,8 @@ class TranscriptionManager:
             episode_url: Episode URL to transcribe
             use_cache: Whether to use cache (default: True)
             skip_youtube: Skip YouTube tier, go straight to Gemini (default: False)
+            auth_username: Username for authenticated audio downloads (private feeds)
+            auth_password: Password for authenticated audio downloads (private feeds)
 
         Returns:
             TranscriptionResult with transcript and metadata
@@ -195,8 +199,12 @@ class TranscriptionManager:
 
         attempts.append("gemini")
         try:
-            # Download audio
-            audio_path = await self.audio_downloader.download(episode_url)
+            # Download audio (with auth credentials for private feeds)
+            audio_path = await self.audio_downloader.download(
+                episode_url,
+                username=auth_username,
+                password=auth_password,
+            )
 
             # Transcribe with Gemini
             transcript = await self.gemini_transcriber.transcribe(audio_path, episode_url)


### PR DESCRIPTION
Implements the missing workflow from the PRD to fetch episodes by feed name:
- inkwell fetch <feed-name> --latest
- inkwell fetch <feed-name> --episode "keyword"

Also adds new 'episodes' command to list episodes from a configured feed:
- inkwell episodes <feed-name>

The fetch command now:
- Detects if argument is a feed name vs URL
- Parses RSS feed to extract episode audio URL
- Uses feed's category if not overridden

Fixes the gap where users could add feeds but had no way to browse
or fetch episodes from them without manually extracting the audio URL.