### PR TITLE
feat(cli): add feed --count support

### DIFF
--- a/docs/building-in-public/devlog/2026-04-30-feed-count-support.md
+++ b/docs/building-in-public/devlog/2026-04-30-feed-count-support.md
@@ -1,0 +1,24 @@
+# Feed Count Support
+
+**Date:** 2026-04-30
+**Author:** Diego
+
+## Focus
+
+Implement GitHub issue #57: `inkwell fetch <feed-name> --count N` for processing the N latest episodes from a saved feed.
+
+## Progress
+
+Started from the OBRA-3 technical review. The docs already mention `--count`, but the current CLI only supports `--latest` and `--episode` selectors for feeds.
+
+## Observations
+
+The existing feed parser already has range/list/position selection with a max episode limit. `--count` should use that same limit but stay explicit in the CLI so validation and help text are clear.
+
+## Next
+
+Add parser/CLI support, focused tests, and docs updates. Land as a PR closing #57.
+
+## Links
+
+- Issue: #57

--- a/docs/getting-started/first-episode.md
+++ b/docs/getting-started/first-episode.md
@@ -330,7 +330,7 @@ A: Read Lenny's newsletter on growth loops, check out Reforge courses.
 ### Process More Episodes
 
 ```bash
-# Process last 5 episodes
+# Process latest 5 episodes
 inkwell fetch lennys --count 5
 
 # Process specific episode

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -173,6 +173,7 @@ inkwell fetch <SOURCE> [OPTIONS]
 | `--output-dir` | `-o` | path | `~/inkwell-notes` | Base directory for output |
 | `--podcast-name` | `-n` | string | Auto | Podcast name for output directory (overrides auto-detection) |
 | `--latest` | `-l` | flag | false | Process only latest episode |
+| `--count` | | int | | Process the N latest episodes from a feed |
 | `--episode` | `-e` | string | | Position (3), range (1-5), list (1,3,7), or title keyword |
 | `--templates` | `-t` | string | Auto | Comma-separated template list |
 | `--category` | `-c` | string | Auto | Episode category |
@@ -202,6 +203,9 @@ inkwell fetch https://youtube.com/watch?v=xyz --podcast-name "Python Tutorials"
 
 # Latest from feed
 inkwell fetch my-podcast --latest
+
+# Latest 5 episodes from feed
+inkwell fetch my-podcast --count 5
 
 # Specific episode by position
 inkwell fetch my-podcast --episode 3

--- a/docs/user-guide/processing.md
+++ b/docs/user-guide/processing.md
@@ -22,7 +22,7 @@ If you've added a feed, process by feed name:
 # Latest episode
 inkwell fetch my-podcast --latest
 
-# Specific number of episodes
+# Latest 5 episodes
 inkwell fetch my-podcast --count 5
 ```
 
@@ -76,6 +76,7 @@ Step 4/4: Writing markdown files...
 | Option | Short | Description | Default |
 |--------|-------|-------------|---------|
 | `--output` | `-o` | Output directory | `~/inkwell-notes` |
+| `--count` | | Latest N episodes from a saved feed | |
 | `--templates` | `-t` | Comma-separated template list | Auto-select |
 | `--category` | `-c` | Episode category | Auto-detect |
 | `--provider` | `-p` | LLM provider (claude, gemini) | Smart selection |

--- a/src/inkwell/cli.py
+++ b/src/inkwell/cli.py
@@ -18,7 +18,7 @@ from inkwell.config.logging import setup_logging
 from inkwell.config.manager import ConfigManager, normalize_feed_name, slugify_feed_name
 from inkwell.config.schema import AuthConfig, FeedConfig
 from inkwell.feeds.models import Episode
-from inkwell.feeds.parser import RSSParser
+from inkwell.feeds.parser import MAX_EPISODES_PER_SELECTION, RSSParser
 from inkwell.feeds.youtube_resolver import (
     ResolvedFeed,
     channel_id_from_feed_url,
@@ -702,6 +702,12 @@ def fetch_command(
         help="Podcast name for output directory (overrides auto-detection)",
     ),
     latest: bool = typer.Option(False, "--latest", "-l", help="Fetch the latest episode from feed"),
+    count: int | None = typer.Option(
+        None,
+        "--count",
+        min=1,
+        help="Process the N latest episodes from a feed",
+    ),
     episode: str | None = typer.Option(
         None,
         "--episode",
@@ -841,6 +847,15 @@ def fetch_command(
 
             is_url = url_or_feed.startswith(("http://", "https://"))
 
+            if is_url and count is not None:
+                raise ValidationError(
+                    "--count only works with saved feeds",
+                    suggestion=(
+                        "Use 'inkwell add <feed-url> --feed-name <name>' first, "
+                        "then run 'inkwell fetch <name> --count N'."
+                    ),
+                )
+
             # Pre-fetch validation for --save-feed (fail fast, before the
             # long-running pipeline starts).
             if save_feed:
@@ -888,14 +903,30 @@ def fetch_command(
                     console.print("  Or provide a direct episode URL.")
                     sys.exit(1)
                 else:
-                    # Found the feed - need --latest or --episode flag
-                    if not latest and not episode:
+                    selection_modes = (
+                        int(latest) + int(episode is not None) + int(count is not None)
+                    )
+                    if selection_modes > 1:
+                        raise ValidationError(
+                            "--latest, --episode, and --count are mutually exclusive",
+                            suggestion="Choose one feed selection mode",
+                        )
+
+                    if count is not None and count > MAX_EPISODES_PER_SELECTION:
+                        raise ValidationError(
+                            f"--count {count} exceeds maximum of {MAX_EPISODES_PER_SELECTION}",
+                            suggestion="Select fewer episodes or use multiple smaller requests",
+                        )
+
+                    # Found the feed - need --latest, --episode, or --count flag
+                    if selection_modes == 0:
                         console.print(
                             f"[red]✗[/red] Feed '{url_or_feed}' requires "
-                            "--latest or --episode flag."
+                            "--latest, --episode, or --count flag."
                         )
                         console.print("\nUsage:")
                         console.print(f"  inkwell fetch {url_or_feed} --latest")
+                        console.print(f"  inkwell fetch {url_or_feed} --count 5")
                         console.print(f'  inkwell fetch {url_or_feed} --episode "keyword"')
                         sys.exit(1)
 
@@ -911,6 +942,9 @@ def fetch_command(
                         console.print(
                             f"[green]✓[/green] Latest episode: {selected_episodes[0].title}"
                         )
+                    elif count is not None:
+                        selected_episodes = parser.get_latest_episodes(feed, url_or_feed, count)
+                        console.print(f"[green]✓[/green] Found {len(selected_episodes)} episodes")
                     else:
                         # episode is guaranteed to be set when not using --latest
                         assert episode is not None, "Episode selector required"

--- a/src/inkwell/feeds/parser.py
+++ b/src/inkwell/feeds/parser.py
@@ -136,6 +136,38 @@ class RSSParser:
         latest_entry = feed.entries[0]
         return self.extract_episode_metadata(latest_entry, podcast_name)
 
+    def get_latest_episodes(
+        self,
+        feed: feedparser.FeedParserDict,
+        podcast_name: str,
+        count: int,
+    ) -> list[Episode]:
+        """Extract the N latest episodes from a feed."""
+        if count < 1:
+            raise ValidationError(
+                "--count must be a positive integer",
+                suggestion="Use --count 1 or higher",
+            )
+
+        if count > MAX_EPISODES_PER_SELECTION:
+            raise ValidationError(
+                f"--count {count} exceeds maximum of {MAX_EPISODES_PER_SELECTION}",
+                suggestion="Select fewer episodes or use multiple smaller requests",
+            )
+
+        feed_size = len(feed.entries)
+        if count > feed_size:
+            raise NotFoundError(
+                resource_type="Episode count",
+                resource_id=str(count),
+                details={"feed_size": feed_size, "requested": count},
+                suggestion=f"Feed has {feed_size} episodes. Select 1-{feed_size}.",
+            )
+
+        return [
+            self.extract_episode_metadata(entry, podcast_name) for entry in feed.entries[:count]
+        ]
+
     def get_episode_by_title(
         self,
         feed: feedparser.FeedParserDict,

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -746,6 +746,132 @@ class TestCLIFetchSaveFeed:
         assert result.exit_code == 0, result.output
         assert "Latest" in result.output
 
+    def test_fetch_saved_feed_count_processes_latest_n(self, tmp_path: Path, monkeypatch) -> None:
+        """`--count N` processes the N latest episodes from a saved feed."""
+        from types import SimpleNamespace
+
+        monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
+
+        manager = ConfigManager(config_dir=tmp_path)
+        from inkwell.config.schema import FeedConfig as _FeedConfig
+
+        manager.add_feed(
+            "count-feed",
+            _FeedConfig(url="https://example.com/feed.rss"),  # type: ignore[arg-type]
+        )
+
+        async def fake_fetch_feed(*_args, **_kwargs):
+            return SimpleNamespace(entries=[object(), object()])
+
+        seen_count: list[int] = []
+
+        def fake_get_latest_episodes(_parser, _feed, podcast_name, count):
+            seen_count.append(count)
+            return [
+                SimpleNamespace(
+                    title="First",
+                    url="https://example.com/first.mp3",
+                    podcast_name=podcast_name,
+                ),
+                SimpleNamespace(
+                    title="Second",
+                    url="https://example.com/second.mp3",
+                    podcast_name=podcast_name,
+                ),
+            ]
+
+        output_dir = tmp_path / "episode-dir"
+        output_dir.mkdir()
+        processed_urls: list[str] = []
+
+        async def fake_process(_orchestrator, options, *_args, **_kwargs):
+            processed_urls.append(options.url)
+            return SimpleNamespace(
+                episode_output=SimpleNamespace(directory=output_dir),
+                extraction_results=[],
+                interview_result=None,
+                extraction_cost_usd=0.0,
+                interview_cost_usd=0.0,
+                total_cost_usd=0.0,
+            )
+
+        monkeypatch.setattr("inkwell.feeds.parser.RSSParser.fetch_feed", fake_fetch_feed)
+        monkeypatch.setattr(
+            "inkwell.feeds.parser.RSSParser.get_latest_episodes",
+            fake_get_latest_episodes,
+        )
+        monkeypatch.setattr("inkwell.pipeline.PipelineOrchestrator.process_episode", fake_process)
+
+        result = runner.invoke(
+            app,
+            [
+                "fetch",
+                "count-feed",
+                "--count",
+                "2",
+                "--dry-run",
+                "--output-dir",
+                str(tmp_path),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert seen_count == [2]
+        assert processed_urls == [
+            "https://example.com/first.mp3",
+            "https://example.com/second.mp3",
+        ]
+        assert "Found 2 episodes" in result.output
+
+    def test_fetch_saved_feed_count_is_mutually_exclusive(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """`--count` cannot be combined with other feed selection modes."""
+        monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
+
+        manager = ConfigManager(config_dir=tmp_path)
+        from inkwell.config.schema import FeedConfig as _FeedConfig
+
+        manager.add_feed(
+            "count-feed",
+            _FeedConfig(url="https://example.com/feed.rss"),  # type: ignore[arg-type]
+        )
+
+        result = runner.invoke(
+            app,
+            ["fetch", "count-feed", "--latest", "--count", "2", "--dry-run"],
+        )
+
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+
+    def test_fetch_saved_feed_count_enforces_max_before_fetch(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Oversized `--count` values fail before fetching the RSS feed."""
+        monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
+
+        manager = ConfigManager(config_dir=tmp_path)
+        from inkwell.config.schema import FeedConfig as _FeedConfig
+
+        manager.add_feed(
+            "count-feed",
+            _FeedConfig(url="https://example.com/feed.rss"),  # type: ignore[arg-type]
+        )
+
+        async def fetch_should_not_run(*_args, **_kwargs):
+            raise AssertionError("RSS fetch should not run for invalid --count")
+
+        monkeypatch.setattr("inkwell.feeds.parser.RSSParser.fetch_feed", fetch_should_not_run)
+
+        result = runner.invoke(
+            app,
+            ["fetch", "count-feed", "--count", "101", "--dry-run"],
+        )
+
+        assert result.exit_code != 0
+        assert "maximum of 100" in result.output
+
     def test_feed_name_without_save_feed_errors(self, tmp_path: Path, monkeypatch) -> None:
         """--feed-name alone is a no-op that silently mislead users and
         scripts into thinking the channel was persisted. Reject up-front.

--- a/tests/unit/test_feeds_parser.py
+++ b/tests/unit/test_feeds_parser.py
@@ -164,6 +164,44 @@ class TestRSSParser:
         assert episode.episode_number == 100
         assert episode.duration_seconds == 3600
 
+    def test_get_latest_episodes(self, valid_rss_feed: str) -> None:
+        """Test extracting the N latest episodes from a feed."""
+        feed = feedparser.parse(valid_rss_feed)
+        parser = RSSParser()
+
+        episodes = parser.get_latest_episodes(feed, "Tech Talks", 2)
+
+        assert [episode.title for episode in episodes] == [
+            "Episode 100: The Future of AI",
+            "Episode 99: Building Scalable Systems",
+        ]
+
+    def test_get_latest_episodes_rejects_zero(self, valid_rss_feed: str) -> None:
+        """Test that count must be positive."""
+        feed = feedparser.parse(valid_rss_feed)
+        parser = RSSParser()
+
+        with pytest.raises(ValidationError, match="positive integer"):
+            parser.get_latest_episodes(feed, "Tech Talks", 0)
+
+    def test_get_latest_episodes_rejects_too_many(self, valid_rss_feed: str) -> None:
+        """Test that count cannot exceed the feed size."""
+        feed = feedparser.parse(valid_rss_feed)
+        parser = RSSParser()
+
+        with pytest.raises(NotFoundError) as exc_info:
+            parser.get_latest_episodes(feed, "Tech Talks", 4)
+
+        assert "1-3" in exc_info.value.suggestion
+
+    def test_get_latest_episodes_rejects_selection_over_max(self, valid_rss_feed: str) -> None:
+        """Test that count enforces the same maximum as range/list selection."""
+        feed = feedparser.parse(valid_rss_feed)
+        parser = RSSParser()
+
+        with pytest.raises(ValidationError, match="maximum of 100"):
+            parser.get_latest_episodes(feed, "Tech Talks", 101)
+
     def test_get_episode_by_title(self, valid_rss_feed: str) -> None:
         """Test finding episode by title keyword."""
         feed = feedparser.parse(valid_rss_feed)


### PR DESCRIPTION
## Summary

- Add `inkwell fetch <feed> --count N` for processing the N latest saved-feed episodes
- Validate mutual exclusion with `--latest` / `--episode`, positive counts, and the existing max selection limit
- Update feed parser, CLI docs, and focused parser/CLI tests

Closes #57

## Verification

- `uv run pytest tests/unit/test_feeds_parser.py tests/integration/test_cli.py -q`
- `uv run ruff check src/inkwell/cli.py src/inkwell/feeds/parser.py tests/unit/test_feeds_parser.py tests/integration/test_cli.py`
- pre-commit hooks on commit