### PR TITLE
feat(cli): add feed extra templates

### DIFF
--- a/docs/building-in-public/devlog/2026-04-30-extra-templates.md
+++ b/docs/building-in-public/devlog/2026-04-30-extra-templates.md
@@ -1,0 +1,20 @@
+# Extra Templates CLI
+
+**Date:** 2026-04-30
+**Author:** Diego
+
+## Focus
+
+Implement GitHub issue #33: expose feed-level additive templates through CLI and listing commands without renaming the persisted `custom_templates` schema field.
+
+## Progress
+
+Technical review confirmed the issue is still current. `FeedConfig.custom_templates` exists, and `TemplateSelector` already treats custom templates as additive. The missing pieces are CLI write paths, feed listing visibility, feed-mode merge into pipeline options, and docs/tests.
+
+## Decision
+
+Keep `custom_templates` in YAML for compatibility. Use `--extra-templates` in CLI copy because it describes behavior: feed templates are added to default/category-selected templates.
+
+## Next
+
+Add focused integration tests for add/config/list behavior, update docs, and open a PR closing #33.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -37,6 +37,7 @@ inkwell add <URL> --feed-name <NAME> [OPTIONS]
 | `--feed-name` | `-n` | string | Required | Feed display name or identifier. Human-readable names are slugified for the config key. |
 | `--name` | | string | Required | Backward-compatible alias for `--feed-name` |
 | `--category` | `-c` | string | None | Feed category |
+| `--extra-templates` | `-t` | string | None | Additional templates to run for this feed, added to category defaults. Comma-separated. |
 | `--auth` | | flag | false | Prompt for authentication |
 
 ### Examples
@@ -50,6 +51,9 @@ inkwell add https://example.com/feed.rss --feed-name "Oren Meets World"
 
 # With category
 inkwell add https://example.com/feed.rss --feed-name tech-show --category tech
+
+# With feed-level extra templates
+inkwell add https://example.com/feed.rss --feed-name interview-show --category interview --extra-templates books-mentioned,step-by-step-plan
 
 # With authentication
 inkwell add https://private.com/feed.rss --feed-name premium --auth
@@ -80,9 +84,9 @@ inkwell list
 ╭─────────────────────────────────────────────────────────╮
 │           Configured Podcast Feeds                      │
 ├────────────────┬───────────────────┬──────┬─────────────┤
-│ Name           │ URL               │ Auth │ Category    │
+│ Name           │ URL               │ Auth │ Category │ Extra Templates │
 ├────────────────┼───────────────────┼──────┼─────────────┤
-│ my-podcast     │ example.com/...   │ —    │ tech        │
+│ my-podcast     │ example.com/...   │ —    │ tech     │ books-mentioned │
 ╰────────────────┴───────────────────┴──────┴─────────────╯
 
 Total: 1 feed(s)
@@ -389,6 +393,27 @@ inkwell config set <KEY> <VALUE>
 inkwell config set log_level DEBUG
 inkwell config set default_output_dir ~/Documents/podcasts
 inkwell config set transcription.api_key "your-key"
+```
+
+### inkwell config feed
+
+Update per-feed settings.
+
+```bash
+inkwell config feed <NAME> --extra-templates <TEMPLATE_LIST>
+```
+
+Options:
+
+| Option | Short | Type | Description |
+|--------|-------|------|-------------|
+| `--extra-templates` | `-t` | string | Additional templates to run for this feed, added to category defaults. Pass an empty string to clear. |
+
+Examples:
+
+```bash
+inkwell config feed my-podcast --extra-templates books-mentioned,step-by-step-plan
+inkwell config feed my-podcast --extra-templates ""
 ```
 
 ---

--- a/docs/user-guide/feeds.md
+++ b/docs/user-guide/feeds.md
@@ -49,6 +49,26 @@ inkwell add https://example.com/feed.rss --feed-name startup-podcast --category 
 | `interview` | Interview shows | summary, quotes |
 | `education` | Educational content | summary, key-concepts |
 
+### Feed with Extra Templates
+
+Use `--extra-templates` when a feed should always run additional templates beyond its category defaults:
+
+```bash
+inkwell add https://example.com/feed.rss \
+  --feed-name founder-interviews \
+  --category interview \
+  --extra-templates books-mentioned,step-by-step-plan
+```
+
+Extra templates are additive. A feed with category `interview` still gets the interview defaults, then Inkwell adds `books-mentioned` and `step-by-step-plan`.
+
+Change or clear them later:
+
+```bash
+inkwell config feed founder-interviews --extra-templates books-mentioned
+inkwell config feed founder-interviews --extra-templates ""
+```
+
 ### Private/Paid Feeds
 
 For premium podcasts requiring authentication:
@@ -127,10 +147,10 @@ inkwell list
 ╭─────────────────────────────────────────────────────────╮
 │           Configured Podcast Feeds                      │
 ├────────────────┬───────────────────┬──────┬─────────────┤
-│ Name           │ URL               │ Auth │ Category    │
+│ Name           │ URL               │ Auth │ Category    │ Extra Templates │
 ├────────────────┼───────────────────┼──────┼─────────────┤
-│ tech-show      │ feeds.example...  │ —    │ tech        │
-│ premium-show   │ private.com/...   │ ✓    │ —           │
+│ tech-show      │ feeds.example...  │ —    │ tech        │ books-mentioned │
+│ premium-show   │ private.com/...   │ ✓    │ —           │ -               │
 ╰────────────────┴───────────────────┴──────┴─────────────╯
 
 Total: 2 feed(s)
@@ -188,7 +208,7 @@ inkwell rename old-name new-name --force
 
 ```bash
 inkwell add https://tech1.com/feed.rss --feed-name tech-podcast-1 --category tech
-inkwell add https://tech2.com/feed.rss --feed-name tech-podcast-2 --category tech
+inkwell add https://tech2.com/feed.rss --feed-name tech-podcast-2 --category tech --extra-templates step-by-step-plan
 inkwell add https://biz.com/feed.rss --feed-name business-show --category business
 ```
 

--- a/src/inkwell/cli.py
+++ b/src/inkwell/cli.py
@@ -17,6 +17,7 @@ from rich.table import Table
 from inkwell.config.logging import setup_logging
 from inkwell.config.manager import ConfigManager, normalize_feed_name, slugify_feed_name
 from inkwell.config.schema import AuthConfig, FeedConfig
+from inkwell.extraction.templates import TemplateLoader
 from inkwell.feeds.models import Episode
 from inkwell.feeds.parser import MAX_EPISODES_PER_SELECTION, RSSParser
 from inkwell.feeds.youtube_resolver import (
@@ -100,6 +101,45 @@ def _normalize_feed_name(name: str) -> str:
     return normalize_feed_name(name)
 
 
+def _parse_extra_templates(value: str | None) -> list[str]:
+    """Parse a comma-separated --extra-templates value."""
+    if value is None:
+        return []
+    return [template.strip() for template in value.split(",") if template.strip()]
+
+
+def _dedupe_template_names(names: list[str]) -> list[str]:
+    """Deduplicate template names while preserving user-provided order."""
+    seen: set[str] = set()
+    deduped = []
+    for name in names:
+        if name not in seen:
+            seen.add(name)
+            deduped.append(name)
+    return deduped
+
+
+def _validate_template_names(names: list[str]) -> None:
+    """Validate template names against built-in and user templates."""
+    if not names:
+        return
+
+    available = set(TemplateLoader().list_templates())
+    missing = [name for name in names if name not in available]
+    if missing:
+        raise ValidationError(
+            f"Unknown template(s): {', '.join(missing)}",
+            suggestion="Run 'inkwell list templates' to see available templates.",
+        )
+
+
+def _parse_and_validate_extra_templates(value: str | None) -> list[str]:
+    """Parse, dedupe, and validate --extra-templates."""
+    templates = _dedupe_template_names(_parse_extra_templates(value))
+    _validate_template_names(templates)
+    return templates
+
+
 def _derive_feed_name(resolved: ResolvedFeed, existing: set[str]) -> str:
     """Auto-derive a feed name from channel metadata when --feed-name is omitted.
 
@@ -162,6 +202,15 @@ def add_feed(
     category: str | None = typer.Option(
         None, "--category", "-c", help="Feed category (e.g., tech, interview)"
     ),
+    extra_templates: str | None = typer.Option(
+        None,
+        "--extra-templates",
+        "-t",
+        help=(
+            "Additional templates to run for this feed, added to category defaults. "
+            "Comma-separated."
+        ),
+    ),
 ) -> None:
     """Add a new podcast feed.
 
@@ -200,11 +249,13 @@ def add_feed(
         # Non-YouTube URLs pass through as-is (resolver returns None).
         resolved = await resolve_youtube_url(url)
         feed_url = resolved.feed_url if resolved else url
+        custom_templates = _parse_and_validate_extra_templates(extra_templates)
 
         feed_config = FeedConfig(
             url=HttpUrl(feed_url),
             auth=auth_config,
             category=category,
+            custom_templates=custom_templates,
         )
 
         stored_name = manager.add_feed(feed_name, feed_config)
@@ -216,6 +267,8 @@ def add_feed(
         # they can spot a mis-resolved channel without running `inkwell list`.
         if feed_url != url:
             console.print(f"[dim]  Resolved to {feed_url}[/dim]")
+        if custom_templates:
+            console.print(f"[dim]  Extra templates: {', '.join(custom_templates)}[/dim]")
         if auth:
             console.print("[dim]  Credentials encrypted and stored securely[/dim]")
 
@@ -302,9 +355,18 @@ def remove_feed(
 
 @app.command("config")
 def config_command(
-    action: str = typer.Argument(..., help="Action: show, edit, or set <key> <value>"),
+    action: str = typer.Argument(..., help="Action: show, edit, set, or feed"),
     key: str | None = typer.Argument(None, help="Config key (for 'set' action)"),
     value: str | None = typer.Argument(None, help="Config value (for 'set' action)"),
+    extra_templates: str | None = typer.Option(
+        None,
+        "--extra-templates",
+        "-t",
+        help=(
+            "For 'feed': additional templates to run for this feed, added to "
+            "category defaults. Pass an empty string to clear."
+        ),
+    ),
 ) -> None:
     """Manage Inkwell configuration.
 
@@ -312,6 +374,7 @@ def config_command(
         show: Display current configuration
         edit: Open config file in $EDITOR
         set:  Set a configuration value
+        feed: Update per-feed settings
 
     Examples:
         inkwell config show
@@ -319,6 +382,10 @@ def config_command(
         inkwell config edit
 
         inkwell config set log_level DEBUG
+
+        inkwell config feed my-podcast --extra-templates books-mentioned,step-by-step-plan
+
+        inkwell config feed my-podcast --extra-templates ""
     """
     try:
         manager = ConfigManager()
@@ -514,9 +581,32 @@ def config_command(
                 )
                 sys.exit(1)
 
+        elif action == "feed":
+            if not key or extra_templates is None:
+                console.print(
+                    "[red]✗[/red] Usage: inkwell config feed <name> --extra-templates <list>"
+                )
+                console.print('[dim]  Pass --extra-templates "" to clear extra templates.[/dim]')
+                sys.exit(1)
+
+            feed_config = manager.get_feed(key)
+            custom_templates = _parse_and_validate_extra_templates(extra_templates)
+            manager.update_feed(
+                key,
+                feed_config.model_copy(update={"custom_templates": custom_templates}),
+            )
+
+            if custom_templates:
+                console.print(
+                    f"[green]✓[/green] Set extra templates for [cyan]{key}[/cyan]: "
+                    f"[yellow]{', '.join(custom_templates)}[/yellow]"
+                )
+            else:
+                console.print(f"[green]✓[/green] Cleared extra templates for [cyan]{key}[/cyan]")
+
         else:
             console.print(f"[red]✗[/red] Unknown action: {action}")
-            console.print("Valid actions: show, edit, set")
+            console.print("Valid actions: show, edit, set, feed")
             sys.exit(1)
 
     except InkwellError as e:
@@ -839,6 +929,7 @@ def fetch_command(
             # Auth credentials for private feeds (passed to audio downloader)
             auth_username: str | None = None
             auth_password: str | None = None
+            feed_extra_templates: list[str] = []
             # Episode from RSS feed (if applicable)
             ep: Episode | None = None
             # Set when the argument resolves to a configured feed (and we fan
@@ -962,6 +1053,7 @@ def fetch_command(
 
                     if not resolved_category and feed_config.category:
                         resolved_category = feed_config.category
+                    feed_extra_templates = feed_config.custom_templates
 
                     # Extract auth credentials for audio download (basic auth only)
                     if feed_config.auth and feed_config.auth.type == "basic":
@@ -1013,11 +1105,18 @@ def fetch_command(
                 # Show output directory upfront
                 console.print("[bold cyan]Inkwell Extraction Pipeline[/bold cyan]")
                 console.print(f"[dim]Output: {effective_output_dir}[/dim]\n")
+                template_names = (
+                    [t.strip() for t in templates.split(",") if t.strip()] if templates else []
+                )
+                if feed_extra_templates:
+                    template_names = _dedupe_template_names(
+                        [*template_names, *feed_extra_templates]
+                    )
 
                 options = PipelineOptions(
                     url=url,
                     category=resolved_category,
-                    templates=[t.strip() for t in templates.split(",")] if templates else None,
+                    templates=template_names or None,
                     provider=provider,
                     interview=interview,
                     no_resume=no_resume,

--- a/src/inkwell/cli_list.py
+++ b/src/inkwell/cli_list.py
@@ -234,6 +234,7 @@ def _list_feeds_impl(json_output: bool = False) -> None:
                         "url": str(feed.url),
                         "auth": auth_type,
                         "category": feed.category or "",
+                        "extra_templates": feed.custom_templates,
                     }
                 )
             result = {"feeds": feeds_data, "total": len(feeds)}
@@ -251,17 +252,27 @@ def _list_feeds_impl(json_output: bool = False) -> None:
         table.add_column("URL", style="blue")
         table.add_column("Auth", justify="center", style="yellow")
         table.add_column("Category", style="green")
+        table.add_column("Extra Templates", style="magenta")
 
         # Add rows
         for name, feed in feeds.items():
             auth_status = "Yes" if feed.auth.type != "none" else "-"
             category_display = feed.category or "-"
+            extra_templates_display = (
+                ", ".join(feed.custom_templates) if feed.custom_templates else "-"
+            )
             url_display = truncate_url(str(feed.url), max_length=50)
             name_display = feed.display_name or name
             if feed.display_name and feed.display_name != name:
                 name_display = f"{feed.display_name}\n[dim]{name}[/dim]"
 
-            table.add_row(name_display, url_display, auth_status, category_display)
+            table.add_row(
+                name_display,
+                url_display,
+                auth_status,
+                category_display,
+                extra_templates_display,
+            )
 
         console.print(table)
         console.print(f"\n[dim]Total: {len(feeds)} feed(s)[/dim]")

--- a/src/inkwell/config/manager.py
+++ b/src/inkwell/config/manager.py
@@ -202,7 +202,7 @@ class ConfigManager:
         )
 
         if old_config:
-            changes = {}
+            changes: dict[str, dict[str, object]] = {}
             if str(old_config.default_output_dir) != str(config.default_output_dir):
                 changes["default_output_dir"] = {
                     "old": str(old_config.default_output_dir),
@@ -483,7 +483,7 @@ class ConfigManager:
             feeds.feeds[resolved_name] = feed_config
             self.save_feeds(feeds)
 
-            changes = {}
+            changes: dict[str, dict[str, object]] = {}
             if str(old_config.url) != str(feed_config.url):
                 changes["url"] = {
                     "old": str(old_config.url),

--- a/src/inkwell/config/manager.py
+++ b/src/inkwell/config/manager.py
@@ -447,6 +447,7 @@ class ConfigManager:
                     "url": str(feed_config.url),
                     "auth_type": feed_config.auth.type if feed_config.auth else "none",
                     "category": feed_config.category,
+                    "custom_templates": feed_config.custom_templates,
                 },
             )
             return normalized_name
@@ -499,6 +500,11 @@ class ConfigManager:
                 changes["display_name"] = {
                     "old": old_config.display_name or "",
                     "new": feed_config.display_name or "",
+                }
+            if old_config.custom_templates != feed_config.custom_templates:
+                changes["custom_templates"] = {
+                    "old": old_config.custom_templates,
+                    "new": feed_config.custom_templates,
                 }
 
             self._log_change(

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -205,6 +205,52 @@ class TestCLIAddYouTube:
         feeds = ConfigManager(config_dir=tmp_path).list_feeds()
         assert "will-not-save" not in feeds
 
+    def test_add_feed_with_extra_templates(self, tmp_path: Path, monkeypatch) -> None:
+        """`inkwell add --extra-templates` persists to FeedConfig.custom_templates."""
+        monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
+        monkeypatch.setattr("inkwell.config.manager.get_config_dir", lambda: tmp_path)
+
+        result = runner.invoke(
+            app,
+            [
+                "add",
+                "https://example.com/feed.rss",
+                "--feed-name",
+                "templated-feed",
+                "--extra-templates",
+                "books-mentioned,step-by-step-plan",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        feeds = ConfigManager(config_dir=tmp_path).list_feeds()
+        assert feeds["templated-feed"].custom_templates == [
+            "books-mentioned",
+            "step-by-step-plan",
+        ]
+        assert "Extra templates" in result.output
+
+    def test_add_feed_rejects_unknown_extra_template(self, tmp_path: Path, monkeypatch) -> None:
+        """Template names are validated before a feed is saved."""
+        monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
+        monkeypatch.setattr("inkwell.config.manager.get_config_dir", lambda: tmp_path)
+
+        result = runner.invoke(
+            app,
+            [
+                "add",
+                "https://example.com/feed.rss",
+                "--feed-name",
+                "bad-template-feed",
+                "--extra-templates",
+                "not-a-template",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "Unknown template" in result.output
+        assert "bad-template-feed" not in ConfigManager(config_dir=tmp_path).list_feeds()
+
 
 class TestShouldShowSaveFeedHint:
     """Unit tests for the hint-visibility decision helper."""
@@ -872,6 +918,73 @@ class TestCLIFetchSaveFeed:
         assert result.exit_code != 0
         assert "maximum of 100" in result.output
 
+    def test_fetch_saved_feed_merges_extra_templates(self, tmp_path: Path, monkeypatch) -> None:
+        """Feed custom templates are added to PipelineOptions.templates."""
+        from types import SimpleNamespace
+
+        monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
+        monkeypatch.setattr("inkwell.config.manager.get_config_dir", lambda: tmp_path)
+
+        manager = ConfigManager(config_dir=tmp_path)
+        from inkwell.config.schema import FeedConfig as _FeedConfig
+
+        manager.add_feed(
+            "templated-feed",
+            _FeedConfig(
+                url="https://example.com/feed.rss",  # type: ignore[arg-type]
+                custom_templates=["books-mentioned", "step-by-step-plan"],
+            ),
+        )
+
+        async def fake_fetch_feed(*_args, **_kwargs):
+            return SimpleNamespace(entries=[object()])
+
+        def fake_get_latest_episode(*_args, **_kwargs):
+            return SimpleNamespace(
+                title="Latest",
+                url="https://example.com/latest.mp3",
+                podcast_name="Templated Feed",
+            )
+
+        output_dir = tmp_path / "episode-dir"
+        output_dir.mkdir()
+        seen_templates: list[list[str] | None] = []
+
+        async def fake_process(_orchestrator, options, *_args, **_kwargs):
+            seen_templates.append(options.templates)
+            return SimpleNamespace(
+                episode_output=SimpleNamespace(directory=output_dir),
+                extraction_results=[],
+                interview_result=None,
+                extraction_cost_usd=0.0,
+                interview_cost_usd=0.0,
+                total_cost_usd=0.0,
+            )
+
+        monkeypatch.setattr("inkwell.feeds.parser.RSSParser.fetch_feed", fake_fetch_feed)
+        monkeypatch.setattr(
+            "inkwell.feeds.parser.RSSParser.get_latest_episode",
+            fake_get_latest_episode,
+        )
+        monkeypatch.setattr("inkwell.pipeline.PipelineOrchestrator.process_episode", fake_process)
+
+        result = runner.invoke(
+            app,
+            [
+                "fetch",
+                "templated-feed",
+                "--latest",
+                "--templates",
+                "summary,books-mentioned",
+                "--dry-run",
+                "--output-dir",
+                str(tmp_path),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert seen_templates == [["summary", "books-mentioned", "step-by-step-plan"]]
+
     def test_feed_name_without_save_feed_errors(self, tmp_path: Path, monkeypatch) -> None:
         """--feed-name alone is a no-op that silently mislead users and
         scripts into thinking the channel was persisted. Reject up-front.
@@ -1158,6 +1271,44 @@ class TestCLIConfig:
         # Verify
         assert reloaded.log_level == "DEBUG"
         assert reloaded.youtube_check is False
+
+    def test_config_feed_sets_and_clears_extra_templates(self, tmp_path: Path, monkeypatch) -> None:
+        """`inkwell config feed` updates feed-level extra templates."""
+        monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
+        monkeypatch.setattr("inkwell.config.manager.get_config_dir", lambda: tmp_path)
+
+        from inkwell.config.schema import FeedConfig
+
+        manager = ConfigManager(config_dir=tmp_path)
+        manager.add_feed(
+            "templated-feed",
+            FeedConfig(url="https://example.com/feed.rss"),  # type: ignore[arg-type]
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "config",
+                "feed",
+                "templated-feed",
+                "--extra-templates",
+                "books-mentioned,step-by-step-plan",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert ConfigManager(config_dir=tmp_path).get_feed("templated-feed").custom_templates == [
+            "books-mentioned",
+            "step-by-step-plan",
+        ]
+
+        clear_result = runner.invoke(
+            app,
+            ["config", "feed", "templated-feed", "--extra-templates", ""],
+        )
+
+        assert clear_result.exit_code == 0, clear_result.output
+        assert ConfigManager(config_dir=tmp_path).get_feed("templated-feed").custom_templates == []
 
 
 class TestCLIHelp:

--- a/tests/integration/test_cli_list.py
+++ b/tests/integration/test_cli_list.py
@@ -43,6 +43,7 @@ class TestListFeeds:
     def test_list_feeds_with_data(self, tmp_path: Path, monkeypatch) -> None:
         """Should show feeds when configured."""
         monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
+        monkeypatch.setattr("inkwell.config.manager.get_config_dir", lambda: tmp_path)
 
         from inkwell.config.manager import ConfigManager
         from inkwell.config.schema import AuthConfig, FeedConfig
@@ -54,6 +55,7 @@ class TestListFeeds:
                 url="https://example.com/feed.rss",  # type: ignore
                 auth=AuthConfig(type="none"),
                 category="tech",
+                custom_templates=["books-mentioned"],
             ),
         )
 
@@ -62,6 +64,32 @@ class TestListFeeds:
         assert result.exit_code == 0
         assert "test-podcast" in result.stdout
         assert "example.com" in result.stdout
+        assert "books-mentioned" in result.stdout
+
+    def test_list_feeds_json_includes_extra_templates(self, tmp_path: Path, monkeypatch) -> None:
+        """JSON feed list includes feed-level extra templates."""
+        import json
+
+        monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
+        monkeypatch.setattr("inkwell.config.manager.get_config_dir", lambda: tmp_path)
+
+        from inkwell.config.manager import ConfigManager
+        from inkwell.config.schema import FeedConfig
+
+        manager = ConfigManager(config_dir=tmp_path)
+        manager.add_feed(
+            "test-podcast",
+            FeedConfig(
+                url="https://example.com/feed.rss",  # type: ignore[arg-type]
+                custom_templates=["books-mentioned"],
+            ),
+        )
+
+        result = runner.invoke(app, ["list", "feeds", "--json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["feeds"][0]["extra_templates"] == ["books-mentioned"]
 
 
 class TestListTemplates:


### PR DESCRIPTION
## Summary

- Add `inkwell add --extra-templates` for feed-level additive templates while keeping the stored `custom_templates` schema field
- Add `inkwell config feed <name> --extra-templates ...` to set or clear feed extra templates after creation
- Merge saved feed extra templates into feed-based fetches, and show them in `inkwell list feeds` table/JSON output
- Update feed/CLI docs and add a DKS devlog

Closes #33

## Verification

- `uv run pytest tests/integration/test_cli.py tests/integration/test_cli_list.py -q`
- `uv run pytest tests/unit/test_config_manager.py tests/unit/test_schema.py -q`
- `uv run ruff check src/inkwell/cli.py src/inkwell/cli_list.py src/inkwell/config/manager.py tests/integration/test_cli.py tests/integration/test_cli_list.py`
- pre-commit hooks on commit