### PR TITLE
[codex] Support feed display names

### DIFF
--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -34,7 +34,7 @@ inkwell add <URL> --feed-name <NAME> [OPTIONS]
 
 | Option | Short | Type | Default | Description |
 |--------|-------|------|---------|-------------|
-| `--feed-name` | `-n` | string | Required | Feed identifier |
+| `--feed-name` | `-n` | string | Required | Feed display name or identifier. Human-readable names are slugified for the config key. |
 | `--name` | | string | Required | Backward-compatible alias for `--feed-name` |
 | `--category` | `-c` | string | None | Feed category |
 | `--auth` | | flag | false | Prompt for authentication |
@@ -44,6 +44,9 @@ inkwell add <URL> --feed-name <NAME> [OPTIONS]
 ```bash
 # Basic feed
 inkwell add https://example.com/feed.rss --feed-name my-podcast
+
+# Human-readable names are stored as display names and keyed by slug
+inkwell add https://example.com/feed.rss --feed-name "Oren Meets World"
 
 # With category
 inkwell add https://example.com/feed.rss --feed-name tech-show --category tech
@@ -59,6 +62,7 @@ inkwell add https://www.youtube.com/channel/UCxxxxxxxxxxxxxxxxxxxx --feed-name s
 
 > **Note:** Playlist URLs (`?list=…`) are rejected with a clear error — playlist ingestion is not yet supported. If you pass a video URL that includes a playlist query param (e.g. `watch?v=X&list=Y`), `inkwell` will tell you to use the channel URL instead.
 > `--name` is still accepted for existing scripts, but new examples use `--feed-name`.
+> Feed lookups accept the stored slug and the display name, so `inkwell fetch oren-meets-world --latest` and `inkwell fetch "Oren Meets World" --latest` both work after adding that feed.
 
 ---
 

--- a/docs/user-guide/feeds.md
+++ b/docs/user-guide/feeds.md
@@ -18,6 +18,14 @@ inkwell add <RSS_URL> --feed-name <FEED_NAME>
 inkwell add https://feeds.example.com/tech-podcast.rss --feed-name tech-show
 ```
 
+Feed names can be human-readable. Inkwell stores a slug as the config key and keeps the original as the display name:
+
+```bash
+inkwell add https://feeds.example.com/show.rss --feed-name "Oren Meets World"
+```
+
+That feed is stored as `oren-meets-world`, but you can fetch or remove it with either the slug or the display name.
+
 **Output:**
 
 ```
@@ -164,6 +172,7 @@ inkwell rename old-name new-name
 ```
 
 Feed names are normalized to lowercase slugs, so `inkwell rename old-name "New Name!"` becomes `new-name`.
+The human-readable name is kept as the feed's display name in `inkwell list`.
 
 Use `--force` only when you intentionally want to replace an existing destination feed:
 

--- a/src/inkwell/cli.py
+++ b/src/inkwell/cli.py
@@ -3,7 +3,6 @@
 import asyncio
 import logging
 import os
-import re
 import sys
 from datetime import timedelta
 from pathlib import Path
@@ -16,7 +15,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
 
 from inkwell.config.logging import setup_logging
-from inkwell.config.manager import ConfigManager
+from inkwell.config.manager import ConfigManager, normalize_feed_name, slugify_feed_name
 from inkwell.config.schema import AuthConfig, FeedConfig
 from inkwell.feeds.models import Episode
 from inkwell.feeds.parser import RSSParser
@@ -91,23 +90,14 @@ def _should_show_save_feed_hint(*, url: str, input_was_url: bool) -> bool:
     return input_was_url and is_youtube_url(url)
 
 
-_NAME_SLUG_RE = re.compile(r"[^a-z0-9]+")
-
-
 def _slugify(s: str) -> str:
     """Collapse any string into a [a-z0-9-] feed-name slug."""
-    return _NAME_SLUG_RE.sub("-", s.lower()).strip("-")
+    return slugify_feed_name(s)
 
 
 def _normalize_feed_name(name: str) -> str:
     """Normalize user-supplied feed names to stable CLI identifiers."""
-    normalized = _slugify(name)
-    if not normalized:
-        raise ValidationError(
-            "Feed name must include at least one letter or number",
-            suggestion="Use a short name like 'syntax' or 'oren-meets-world'",
-        )
-    return normalized
+    return normalize_feed_name(name)
 
 
 def _derive_feed_name(resolved: ResolvedFeed, existing: set[str]) -> str:
@@ -183,7 +173,6 @@ def add_feed(
 
     async def run_add_feed() -> None:
         manager = ConfigManager()
-        normalized_name = _normalize_feed_name(feed_name)
 
         # Collect auth credentials if needed
         auth_config = AuthConfig(type="none")
@@ -218,12 +207,10 @@ def add_feed(
             category=category,
         )
 
-        manager.add_feed(normalized_name, feed_config)
+        stored_name = manager.add_feed(feed_name, feed_config)
 
-        console.print(
-            f"\n[green]✓[/green] Feed '[bold]{normalized_name}[/bold]' added successfully"
-        )
-        if normalized_name != feed_name:
+        console.print(f"\n[green]✓[/green] Feed '[bold]{stored_name}[/bold]' added successfully")
+        if stored_name != feed_name:
             console.print(f"[dim]  Normalized feed name from '{feed_name}'[/dim]")
         # Surface the stored URL when it differs from what the user typed so
         # they can spot a mis-resolved channel without running `inkwell list`.
@@ -257,7 +244,7 @@ def rename_feed(
     try:
         manager = ConfigManager()
         normalized_new_name = _normalize_feed_name(new_name)
-        manager.rename_feed(old_name, normalized_new_name, overwrite=force)
+        manager.rename_feed(old_name, new_name, overwrite=force)
         console.print(
             f"[green]✓[/green] Feed '[bold]{old_name}[/bold]' renamed to "
             f"'[bold]{normalized_new_name}[/bold]'"
@@ -1184,23 +1171,25 @@ def fetch_command(
                         if feed_name is None:
                             existing = set(existing_feeds.keys())
                             effective_name = _derive_feed_name(resolved, existing)
+                            display_name = resolved.channel_name
                         else:
                             effective_name = _normalize_feed_name(feed_name)
-                        manager.add_feed(
+                            display_name = feed_name if effective_name != feed_name else None
+                        stored_name = manager.add_feed(
                             effective_name,
                             FeedConfig(
                                 url=HttpUrl(resolved.feed_url),
+                                display_name=display_name,
                                 auth=AuthConfig(type="none"),
                             ),
                         )
                         err_console.print(
-                            f"[green]✓[/green] Saved channel as feed "
-                            f"'[bold]{effective_name}[/bold]'"
+                            f"[green]✓[/green] Saved channel as feed '[bold]{stored_name}[/bold]'"
                         )
                         if feed_name is None:
                             err_console.print(
                                 f"[dim]  Auto-named from channel metadata. "
-                                f"To rename: [cyan]inkwell rename {effective_name} "
+                                f"To rename: [cyan]inkwell rename {stored_name} "
                                 f"<new-name>[/cyan]. "
                                 f"Pass [cyan]--feed-name[/cyan] next time to skip "
                                 f"this.[/dim]"

--- a/src/inkwell/cli_list.py
+++ b/src/inkwell/cli_list.py
@@ -230,6 +230,7 @@ def _list_feeds_impl(json_output: bool = False) -> None:
                 feeds_data.append(
                     {
                         "name": name,
+                        "display_name": feed.display_name or name,
                         "url": str(feed.url),
                         "auth": auth_type,
                         "category": feed.category or "",
@@ -241,7 +242,7 @@ def _list_feeds_impl(json_output: bool = False) -> None:
 
         if not feeds:
             console.print("[yellow]No feeds configured yet.[/yellow]")
-            console.print("\nAdd a feed: [cyan]inkwell add <url> --name <name>[/cyan]")
+            console.print("\nAdd a feed: [cyan]inkwell add <url> --feed-name <name>[/cyan]")
             return
 
         # Create table
@@ -256,8 +257,11 @@ def _list_feeds_impl(json_output: bool = False) -> None:
             auth_status = "Yes" if feed.auth.type != "none" else "-"
             category_display = feed.category or "-"
             url_display = truncate_url(str(feed.url), max_length=50)
+            name_display = feed.display_name or name
+            if feed.display_name and feed.display_name != name:
+                name_display = f"{feed.display_name}\n[dim]{name}[/dim]"
 
-            table.add_row(name, url_display, auth_status, category_display)
+            table.add_row(name_display, url_display, auth_status, category_display)
 
         console.print(table)
         console.print(f"\n[dim]Total: {len(feeds)} feed(s)[/dim]")

--- a/src/inkwell/config/manager.py
+++ b/src/inkwell/config/manager.py
@@ -3,9 +3,11 @@
 import fcntl
 import json
 import os
+import re
 import sys
 from collections.abc import Iterator
 from contextlib import contextmanager
+from difflib import get_close_matches
 from pathlib import Path
 
 import yaml
@@ -32,6 +34,24 @@ from inkwell.utils.paths import (
     get_feeds_file,
     get_key_file,
 )
+
+_FEED_NAME_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def slugify_feed_name(name: str) -> str:
+    """Collapse a human-readable feed name into a stable config key."""
+    return _FEED_NAME_SLUG_RE.sub("-", name.lower()).strip("-")
+
+
+def normalize_feed_name(name: str) -> str:
+    """Normalize and validate a feed name for use as a config key."""
+    normalized = slugify_feed_name(name)
+    if not normalized:
+        raise InkwellValidationError(
+            "Feed name must include at least one letter or number",
+            suggestion="Use a short name like 'syntax' or 'oren-meets-world'",
+        )
+    return normalized
 
 
 class ConfigManager:
@@ -337,7 +357,58 @@ class ConfigManager:
             encoding="utf-8",
         )
 
-    def add_feed(self, name: str, feed_config: FeedConfig) -> None:
+    def _resolve_feed_key(
+        self,
+        feeds: dict[str, FeedConfig],
+        name: str,
+    ) -> str | None:
+        """Resolve a user-supplied name to a canonical feed key."""
+        if name in feeds:
+            return name
+
+        normalized = slugify_feed_name(name)
+        if normalized in feeds:
+            return normalized
+
+        exact_display_names: dict[str, str] = {}
+        normalized_display_names: dict[str, str] = {}
+        for key, feed in feeds.items():
+            if feed.display_name:
+                exact_display_names[feed.display_name.casefold()] = key
+                display_slug = slugify_feed_name(feed.display_name)
+                if display_slug:
+                    normalized_display_names[display_slug] = key
+
+        display_match = exact_display_names.get(name.casefold())
+        if display_match:
+            return display_match
+
+        display_match = normalized_display_names.get(normalized)
+        if display_match:
+            return display_match
+
+        close_matches = get_close_matches(
+            normalized,
+            list(normalized_display_names),
+            n=1,
+            cutoff=0.82,
+        )
+        if close_matches:
+            return normalized_display_names[close_matches[0]]
+
+        return None
+
+    def resolve_feed_name(self, name: str) -> str:
+        """Return the canonical feed key for a user-supplied feed name."""
+        feeds = self.load_feeds().feeds
+        resolved = self._resolve_feed_key(feeds, name)
+        if resolved is None:
+            raise NotFoundError(
+                "Feed", name, suggestion="Run 'inkwell list' to see available feeds"
+            )
+        return resolved
+
+    def add_feed(self, name: str, feed_config: FeedConfig) -> str:
         """Add or update a feed.
 
         Uses file locking to prevent race conditions in concurrent operations.
@@ -349,27 +420,36 @@ class ConfigManager:
         Raises:
             DuplicateFeedError: If feed already exists (use update instead)
         """
+        normalized_name = normalize_feed_name(name)
         with self._feeds_lock():
             feeds = self.load_feeds()
 
-            if name in feeds.feeds:
+            if normalized_name in feeds.feeds:
                 raise InkwellValidationError(
-                    f"Feed '{name}' already exists. Use update to modify it.",
-                    suggestion="Use 'inkwell remove' first, or choose a different name",
+                    f"Feed '{normalized_name}' already exists. Use update to modify it.",
+                    suggestion=(
+                        "Choose a different name to disambiguate it, or use "
+                        "'inkwell rename' for existing feeds"
+                    ),
                 )
 
-            feeds.feeds[name] = feed_config
+            if feed_config.display_name is None and normalized_name != name:
+                feed_config = feed_config.model_copy(update={"display_name": name})
+
+            feeds.feeds[normalized_name] = feed_config
             self.save_feeds(feeds)
 
             self._log_change(
                 "add_feed",
                 {
-                    "feed_name": name,
+                    "feed_name": normalized_name,
+                    "display_name": feed_config.display_name,
                     "url": str(feed_config.url),
                     "auth_type": feed_config.auth.type if feed_config.auth else "none",
                     "category": feed_config.category,
                 },
             )
+            return normalized_name
 
     def update_feed(self, name: str, feed_config: FeedConfig) -> None:
         """Update an existing feed.
@@ -385,16 +465,21 @@ class ConfigManager:
         """
         with self._feeds_lock():
             feeds = self.load_feeds()
+            resolved_name = self._resolve_feed_key(feeds.feeds, name)
 
-            if name not in feeds.feeds:
+            if resolved_name is None:
                 raise NotFoundError(
                     "Feed", name, suggestion="Run 'inkwell list' to see available feeds"
                 )
 
             # Capture old config for diff
-            old_config = feeds.feeds[name]
+            old_config = feeds.feeds[resolved_name]
+            if feed_config.display_name is None:
+                feed_config = feed_config.model_copy(
+                    update={"display_name": old_config.display_name}
+                )
 
-            feeds.feeds[name] = feed_config
+            feeds.feeds[resolved_name] = feed_config
             self.save_feeds(feeds)
 
             changes = {}
@@ -410,11 +495,16 @@ class ConfigManager:
                     "old": old_config.category or "",
                     "new": feed_config.category or "",
                 }
+            if old_config.display_name != feed_config.display_name:
+                changes["display_name"] = {
+                    "old": old_config.display_name or "",
+                    "new": feed_config.display_name or "",
+                }
 
             self._log_change(
                 "update_feed",
                 {
-                    "feed_name": name,
+                    "feed_name": resolved_name,
                     "changes": changes,
                 },
             )
@@ -432,22 +522,23 @@ class ConfigManager:
         """
         with self._feeds_lock():
             feeds = self.load_feeds()
+            resolved_name = self._resolve_feed_key(feeds.feeds, name)
 
-            if name not in feeds.feeds:
+            if resolved_name is None:
                 raise NotFoundError(
                     "Feed", name, suggestion="Run 'inkwell list' to see available feeds"
                 )
 
             # Capture feed details before deletion
-            removed_feed = feeds.feeds[name]
+            removed_feed = feeds.feeds[resolved_name]
 
-            del feeds.feeds[name]
+            del feeds.feeds[resolved_name]
             self.save_feeds(feeds)
 
             self._log_change(
                 "remove_feed",
                 {
-                    "feed_name": name,
+                    "feed_name": resolved_name,
                     "url": str(removed_feed.url),
                     "auth_type": removed_feed.auth.type if removed_feed.auth else "none",
                     "category": removed_feed.category,
@@ -456,32 +547,38 @@ class ConfigManager:
 
     def rename_feed(self, old_name: str, new_name: str, overwrite: bool = False) -> None:
         """Rename a feed key while preserving the feed configuration."""
+        normalized_new_name = normalize_feed_name(new_name)
         with self._feeds_lock():
             feeds = self.load_feeds()
+            resolved_old_name = self._resolve_feed_key(feeds.feeds, old_name)
 
-            if old_name not in feeds.feeds:
+            if resolved_old_name is None:
                 raise NotFoundError(
                     "Feed", old_name, suggestion="Run 'inkwell list' to see available feeds"
                 )
 
-            if old_name == new_name:
+            if resolved_old_name == normalized_new_name:
                 return
 
-            if new_name in feeds.feeds and not overwrite:
+            if normalized_new_name in feeds.feeds and not overwrite:
                 raise InkwellValidationError(
-                    f"Feed '{new_name}' already exists.",
+                    f"Feed '{normalized_new_name}' already exists.",
                     suggestion="Choose a different name, or pass --force to overwrite it",
                 )
 
-            feed_config = feeds.feeds[old_name]
-            overwritten_feed = feeds.feeds.get(new_name)
-            feeds.feeds[new_name] = feed_config
-            del feeds.feeds[old_name]
+            feed_config = feeds.feeds[resolved_old_name]
+            if normalized_new_name != new_name:
+                feed_config = feed_config.model_copy(update={"display_name": new_name})
+
+            overwritten_feed = feeds.feeds.get(normalized_new_name)
+            feeds.feeds[normalized_new_name] = feed_config
+            del feeds.feeds[resolved_old_name]
             self.save_feeds(feeds)
 
             details = {
-                "old_feed_name": old_name,
-                "new_feed_name": new_name,
+                "old_feed_name": resolved_old_name,
+                "new_feed_name": normalized_new_name,
+                "display_name": feed_config.display_name,
                 "url": str(feed_config.url),
             }
             if overwritten_feed is not None:
@@ -501,13 +598,14 @@ class ConfigManager:
             FeedNotFoundError: If feed doesn't exist
         """
         feeds = self.load_feeds()
+        resolved_name = self._resolve_feed_key(feeds.feeds, name)
 
-        if name not in feeds.feeds:
+        if resolved_name is None:
             raise NotFoundError(
                 "Feed", name, suggestion="Run 'inkwell list' to see available feeds"
             )
 
-        return feeds.feeds[name]
+        return feeds.feeds[resolved_name]
 
     def list_feeds(self) -> dict[str, FeedConfig]:
         """List all feeds.

--- a/src/inkwell/config/schema.py
+++ b/src/inkwell/config/schema.py
@@ -22,6 +22,7 @@ class FeedConfig(BaseModel):
     """Configuration for a single podcast feed."""
 
     url: HttpUrl
+    display_name: str | None = None
     auth: AuthConfig = Field(default_factory=AuthConfig)
     category: str | None = None
     custom_templates: list[str] = Field(default_factory=list)

--- a/src/inkwell/feeds/youtube_resolver.py
+++ b/src/inkwell/feeds/youtube_resolver.py
@@ -44,7 +44,7 @@ _YTDLP_SOCKET_TIMEOUT_SECONDS = 30
 
 _MANUAL_ESCAPE_HATCH = (
     "If resolution keeps failing, you can still add the channel manually: "
-    "inkwell add 'https://www.youtube.com/feeds/videos.xml?channel_id=UCxxx' --name X"
+    "inkwell add 'https://www.youtube.com/feeds/videos.xml?channel_id=UCxxx' --feed-name X"
 )
 
 

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -156,6 +156,7 @@ class TestCLIAddYouTube:
         assert result.exit_code == 0, result.stdout
         feeds = ConfigManager(config_dir=tmp_path).list_feeds()
         assert "plain-rss" in feeds
+        assert feeds["plain-rss"].display_name == "Plain RSS!"
         assert "Plain RSS!" in result.output
 
     def test_add_playlist_url_rejected(self, tmp_path: Path, monkeypatch) -> None:
@@ -683,6 +684,68 @@ class TestCLIFetchSaveFeed:
         feeds = ConfigManager(config_dir=tmp_path).list_feeds()
         assert "scheme-less" in feeds
 
+    def test_fetch_saved_feed_accepts_display_name(self, tmp_path: Path, monkeypatch) -> None:
+        """Saved feeds can be fetched by their display name."""
+        from types import SimpleNamespace
+
+        monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
+
+        manager = ConfigManager(config_dir=tmp_path)
+        from inkwell.config.schema import FeedConfig as _FeedConfig
+
+        manager.add_feed(
+            "omw",
+            _FeedConfig(
+                url="https://example.com/feed.rss",  # type: ignore[arg-type]
+                display_name="Oren Meets World",
+            ),
+        )
+
+        async def fake_fetch_feed(*_args, **_kwargs):
+            return SimpleNamespace(entries=[object()])
+
+        def fake_get_latest_episode(*_args, **_kwargs):
+            return SimpleNamespace(
+                title="Latest",
+                url="https://example.com/episode.mp3",
+                podcast_name="Oren Meets World",
+            )
+
+        output_dir = tmp_path / "episode-dir"
+        output_dir.mkdir()
+
+        async def fake_process(*_args, **_kwargs):
+            return SimpleNamespace(
+                episode_output=SimpleNamespace(directory=output_dir),
+                extraction_results=[],
+                interview_result=None,
+                extraction_cost_usd=0.0,
+                interview_cost_usd=0.0,
+                total_cost_usd=0.0,
+            )
+
+        monkeypatch.setattr("inkwell.feeds.parser.RSSParser.fetch_feed", fake_fetch_feed)
+        monkeypatch.setattr(
+            "inkwell.feeds.parser.RSSParser.get_latest_episode",
+            fake_get_latest_episode,
+        )
+        monkeypatch.setattr("inkwell.pipeline.PipelineOrchestrator.process_episode", fake_process)
+
+        result = runner.invoke(
+            app,
+            [
+                "fetch",
+                "Oren Meets World",
+                "--latest",
+                "--dry-run",
+                "--output-dir",
+                str(tmp_path),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Latest" in result.output
+
     def test_feed_name_without_save_feed_errors(self, tmp_path: Path, monkeypatch) -> None:
         """--feed-name alone is a no-op that silently mislead users and
         scripts into thinking the channel was persisted. Reject up-front.
@@ -781,7 +844,7 @@ class TestCLIList:
         # Mock get_config_dir - other path functions derive from it
         monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
 
-        result = runner.invoke(app, ["list"])
+        result = runner.invoke(app, ["list", "feeds"])
 
         assert result.exit_code == 0
         assert "No feeds configured" in result.stdout
@@ -819,6 +882,28 @@ class TestCLIList:
         assert feeds["podcast2"].auth.type == "basic"
         assert feeds["podcast2"].auth.username == "user"  # Decrypted
 
+    def test_list_feeds_renders_display_name(self, tmp_path: Path, monkeypatch) -> None:
+        """Test list output shows display names while keeping the key visible."""
+        monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
+        monkeypatch.setattr("inkwell.config.manager.get_config_dir", lambda: tmp_path)
+        manager = ConfigManager(config_dir=tmp_path)
+
+        from inkwell.config.schema import FeedConfig
+
+        manager.add_feed(
+            "omw",
+            FeedConfig(
+                url="https://example.com/feed.rss",  # type: ignore
+                display_name="Oren Meets World",
+            ),
+        )
+
+        result = runner.invoke(app, ["list", "feeds"])
+
+        assert result.exit_code == 0, result.output
+        assert "Oren Meets World" in result.output
+        assert "omw" in result.output
+
 
 class TestCLIRemove:
     """Tests for remove command."""
@@ -852,6 +937,26 @@ class TestCLIRemove:
         with pytest.raises(NotFoundError):
             manager.remove_feed("nonexistent")
 
+    def test_remove_feed_accepts_display_name(self, tmp_path: Path, monkeypatch) -> None:
+        """Test removing a feed through the CLI by display name."""
+        monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
+        manager = ConfigManager(config_dir=tmp_path)
+
+        from inkwell.config.schema import FeedConfig
+
+        manager.add_feed(
+            "omw",
+            FeedConfig(
+                url="https://example.com/feed.rss",  # type: ignore
+                display_name="Oren Meets World",
+            ),
+        )
+
+        result = runner.invoke(app, ["remove", "Oren Meets World", "--force"])
+
+        assert result.exit_code == 0, result.output
+        assert "omw" not in ConfigManager(config_dir=tmp_path).list_feeds()
+
 
 class TestCLIRename:
     """Tests for rename command."""
@@ -878,6 +983,7 @@ class TestCLIRename:
         feeds = ConfigManager(config_dir=tmp_path).list_feeds()
         assert "old-name" not in feeds
         assert "new-name" in feeds
+        assert feeds["new-name"].display_name == "New Name!"
         assert feeds["new-name"].category == "tech"
         assert "Normalized" in result.output
 

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -90,6 +90,26 @@ class TestConfigManager:
         feeds = manager.list_feeds()
         assert "my-podcast" in feeds
 
+    def test_add_feed_slugifies_human_name_and_preserves_display_name(self, tmp_path: Path) -> None:
+        """Test adding a human-readable feed name stores a canonical key."""
+        manager = ConfigManager(config_dir=tmp_path)
+        feed_config = FeedConfig(url="https://example.com/feed.rss")  # type: ignore
+
+        stored_name = manager.add_feed("Oren Meets World!", feed_config)
+
+        feeds = manager.list_feeds()
+        assert stored_name == "oren-meets-world"
+        assert "oren-meets-world" in feeds
+        assert feeds["oren-meets-world"].display_name == "Oren Meets World!"
+
+    def test_add_feed_empty_after_slugify_raises(self, tmp_path: Path) -> None:
+        """Test feed names must contain at least one ASCII letter or number."""
+        manager = ConfigManager(config_dir=tmp_path)
+        feed_config = FeedConfig(url="https://example.com/feed.rss")  # type: ignore
+
+        with pytest.raises(ValidationError, match="at least one letter or number"):
+            manager.add_feed("!!!", feed_config)
+
     def test_add_duplicate_feed_raises(self, tmp_path: Path) -> None:
         """Test that adding duplicate feed raises DuplicateFeedError."""
         manager = ConfigManager(config_dir=tmp_path)
@@ -99,6 +119,16 @@ class TestConfigManager:
 
         with pytest.raises(ValidationError, match="already exists"):
             manager.add_feed("my-podcast", feed_config)
+
+    def test_add_duplicate_after_slugify_raises(self, tmp_path: Path) -> None:
+        """Test duplicate detection uses the canonical slug."""
+        manager = ConfigManager(config_dir=tmp_path)
+        feed_config = FeedConfig(url="https://example.com/feed.rss")  # type: ignore
+
+        manager.add_feed("Oren Meets World", feed_config)
+
+        with pytest.raises(ValidationError, match="oren-meets-world"):
+            manager.add_feed("oren-meets-world", feed_config)
 
     def test_update_feed(self, tmp_path: Path) -> None:
         """Test updating an existing feed."""
@@ -113,6 +143,24 @@ class TestConfigManager:
         # Verify update
         feed = manager.get_feed("my-podcast")
         assert feed.category == "interview"
+
+    def test_update_feed_preserves_display_name(self, tmp_path: Path) -> None:
+        """Test updating a feed does not erase existing display metadata."""
+        manager = ConfigManager(config_dir=tmp_path)
+
+        manager.add_feed(
+            "Oren Meets World",
+            FeedConfig(url="https://example.com/feed.rss", category="tech"),  # type: ignore
+        )
+
+        manager.update_feed(
+            "oren-meets-world",
+            FeedConfig(url="https://example.com/feed.rss", category="interview"),  # type: ignore
+        )
+
+        feed = manager.get_feed("oren-meets-world")
+        assert feed.category == "interview"
+        assert feed.display_name == "Oren Meets World"
 
     def test_update_nonexistent_feed_raises(self, tmp_path: Path) -> None:
         """Test that updating nonexistent feed raises FeedNotFoundError."""
@@ -134,6 +182,17 @@ class TestConfigManager:
         # Verify removal
         feeds = manager.list_feeds()
         assert "my-podcast" not in feeds
+
+    def test_remove_feed_by_display_name(self, tmp_path: Path) -> None:
+        """Test removing a feed by its display name resolves to the key."""
+        manager = ConfigManager(config_dir=tmp_path)
+        manager.add_feed(
+            "omw", FeedConfig(url="https://example.com/feed.rss", display_name="Oren Meets World")
+        )  # type: ignore
+
+        manager.remove_feed("Oren Meets World")
+
+        assert "omw" not in manager.list_feeds()
 
     def test_remove_nonexistent_feed_raises(self, tmp_path: Path) -> None:
         """Test that removing nonexistent feed raises FeedNotFoundError."""
@@ -188,6 +247,17 @@ class TestConfigManager:
         assert "old-name" not in feeds
         assert str(feeds["new-name"].url) == "https://example.com/old.rss"
 
+    def test_rename_feed_slugifies_and_updates_display_name(self, tmp_path: Path) -> None:
+        """Test renaming with a human-readable name stores display metadata."""
+        manager = ConfigManager(config_dir=tmp_path)
+        manager.add_feed("old-name", FeedConfig(url="https://example.com/old.rss"))  # type: ignore
+
+        manager.rename_feed("old-name", "Better Name!")
+
+        feeds = manager.list_feeds()
+        assert "better-name" in feeds
+        assert feeds["better-name"].display_name == "Better Name!"
+
     def test_get_feed(self, tmp_path: Path) -> None:
         """Test getting a single feed."""
         manager = ConfigManager(config_dir=tmp_path)
@@ -196,6 +266,28 @@ class TestConfigManager:
         manager.add_feed("my-podcast", feed_config)
 
         feed = manager.get_feed("my-podcast")
+
+        assert str(feed.url) == "https://example.com/feed.rss"
+
+    def test_get_feed_by_display_name(self, tmp_path: Path) -> None:
+        """Test display names can be used as feed lookup aliases."""
+        manager = ConfigManager(config_dir=tmp_path)
+        manager.add_feed(
+            "omw", FeedConfig(url="https://example.com/feed.rss", display_name="Oren Meets World")
+        )  # type: ignore
+
+        feed = manager.get_feed("Oren Meets World")
+
+        assert str(feed.url) == "https://example.com/feed.rss"
+
+    def test_get_feed_by_close_display_name_match(self, tmp_path: Path) -> None:
+        """Test close display-name matches can resolve saved feeds."""
+        manager = ConfigManager(config_dir=tmp_path)
+        manager.add_feed(
+            "omw", FeedConfig(url="https://example.com/feed.rss", display_name="Oren Meets World")
+        )  # type: ignore
+
+        feed = manager.get_feed("oren meet world")
 
         assert str(feed.url) == "https://example.com/feed.rss"
 


### PR DESCRIPTION
## Summary
- Add optional feed display names while storing stable slug keys in feeds.yaml.
- Resolve feed operations by slug, exact display name, normalized display name, or a close display-name match.
- Update add, fetch --save-feed, rename, remove, and list flows plus docs so human-readable names behave naturally.

## Validation
- uv run pytest tests/unit/test_config_manager.py tests/integration/test_cli.py tests/unit/test_youtube_resolver.py
- uv run pytest --cov=src/inkwell --cov-report=term-missing --cov-report=xml --cov-fail-under=75
- uv run ruff format --check .
- uv run ruff check .
- uv run mypy src/
- uv run mkdocs build --strict
- pre-push hook pytest

Closes #37