### PR TITLE
refactor: narrow simplification pass (OBRA-9 / #18)

### DIFF
--- a/src/inkwell/transcription/gemini.py
+++ b/src/inkwell/transcription/gemini.py
@@ -143,9 +143,11 @@ class GeminiTranscriber(TranscriptionPlugin):
             cost_confirmation_callback: Callback for cost confirmation
         """
         # Try GOOGLE_API_KEY first (standard), then GOOGLE_AI_API_KEY (deprecated)
-        self.api_key = api_key or os.getenv("GOOGLE_API_KEY") or os.getenv("GOOGLE_AI_API_KEY")
+        _google_api_key = os.getenv("GOOGLE_API_KEY")
+        _google_ai_api_key = os.getenv("GOOGLE_AI_API_KEY")
+        self.api_key = api_key or _google_api_key or _google_ai_api_key
 
-        if os.getenv("GOOGLE_AI_API_KEY") and not os.getenv("GOOGLE_API_KEY"):
+        if _google_ai_api_key and not _google_api_key:
             logger.warning(
                 "GOOGLE_AI_API_KEY is deprecated. Please use GOOGLE_API_KEY instead. "
                 "GOOGLE_AI_API_KEY will be removed in v2.0.0"


### PR DESCRIPTION
## Summary

- Caches `os.getenv("GOOGLE_API_KEY")` and `os.getenv("GOOGLE_AI_API_KEY")` into locals in `GeminiTranscriber._initialize_client` so each env var is read exactly once instead of twice (once for key resolution, once for the deprecation-warning check).
- `src/inkwell/config/manager.py` import consolidation was attempted but ruff's isort rule enforces the aliased-import-in-separate-block form — the split is the canonical style for this project and requires no change.

## Test plan

- [x] `tests/unit/transcription/test_gemini.py` — all 28 tests pass (covers explicit key, `GOOGLE_API_KEY` env, deprecated `GOOGLE_AI_API_KEY` env, precedence, missing-key failure)
- [x] `tests/unit/test_config_manager.py` — all 49 tests pass (no behaviour change)
- [x] `ruff check` / `ruff format` — clean on both files

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)