### PR TITLE
feat: Direct URL captures go to _inbox with smart title extraction

### DIFF
--- a/src/inkwell/cli.py
+++ b/src/inkwell/cli.py
@@ -28,6 +28,11 @@ from inkwell.utils.errors import (
     ValidationError,
 )
 from inkwell.utils.progress import PipelineProgress
+from inkwell.utils.url_metadata import (
+    INBOX_PODCAST_NAME,
+    extract_url_metadata,
+    get_episode_title_from_metadata,
+)
 
 app = typer.Typer(
     name="inkwell",
@@ -730,6 +735,11 @@ def fetch_command(
     resume_session: str | None = typer.Option(
         None, "--resume-session", help="Resume specific interview session by ID"
     ),
+    podcast: str | None = typer.Option(
+        None,
+        "--podcast",
+        help="Podcast name for direct URL captures (default: _inbox)",
+    ),
 ) -> None:
     """Fetch and process a podcast episode.
 
@@ -852,12 +862,24 @@ def fetch_command(
                 # Determine if interview will be included for progress display
                 will_interview = interview or config.interview.auto_start
 
-                # Extract episode metadata if available from feed parsing
+                # Extract episode metadata
                 episode_title: str | None = None
                 podcast_name: str | None = None
+
                 if ep is not None:
+                    # Feed mode: use episode metadata from RSS
                     episode_title = ep.title
                     podcast_name = ep.podcast_name or url_or_feed
+                else:
+                    # Direct URL mode: extract metadata from URL
+                    console.print("[dim]Extracting episode metadata...[/dim]")
+                    url_metadata = await extract_url_metadata(url)
+                    episode_title = get_episode_title_from_metadata(url_metadata, url)
+                    # Use --podcast override or default to _inbox
+                    podcast_name = podcast or INBOX_PODCAST_NAME
+                    console.print(
+                        f"[green]✓[/green] {episode_title} → [cyan]{podcast_name}/[/cyan]"
+                    )
 
                 # Compute effective output directory
                 effective_output_dir = output_dir or config.default_output_dir

--- a/src/inkwell/cli.py
+++ b/src/inkwell/cli.py
@@ -872,13 +872,14 @@ def fetch_command(
                     podcast_name = ep.podcast_name or url_or_feed
                 else:
                     # Direct URL mode: extract metadata from URL
-                    console.print("[dim]Extracting episode metadata...[/dim]")
-                    url_metadata = await extract_url_metadata(url)
+                    with console.status("[dim]Extracting episode metadata...[/dim]"):
+                        url_metadata = await extract_url_metadata(url)
                     episode_title = get_episode_title_from_metadata(url_metadata, url)
                     # Use --podcast override or default to _inbox
                     podcast_name = podcast or INBOX_PODCAST_NAME
                     console.print(
-                        f"[green]✓[/green] {episode_title} → [cyan]{podcast_name}/[/cyan]"
+                        f"[dim]Episode:[/dim] {episode_title}\n"
+                        f"[dim]Destination:[/dim] [cyan]{podcast_name}/[/cyan]"
                     )
 
                 # Compute effective output directory

--- a/src/inkwell/pipeline/orchestrator.py
+++ b/src/inkwell/pipeline/orchestrator.py
@@ -23,6 +23,10 @@ from inkwell.utils.api_keys import APIKeyError, get_validated_api_key
 from inkwell.utils.costs import CostTracker
 from inkwell.utils.datetime import now_utc
 from inkwell.utils.errors import InkwellError
+from inkwell.utils.url_metadata import (
+    INBOX_PODCAST_NAME,
+    create_fallback_title,
+)
 
 from .models import PipelineOptions, PipelineResult
 
@@ -89,7 +93,7 @@ class PipelineOrchestrator:
         Returns:
             List of templates that need processing
         """
-        templates_to_process: list["ExtractionTemplate"] = []
+        templates_to_process: list[ExtractionTemplate] = []
         existing_versions = existing_output.metadata.templates_versions
 
         for template in templates:
@@ -203,9 +207,10 @@ class PipelineOrchestrator:
         )
 
         # Create episode metadata (use values from options if available)
+        # Fallbacks use _inbox for podcast and a readable title from URL
         episode_metadata = EpisodeMetadata(
-            podcast_name=options.podcast_name or "Unknown Podcast",
-            episode_title=options.episode_title or f"Episode from {options.url}",
+            podcast_name=options.podcast_name or INBOX_PODCAST_NAME,
+            episode_title=options.episode_title or create_fallback_title(options.url),
             episode_url=options.url,
             transcription_source=transcript_result.transcript.source,
         )

--- a/src/inkwell/utils/url_metadata.py
+++ b/src/inkwell/utils/url_metadata.py
@@ -1,0 +1,213 @@
+"""URL metadata extraction for direct URL captures.
+
+Extracts meaningful titles and creates short slugs from URLs,
+supporting YouTube, audio files, and generic URLs.
+"""
+
+import hashlib
+import logging
+import re
+from urllib.parse import parse_qs, urlparse
+
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+# Default podcast name for direct URL captures
+INBOX_PODCAST_NAME = "_inbox"
+
+
+class URLMetadata(BaseModel):
+    """Metadata extracted from a URL."""
+
+    title: str | None = None
+    video_id: str | None = None
+    domain: str | None = None
+    duration_seconds: float | None = None
+
+    @property
+    def short_slug(self) -> str:
+        """Get a short identifier for the URL.
+
+        Priority:
+        1. Video ID (for YouTube, etc.)
+        2. First 12 chars of URL hash
+
+        Returns:
+            Short, filesystem-safe identifier
+        """
+        if self.video_id:
+            return self.video_id
+        # Fallback to hash - should not happen if video_id is extracted
+        return "unknown"
+
+
+def extract_youtube_id(url: str) -> str | None:
+    """Extract YouTube video ID from URL.
+
+    Handles various YouTube URL formats:
+    - youtube.com/watch?v=ID
+    - youtu.be/ID
+    - youtube.com/embed/ID
+    - youtube.com/v/ID
+
+    Args:
+        url: YouTube URL
+
+    Returns:
+        Video ID or None if not a YouTube URL
+    """
+    parsed = urlparse(url)
+    host = parsed.netloc.lower().replace("www.", "")
+
+    if host in ("youtube.com", "m.youtube.com"):
+        # Standard watch URL
+        if parsed.path == "/watch":
+            query = parse_qs(parsed.query)
+            if "v" in query:
+                return query["v"][0]
+        # Embed or v URL
+        elif parsed.path.startswith(("/embed/", "/v/")):
+            parts = parsed.path.split("/")
+            if len(parts) >= 3:
+                return parts[2].split("?")[0]
+    elif host == "youtu.be":
+        # Short URL
+        return parsed.path.lstrip("/").split("?")[0]
+
+    return None
+
+
+def extract_url_slug(url: str) -> str:
+    """Extract a short slug from any URL.
+
+    For non-YouTube URLs, creates a short hash-based identifier.
+
+    Args:
+        url: Any URL
+
+    Returns:
+        Short, filesystem-safe slug (8-12 chars)
+    """
+    # Try YouTube first
+    yt_id = extract_youtube_id(url)
+    if yt_id:
+        return yt_id
+
+    # For other URLs, use a hash of the full URL
+    url_hash = hashlib.sha256(url.encode()).hexdigest()[:12]
+    return url_hash
+
+
+def extract_filename_from_url(url: str) -> str | None:
+    """Extract filename from URL path.
+
+    Args:
+        url: URL to extract filename from
+
+    Returns:
+        Filename without extension, or None
+    """
+    parsed = urlparse(url)
+    path = parsed.path
+
+    # Get last path segment
+    if "/" in path:
+        filename = path.rsplit("/", 1)[-1]
+        # Remove extension
+        if "." in filename:
+            filename = filename.rsplit(".", 1)[0]
+        # Clean up
+        filename = re.sub(r"[^\w\s-]", "", filename)
+        filename = re.sub(r"[-\s]+", "-", filename).strip("-")
+        if filename and len(filename) > 3:
+            return filename
+
+    return None
+
+
+def create_fallback_title(url: str) -> str:
+    """Create a fallback title from URL when no metadata is available.
+
+    Args:
+        url: Source URL
+
+    Returns:
+        Human-readable fallback title
+    """
+    # Try to get filename from URL
+    filename = extract_filename_from_url(url)
+    if filename:
+        # Convert slug back to title case
+        return filename.replace("-", " ").title()
+
+    # Use domain + short ID
+    parsed = urlparse(url)
+    domain = parsed.netloc.replace("www.", "").split(".")[0].title()
+    short_id = extract_url_slug(url)[:8]
+
+    return f"{domain} {short_id}"
+
+
+async def extract_url_metadata(url: str) -> URLMetadata:
+    """Extract metadata from URL without downloading.
+
+    Uses yt-dlp to fetch metadata when available.
+
+    Args:
+        url: URL to extract metadata from
+
+    Returns:
+        URLMetadata with extracted information
+    """
+    from inkwell.audio import AudioDownloader
+
+    # Pre-extract what we can from the URL itself
+    video_id = extract_youtube_id(url) or extract_url_slug(url)
+    parsed = urlparse(url)
+    domain = parsed.netloc.replace("www.", "")
+
+    try:
+        # Use yt-dlp to get full metadata
+        downloader = AudioDownloader()
+        info = await downloader.get_info(url)
+
+        title = info.get("title")
+        duration = info.get("duration")
+
+        # Prefer yt-dlp's video ID if available
+        if info.get("id"):
+            video_id = info["id"]
+
+        return URLMetadata(
+            title=title,
+            video_id=video_id,
+            domain=domain,
+            duration_seconds=duration,
+        )
+
+    except Exception as e:
+        logger.debug(f"Could not extract metadata from {url}: {e}")
+        # Return what we could extract from URL parsing
+        return URLMetadata(
+            title=None,
+            video_id=video_id,
+            domain=domain,
+            duration_seconds=None,
+        )
+
+
+def get_episode_title_from_metadata(metadata: URLMetadata, url: str) -> str:
+    """Get best episode title from metadata.
+
+    Args:
+        metadata: Extracted URL metadata
+        url: Original URL (for fallback)
+
+    Returns:
+        Best available title
+    """
+    if metadata.title:
+        return metadata.title
+
+    return create_fallback_title(url)

--- a/tests/unit/test_url_metadata.py
+++ b/tests/unit/test_url_metadata.py
@@ -1,0 +1,191 @@
+"""Tests for URL metadata extraction utilities."""
+
+import pytest
+
+from inkwell.utils.url_metadata import (
+    INBOX_PODCAST_NAME,
+    URLMetadata,
+    create_fallback_title,
+    extract_filename_from_url,
+    extract_url_slug,
+    extract_youtube_id,
+    get_episode_title_from_metadata,
+)
+
+
+class TestExtractYoutubeId:
+    """Tests for extract_youtube_id function."""
+
+    def test_standard_watch_url(self):
+        """Should extract ID from standard youtube.com/watch URL."""
+        url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        assert extract_youtube_id(url) == "dQw4w9WgXcQ"
+
+    def test_watch_url_with_extra_params(self):
+        """Should extract ID even with extra query parameters."""
+        url = "https://youtube.com/watch?v=abc123&t=120&list=PLxyz"
+        assert extract_youtube_id(url) == "abc123"
+
+    def test_short_url(self):
+        """Should extract ID from youtu.be short URL."""
+        url = "https://youtu.be/dQw4w9WgXcQ"
+        assert extract_youtube_id(url) == "dQw4w9WgXcQ"
+
+    def test_short_url_with_timestamp(self):
+        """Should extract ID from short URL with timestamp."""
+        url = "https://youtu.be/dQw4w9WgXcQ?t=42"
+        assert extract_youtube_id(url) == "dQw4w9WgXcQ"
+
+    def test_embed_url(self):
+        """Should extract ID from embed URL."""
+        url = "https://www.youtube.com/embed/dQw4w9WgXcQ"
+        assert extract_youtube_id(url) == "dQw4w9WgXcQ"
+
+    def test_v_url(self):
+        """Should extract ID from /v/ URL format."""
+        url = "https://www.youtube.com/v/dQw4w9WgXcQ"
+        assert extract_youtube_id(url) == "dQw4w9WgXcQ"
+
+    def test_mobile_url(self):
+        """Should extract ID from mobile YouTube URL."""
+        url = "https://m.youtube.com/watch?v=dQw4w9WgXcQ"
+        assert extract_youtube_id(url) == "dQw4w9WgXcQ"
+
+    def test_non_youtube_url(self):
+        """Should return None for non-YouTube URLs."""
+        url = "https://vimeo.com/123456"
+        assert extract_youtube_id(url) is None
+
+    def test_invalid_youtube_url(self):
+        """Should return None for YouTube URL without video ID."""
+        url = "https://youtube.com/channel/UCxyz"
+        assert extract_youtube_id(url) is None
+
+
+class TestExtractUrlSlug:
+    """Tests for extract_url_slug function."""
+
+    def test_youtube_url_returns_video_id(self):
+        """Should return video ID for YouTube URLs."""
+        url = "https://youtube.com/watch?v=abc123xyz"
+        assert extract_url_slug(url) == "abc123xyz"
+
+    def test_non_youtube_returns_hash(self):
+        """Should return hash for non-YouTube URLs."""
+        url = "https://example.com/podcast/episode-42.mp3"
+        slug = extract_url_slug(url)
+        assert len(slug) == 12  # Hash is 12 chars
+        assert slug.isalnum()
+
+    def test_same_url_same_hash(self):
+        """Should return same hash for same URL."""
+        url = "https://example.com/audio.mp3"
+        assert extract_url_slug(url) == extract_url_slug(url)
+
+    def test_different_urls_different_hashes(self):
+        """Should return different hashes for different URLs."""
+        url1 = "https://example.com/episode1.mp3"
+        url2 = "https://example.com/episode2.mp3"
+        assert extract_url_slug(url1) != extract_url_slug(url2)
+
+
+class TestExtractFilenameFromUrl:
+    """Tests for extract_filename_from_url function."""
+
+    def test_simple_filename(self):
+        """Should extract filename from URL path."""
+        url = "https://example.com/podcasts/my-episode.mp3"
+        assert extract_filename_from_url(url) == "my-episode"
+
+    def test_filename_with_underscores(self):
+        """Should handle filenames with underscores (preserved as-is after cleaning)."""
+        url = "https://example.com/episode_42_final.mp3"
+        # Underscores are kept, only special chars are removed
+        assert extract_filename_from_url(url) == "episode_42_final"
+
+    def test_short_filename_returns_none(self):
+        """Should return None for very short filenames."""
+        url = "https://example.com/ep.mp3"
+        assert extract_filename_from_url(url) is None
+
+    def test_no_filename_returns_none(self):
+        """Should return None when no filename in path."""
+        url = "https://example.com/"
+        assert extract_filename_from_url(url) is None
+
+
+class TestCreateFallbackTitle:
+    """Tests for create_fallback_title function."""
+
+    def test_uses_filename_when_available(self):
+        """Should use cleaned filename when available."""
+        url = "https://example.com/my-great-episode.mp3"
+        title = create_fallback_title(url)
+        assert "Great" in title or "great" in title.lower()
+
+    def test_uses_domain_when_no_filename(self):
+        """Should use domain + hash when no filename."""
+        url = "https://spotify.com/"
+        title = create_fallback_title(url)
+        assert "Spotify" in title
+
+    def test_strips_www_from_domain(self):
+        """Should strip www. from domain."""
+        url = "https://www.podcasts.com/"
+        title = create_fallback_title(url)
+        assert "Podcasts" in title
+        assert "www" not in title.lower()
+
+
+class TestGetEpisodeTitleFromMetadata:
+    """Tests for get_episode_title_from_metadata function."""
+
+    def test_uses_metadata_title_when_available(self):
+        """Should prefer metadata title over fallback."""
+        metadata = URLMetadata(title="The Real Title")
+        url = "https://example.com/episode.mp3"
+        assert get_episode_title_from_metadata(metadata, url) == "The Real Title"
+
+    def test_uses_fallback_when_no_title(self):
+        """Should use fallback when metadata has no title."""
+        metadata = URLMetadata(title=None)
+        url = "https://example.com/great-episode.mp3"
+        title = get_episode_title_from_metadata(metadata, url)
+        assert "Great" in title or "great" in title.lower()
+
+
+class TestURLMetadata:
+    """Tests for URLMetadata model."""
+
+    def test_all_fields_optional(self):
+        """Should allow creating with no fields."""
+        metadata = URLMetadata()
+        assert metadata.title is None
+        assert metadata.video_id is None
+        assert metadata.domain is None
+        assert metadata.duration_seconds is None
+
+    def test_with_all_fields(self):
+        """Should store all fields correctly."""
+        metadata = URLMetadata(
+            title="Test Episode",
+            video_id="abc123",
+            domain="youtube.com",
+            duration_seconds=3600.5,
+        )
+        assert metadata.title == "Test Episode"
+        assert metadata.video_id == "abc123"
+        assert metadata.domain == "youtube.com"
+        assert metadata.duration_seconds == 3600.5
+
+
+class TestInboxConstant:
+    """Tests for INBOX_PODCAST_NAME constant."""
+
+    def test_inbox_name(self):
+        """Should be _inbox."""
+        assert INBOX_PODCAST_NAME == "_inbox"
+
+    def test_starts_with_underscore(self):
+        """Should start with underscore for sorting."""
+        assert INBOX_PODCAST_NAME.startswith("_")


### PR DESCRIPTION
- Add `_inbox` as default podcast name for direct URL captures
- Extract episode titles from yt-dlp metadata (YouTube title, etc.)
- Add `--podcast` flag to override default for direct URLs
- Use short slugs (video ID/hash) instead of ugly full URLs
- Creates clear visual separation between curated feeds and quick captures

Output structure:
~/inkwell-notes/
├── _inbox/                           # Quick captures
│   └── 2025-12-22-video-title/
├── lex-fridman/                      # Feed episodes
│   └── 2025-12-15-episode-title/