### PR TITLE
feat(cli): Add --podcast-name flag and rename --output to --output-dir

### DIFF
--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -127,7 +127,8 @@ inkwell fetch <SOURCE> [OPTIONS]
 
 | Option | Short | Type | Default | Description |
 |--------|-------|------|---------|-------------|
-| `--output` | `-o` | path | `~/inkwell-notes` | Output directory |
+| `--output-dir` | `-o` | path | `~/inkwell-notes` | Base directory for output |
+| `--podcast-name` | `-n` | string | Auto | Podcast name for output directory (overrides auto-detection) |
 | `--latest` | `-l` | flag | false | Process only latest episode |
 | `--episode` | `-e` | string | | Position (3), range (1-5), list (1,3,7), or title keyword |
 | `--templates` | `-t` | string | Auto | Comma-separated template list |
@@ -148,6 +149,9 @@ inkwell fetch <SOURCE> [OPTIONS]
 ```bash
 # From URL
 inkwell fetch https://youtube.com/watch?v=xyz
+
+# From URL with custom podcast name
+inkwell fetch https://youtube.com/watch?v=xyz --podcast-name "Python Tutorials"
 
 # Latest from feed
 inkwell fetch my-podcast --latest

--- a/plans/feat-cli-add-podcast-name-flag-rename-output-to-output-dir.md
+++ b/plans/feat-cli-add-podcast-name-flag-rename-output-to-output-dir.md
@@ -1,0 +1,132 @@
+# feat(cli): Add --podcast-name flag and rename --output to --output-dir
+
+**Issue:** [#28](https://github.com/chekos/inkwell-cli/issues/28)
+**Type:** Enhancement
+**Estimated effort:** ~30 minutes
+
+---
+
+## Overview
+
+Add `--podcast-name` / `-n` flag to `fetch` command and rename `--output` to `--output-dir`.
+
+**Key insight:** Infrastructure already exists. Just expose `PipelineOptions.podcast_name` as a CLI flag.
+
+## Problem
+
+```bash
+inkwell fetch "https://youtu.be/TqC1qOfiVcQ"
+# Creates: unknown-podcast/2026-01-05-episode-from-httpsyoutubetqc1qofivcq/
+```
+
+No way to specify podcast name for standalone URLs. Also, `--output` is misleading (expects directory).
+
+## Solution
+
+```bash
+inkwell fetch "https://youtu.be/TqC1qOfiVcQ" --podcast-name "Python Tutorials"
+# Creates: python-tutorials/2026-01-05-episode-title/
+
+inkwell fetch <url> --output-dir ~/notes  # Clear it's a directory
+```
+
+---
+
+## Implementation
+
+### 1. Add `--podcast-name` option (`cli.py` ~line 695)
+
+```python
+podcast_name: str | None = typer.Option(
+    None,
+    "--podcast-name",
+    "-n",
+    help="Podcast name for output directory (overrides auto-detection)",
+),
+```
+
+### 2. Rename `--output` to `--output-dir` (`cli.py` lines 686-688)
+
+```python
+output_dir: Path | None = typer.Option(
+    None, "--output-dir", "-o", help="Base directory for output (default: ~/inkwell-notes)"
+),
+```
+
+### 3. Fix variable shadowing (`cli.py` ~line 857)
+
+The local variable `podcast_name` at line 857 will shadow the new CLI parameter. Rename it:
+
+```python
+# Current (line 857-860)
+podcast_name: str | None = None
+if ep is not None:
+    episode_title = ep.title
+    podcast_name = ep.podcast_name or url_or_feed
+
+# Change to
+episode_title: str | None = None
+detected_podcast_name: str | None = None
+if ep is not None:
+    episode_title = ep.title
+    detected_podcast_name = ep.podcast_name or url_or_feed
+
+# Then at PipelineOptions (line 893):
+podcast_name=podcast_name or detected_podcast_name,
+```
+
+### 4. Add test (`test_cli.py`)
+
+```python
+class TestFetchCommand:
+    """Tests for fetch command options."""
+
+    def test_fetch_help_shows_new_options(self) -> None:
+        """Test new options appear in help output."""
+        result = runner.invoke(app, ["fetch", "--help"])
+
+        assert result.exit_code == 0
+        # New flag names
+        assert "--output-dir" in result.stdout
+        assert "--podcast-name" in result.stdout
+        # Short forms
+        assert "-o" in result.stdout
+        assert "-n" in result.stdout
+```
+
+### 5. Update docs (`docs/reference/cli-commands.md`)
+
+Update the options table for `inkwell fetch`:
+
+```markdown
+| Option | Short | Type | Default | Description |
+|--------|-------|------|---------|-------------|
+| `--output-dir` | `-o` | path | `~/inkwell-notes` | Base directory for output |
+| `--podcast-name` | `-n` | string | Auto | Podcast name for output directory |
+```
+
+---
+
+## Key Behavior
+
+- **CLI flag overrides auto-detection:** `--podcast-name "Custom"` wins over RSS metadata
+- **Empty string falls through:** `--podcast-name ""` behaves like not passing the flag (uses auto-detection)
+- **Sanitization handled:** Existing `podcast_slug` property handles special characters
+
+---
+
+## Acceptance Criteria
+
+- [ ] `--podcast-name` / `-n` flag added to `fetch` command
+- [ ] `--output` renamed to `--output-dir` (keep `-o`)
+- [ ] CLI flag overrides auto-detected podcast name
+- [ ] Test verifies flags appear in help
+- [ ] `docs/reference/cli-commands.md` updated
+
+---
+
+## References
+
+- `src/inkwell/cli.py:683-732` - fetch command
+- `src/inkwell/pipeline/models.py:35` - PipelineOptions.podcast_name
+- `src/inkwell/output/models.py:89-96` - podcast_slug sanitization

--- a/src/inkwell/cli.py
+++ b/src/inkwell/cli.py
@@ -684,7 +684,13 @@ def cache_command(
 def fetch_command(
     url_or_feed: str = typer.Argument(..., help="Episode URL or configured feed name"),
     output_dir: Path | None = typer.Option(
-        None, "--output", "-o", help="Output directory (default: ~/inkwell-notes)"
+        None, "--output-dir", "-o", help="Base directory for output (default: ~/inkwell-notes)"
+    ),
+    podcast_name: str | None = typer.Option(
+        None,
+        "--podcast-name",
+        "-n",
+        help="Podcast name for output directory (overrides auto-detection)",
     ),
     latest: bool = typer.Option(False, "--latest", "-l", help="Fetch the latest episode from feed"),
     episode: str | None = typer.Option(
@@ -854,10 +860,10 @@ def fetch_command(
 
                 # Extract episode metadata if available from feed parsing
                 episode_title: str | None = None
-                podcast_name: str | None = None
+                detected_podcast_name: str | None = None
                 if ep is not None:
                     episode_title = ep.title
-                    podcast_name = ep.podcast_name or url_or_feed
+                    detected_podcast_name = ep.podcast_name or url_or_feed
 
                 # Compute effective output directory
                 effective_output_dir = output_dir or config.default_output_dir
@@ -890,7 +896,7 @@ def fetch_command(
                     auth_username=auth_username,
                     auth_password=auth_password,
                     episode_title=episode_title,
-                    podcast_name=podcast_name,
+                    podcast_name=podcast_name or detected_podcast_name,
                 )
 
                 # Create orchestrator

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -248,6 +248,18 @@ class TestCLIHelp:
         assert "edit" in result.stdout.lower()
         assert "set" in result.stdout.lower()
 
+    def test_fetch_help_shows_new_options(self) -> None:
+        """Test fetch command help shows --output-dir and --podcast-name."""
+        result = runner.invoke(app, ["fetch", "--help"])
+
+        assert result.exit_code == 0
+        # New flag names
+        assert "--output-dir" in result.stdout
+        assert "--podcast-name" in result.stdout
+        # Short forms
+        assert "-o" in result.stdout
+        assert "-n" in result.stdout
+
 
 class TestCLIErrorHandling:
     """Tests for CLI error handling."""


### PR DESCRIPTION
## Summary

- Add `--podcast-name` / `-n` flag to `fetch` command to override auto-detected podcast name for standalone URLs
- Rename `--output` to `--output-dir` for clarity (keep `-o` short form for backwards compatibility)

## Problem

When fetching standalone YouTube videos or direct audio URLs, there was no way to specify a podcast name from the CLI. The output defaulted to "Unknown Podcast":

```bash
inkwell fetch "https://youtu.be/TqC1qOfiVcQ"
# Creates: unknown-podcast/2026-01-05-episode-from-httpsyoutubetqc1qofivcq/
```

Additionally, `--output` was misleading since it expects a directory, not a file path.

## Solution

```bash
inkwell fetch "https://youtu.be/TqC1qOfiVcQ" --podcast-name "Python Tutorials"
# Creates: python-tutorials/2026-01-05-episode-title/

inkwell fetch <url> --output-dir ~/notes  # Clear it's a directory
```

## Changes

| File | Changes |
|------|---------|
| `src/inkwell/cli.py` | Add `--podcast-name` option, rename `--output` to `--output-dir` |
| `tests/integration/test_cli.py` | Add test for new options in help output |
| `docs/reference/cli-commands.md` | Update options table and add example |

## Testing

- [x] New test verifies flags appear in help output
- [x] All 995 tests pass
- [x] Linting passes

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)