### PR TITLE
chore: gitignore .context/ (ce-review session artifacts)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,9 +182,9 @@ cython_debug/
 .abstra/
 
 # Visual Studio Code
-#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  and can be added to the global gitignore or merged into this file. However, if you prefer,
 #  you could uncomment the following to ignore the entire vscode folder
 # .vscode/
 
@@ -216,3 +216,6 @@ __marimo__/
 .keyfile
 .keyfile.backup
 KEYFILE_RECOVERY.txt
+
+# Compound-engineering session artifacts (ce-review reviewer JSON, applied-fixes logs)
+.context/


### PR DESCRIPTION
## Summary

Ignore \`.context/\` — compound-engineering's \`ce-review\` skill writes per-reviewer JSON findings and applied-fixes markdown logs there each run. Tool scratch state, not source. Without this, \`git status\` stays dirty between review rounds.

Also sweeps trailing whitespace that pre-commit flagged on pre-existing VS Code comment lines in the same file (unrelated but the hook forced the re-stage).

## Test plan

- [x] pre-commit hooks pass (trailing-whitespace, ruff, pytest)
- [x] \`git status\` clean after running \`ce-review\` again on a follow-up branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)