### PR TITLE
Rebuild direct URL _inbox capture flow

### DIFF
--- a/docs/building-in-public/devlog/2026-04-30-direct-url-inbox-flow.md
+++ b/docs/building-in-public/devlog/2026-04-30-direct-url-inbox-flow.md
@@ -1,0 +1,30 @@
+# Rebuild Direct URL _inbox Flow
+
+**Date:** 2026-04-30
+**Author:** Diego
+
+## Focus
+
+Implement issue #60 by rebuilding direct URL captures so they route into `_inbox` by default, while keeping readable episode titles for URL-derived runs.
+
+## Progress
+
+- Updated metadata defaulting in `PipelineOrchestrator` to resolve podcast/title before `EpisodeMetadata` creation.
+- Direct URL captures now default to podcast `_inbox` unless `--podcast-name` is provided.
+- Added readable URL title extraction and fallback title (`Untitled capture`) for cases where URL paths are not informative.
+- Extended YouTube URL resolution metadata to include optional episode title from yt-dlp and wired CLI fetch to pass it into pipeline options.
+- Added tests for YouTube title pass-through, generic URL title derivation, fallback title behavior, and `--podcast-name` override behavior.
+
+## Observations
+
+The existing save-feed work already had the right pre-resolve hook (`resolve_youtube_url`), so adding episode title reuse was low-risk and avoided introducing a second yt-dlp query path.
+
+## Next
+
+Run targeted tests and open PR with `Closes #60` once green.
+
+## Links
+
+- Related ADR: `../adr/008-use-uv-for-python-tooling.md`
+- PR: TBD
+- Issue: #60

--- a/src/inkwell/cli.py
+++ b/src/inkwell/cli.py
@@ -970,10 +970,9 @@ def fetch_command(
                         ),
                     )
 
-            # Pre-resolve YouTube URLs so the channel name becomes the podcast
-            # display name (output dirs otherwise fall back to "unknown-podcast"
-            # on direct-URL fetches). Also lets the post-fetch --save-feed
-            # block reuse the tuple instead of calling yt-dlp twice.
+            # Pre-resolve YouTube URLs so we can reuse yt-dlp metadata
+            # (channel + video title) and avoid a second yt-dlp call in the
+            # post-fetch --save-feed block.
             pre_resolved: ResolvedFeed | None = None
             if is_url and is_youtube_url(url_or_feed) and not is_youtube_playlist_url(url_or_feed):
                 try:
@@ -1082,17 +1081,10 @@ def fetch_command(
                 if ep is not None:
                     episode_title = ep.title
                     detected_podcast_name = ep.podcast_name or url_or_feed
-                elif save_feed and feed_name is not None:
-                    # Explicit --feed-name means the user told us what to call
-                    # this feed — reuse as the display name so we don't force
-                    # them to pass --podcast-name redundantly. They can still
-                    # override for display via --podcast-name explicitly.
-                    detected_podcast_name = feed_name
-                elif pre_resolved is not None and pre_resolved.channel_name:
-                    # Direct YouTube URL with no --feed-name: use the channel
-                    # name yt-dlp resolved. Without this (or --feed-name, or
-                    # --podcast-name), output dirs fall back to "unknown-podcast/".
-                    detected_podcast_name = pre_resolved.channel_name
+                elif pre_resolved is not None and pre_resolved.episode_title:
+                    # Direct YouTube URL: when yt-dlp provides a video title,
+                    # use it so direct-URL capture folders are readable.
+                    episode_title = pre_resolved.episode_title
 
                 # Compute effective output directory
                 effective_output_dir = output_dir or config.default_output_dir

--- a/src/inkwell/feeds/youtube_resolver.py
+++ b/src/inkwell/feeds/youtube_resolver.py
@@ -30,7 +30,8 @@ class ResolvedFeed(NamedTuple):
     """
 
     feed_url: str
-    channel_name: str | None
+    channel_name: str | None = None
+    episode_title: str | None = None
 
 
 YOUTUBE_HOSTS = frozenset({"youtube.com", "www.youtube.com", "m.youtube.com", "youtu.be"})
@@ -154,9 +155,11 @@ def _resolve_with_ytdlp(url: str) -> ResolvedFeed:
             suggestion=_MANUAL_ESCAPE_HATCH,
         )
     channel_name = info.get("channel") or info.get("uploader")
+    episode_title = info.get("title") if isinstance(info.get("title"), str) else None
     return ResolvedFeed(
         feed_url=_FEED_URL_TEMPLATE.format(channel_id=channel_id),
         channel_name=channel_name,
+        episode_title=episode_title,
     )
 
 

--- a/src/inkwell/pipeline/orchestrator.py
+++ b/src/inkwell/pipeline/orchestrator.py
@@ -23,6 +23,7 @@ from inkwell.utils.api_keys import APIKeyError, get_validated_api_key
 from inkwell.utils.costs import CostTracker
 from inkwell.utils.datetime import now_utc
 from inkwell.utils.errors import InkwellError
+from inkwell.utils.url_metadata import derive_readable_title_from_url
 
 from .models import PipelineOptions, PipelineResult
 
@@ -36,6 +37,9 @@ if TYPE_CHECKING:
     from inkwell.transcription.models import TranscriptionResult
 
 logger = logging.getLogger(__name__)
+
+_DIRECT_URL_PODCAST = "_inbox"
+_FALLBACK_DIRECT_URL_TITLE = "Untitled capture"
 
 
 class PipelineOrchestrator:
@@ -132,6 +136,16 @@ class PipelineOrchestrator:
         output_manager = OutputManager(output_dir=output_path)
         return output_manager._get_episode_directory_path(episode_metadata)
 
+    def _resolve_episode_metadata_defaults(self, options: PipelineOptions) -> tuple[str, str]:
+        """Resolve podcast/title defaults for output naming."""
+        podcast_name = (options.podcast_name or "").strip() or _DIRECT_URL_PODCAST
+        episode_title = (
+            (options.episode_title or "").strip()
+            or derive_readable_title_from_url(options.url)
+            or _FALLBACK_DIRECT_URL_TITLE
+        )
+        return podcast_name, episode_title
+
     async def process_episode(
         self,
         options: PipelineOptions,
@@ -194,15 +208,21 @@ class PipelineOrchestrator:
         if progress_callback:
             progress_callback("template_selection_start", {})
 
+        effective_podcast_name, effective_episode_title = self._resolve_episode_metadata_defaults(
+            options
+        )
+
         selected_templates = self._select_templates(
             options=options,
             transcript=transcript.full_text,
             episode_url=options.url,
+            episode_title=effective_episode_title,
+            podcast_name=effective_podcast_name,
         )
 
         episode_metadata = EpisodeMetadata(
-            podcast_name=options.podcast_name or "Unknown Podcast",
-            episode_title=options.episode_title or f"Episode from {options.url}",
+            podcast_name=effective_podcast_name,
+            episode_title=effective_episode_title,
             episode_url=options.url,
             transcription_source=transcript.source,
         )
@@ -434,6 +454,8 @@ class PipelineOrchestrator:
         options: PipelineOptions,
         transcript: str,
         episode_url: str,
+        episode_title: str,
+        podcast_name: str,
     ) -> list["ExtractionTemplate"]:
         """Select templates based on options and content.
 
@@ -454,11 +476,11 @@ class PipelineOrchestrator:
 
         # url is HttpUrl but Pydantic validates str at runtime
         episode = Episode(
-            title=f"Episode from {episode_url}",
+            title=episode_title,
             url=episode_url,  # type: ignore[arg-type]
             published=now_utc(),
             description="",
-            podcast_name="Unknown Podcast",
+            podcast_name=podcast_name,
         )
 
         selected_templates = selector.select_templates(

--- a/src/inkwell/utils/url_metadata.py
+++ b/src/inkwell/utils/url_metadata.py
@@ -1,0 +1,68 @@
+"""URL metadata helpers."""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import unquote, urlparse
+
+_AUDIO_EXTENSIONS = (
+    ".mp3",
+    ".m4a",
+    ".wav",
+    ".aac",
+    ".ogg",
+    ".flac",
+    ".mp4",
+    ".webm",
+    ".mkv",
+    ".m4v",
+    ".mov",
+)
+
+_GENERIC_PATH_TITLES = {
+    "audio",
+    "embed",
+    "episode",
+    "feed",
+    "feeds",
+    "live",
+    "playlist",
+    "shorts",
+    "videosxml",
+    "watch",
+}
+
+
+def derive_readable_title_from_url(url: str) -> str | None:
+    """Derive a readable episode title from a URL path.
+
+    Returns None if the URL does not contain a useful title candidate.
+    """
+    parsed = urlparse(url)
+    if not parsed.path:
+        return None
+
+    segments = [segment for segment in parsed.path.split("/") if segment]
+    if not segments:
+        return None
+
+    candidate = unquote(segments[-1]).strip()
+    if not candidate:
+        return None
+
+    lower_candidate = candidate.lower()
+    for extension in _AUDIO_EXTENSIONS:
+        if lower_candidate.endswith(extension):
+            candidate = candidate[: -len(extension)]
+            break
+
+    cleaned = candidate.replace("-", " ").replace("_", " ").replace("+", " ")
+    cleaned = re.sub(r"\s+", " ", cleaned).strip(" .-_")
+    if not cleaned:
+        return None
+
+    normalized = re.sub(r"[^a-z0-9]+", "", cleaned.lower())
+    if normalized in _GENERIC_PATH_TITLES:
+        return None
+
+    return cleaned

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -730,6 +730,57 @@ class TestCLIFetchSaveFeed:
         feeds = ConfigManager(config_dir=tmp_path).list_feeds()
         assert "scheme-less" in feeds
 
+    def test_direct_youtube_url_passes_resolved_episode_title_to_pipeline(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Direct YouTube fetch should reuse yt-dlp title metadata for naming."""
+        from types import SimpleNamespace
+
+        monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
+
+        output_dir = tmp_path / "episode-dir"
+        output_dir.mkdir()
+
+        seen_titles: list[tuple[str | None, str | None]] = []
+
+        async def fake_process(_orchestrator, options, *_args, **_kwargs):
+            seen_titles.append((options.podcast_name, options.episode_title))
+            return SimpleNamespace(
+                episode_output=SimpleNamespace(directory=output_dir),
+                extraction_results=[],
+                interview_result=None,
+                extraction_cost_usd=0.0,
+                interview_cost_usd=0.0,
+                total_cost_usd=0.0,
+            )
+
+        async def fake_resolve(_url: str) -> ResolvedFeed:
+            return ResolvedFeed(
+                feed_url="https://www.youtube.com/feeds/videos.xml?channel_id=UCtitle",
+                channel_name="Channel Name",
+                episode_title="Readable Video Title",
+            )
+
+        monkeypatch.setattr("inkwell.pipeline.PipelineOrchestrator.process_episode", fake_process)
+        monkeypatch.setattr("inkwell.cli.resolve_youtube_url", fake_resolve)
+
+        result = runner.invoke(
+            app,
+            [
+                "fetch",
+                "https://www.youtube.com/watch?v=abc",
+                "--dry-run",
+                "--output-dir",
+                str(tmp_path),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        # Direct URL fetches stay in the orchestrator's _inbox default unless
+        # users explicitly pass --podcast-name, but they should still get a
+        # readable title from yt-dlp metadata when available.
+        assert seen_titles == [(None, "Readable Video Title")]
+
     def test_fetch_saved_feed_accepts_display_name(self, tmp_path: Path, monkeypatch) -> None:
         """Saved feeds can be fetched by their display name."""
         from types import SimpleNamespace

--- a/tests/unit/test_pipeline_orchestrator.py
+++ b/tests/unit/test_pipeline_orchestrator.py
@@ -1,0 +1,60 @@
+"""Unit tests for pipeline orchestrator metadata defaults."""
+
+from pathlib import Path
+
+from inkwell.config.schema import GlobalConfig
+from inkwell.pipeline.models import PipelineOptions
+from inkwell.pipeline.orchestrator import PipelineOrchestrator
+
+
+def _orchestrator(tmp_path: Path) -> PipelineOrchestrator:
+    config = GlobalConfig(default_output_dir=tmp_path)
+    return PipelineOrchestrator(config)
+
+
+def test_direct_youtube_url_uses_inbox_and_supplied_episode_title(tmp_path: Path) -> None:
+    orchestrator = _orchestrator(tmp_path)
+    options = PipelineOptions(
+        url="https://www.youtube.com/watch?v=abc123",
+        episode_title="How to Build Durable Systems",
+    )
+
+    podcast_name, episode_title = orchestrator._resolve_episode_metadata_defaults(options)
+
+    assert podcast_name == "_inbox"
+    assert episode_title == "How to Build Durable Systems"
+
+
+def test_direct_generic_url_derives_readable_title(tmp_path: Path) -> None:
+    orchestrator = _orchestrator(tmp_path)
+    options = PipelineOptions(
+        url="https://cdn.example.com/audio/ship-it-fast-and-safe.mp3",
+    )
+
+    podcast_name, episode_title = orchestrator._resolve_episode_metadata_defaults(options)
+
+    assert podcast_name == "_inbox"
+    assert episode_title == "ship it fast and safe"
+
+
+def test_direct_url_falls_back_to_untitled_capture(tmp_path: Path) -> None:
+    orchestrator = _orchestrator(tmp_path)
+    options = PipelineOptions(url="https://example.com/")
+
+    podcast_name, episode_title = orchestrator._resolve_episode_metadata_defaults(options)
+
+    assert podcast_name == "_inbox"
+    assert episode_title == "Untitled capture"
+
+
+def test_podcast_name_override_wins_over_inbox_default(tmp_path: Path) -> None:
+    orchestrator = _orchestrator(tmp_path)
+    options = PipelineOptions(
+        url="https://example.com/audio/episode-12.mp3",
+        podcast_name="My Override",
+    )
+
+    podcast_name, episode_title = orchestrator._resolve_episode_metadata_defaults(options)
+
+    assert podcast_name == "My Override"
+    assert episode_title == "episode 12"

--- a/tests/unit/test_youtube_resolver.py
+++ b/tests/unit/test_youtube_resolver.py
@@ -10,10 +10,12 @@ from inkwell.utils.errors import ValidationError
 
 
 def _mock_ytdlp(
-    channel_id: str | None = "UCtestChannelIdExample", channel: str | None = "Test Channel"
+    channel_id: str | None = "UCtestChannelIdExample",
+    channel: str | None = "Test Channel",
+    title: str | None = "Test Episode Title",
 ):
     """Build a patch context for yt_dlp.YoutubeDL returning the given info dict."""
-    info: dict[str, str | None] = {"channel_id": channel_id, "channel": channel}
+    info: dict[str, str | None] = {"channel_id": channel_id, "channel": channel, "title": title}
     mock_instance = MagicMock()
     mock_instance.extract_info.return_value = info
     mock_class = MagicMock()
@@ -80,11 +82,16 @@ class TestResolveYouTubeUrlWithYtDlp:
 
     @pytest.mark.asyncio
     async def test_watch_url_resolves_via_ytdlp(self) -> None:
-        patcher, mock_class = _mock_ytdlp(channel_id="UCabc", channel="Some Channel")
+        patcher, mock_class = _mock_ytdlp(
+            channel_id="UCabc",
+            channel="Some Channel",
+            title="How to Build Durable Systems",
+        )
         with patcher:
             result = await resolve_youtube_url("https://www.youtube.com/watch?v=someVideoId")
         assert result is not None
         assert "channel_id=UCabc" in result.feed_url
+        assert result.episode_title == "How to Build Durable Systems"
         mock_class.assert_called_once()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- default direct URL captures to `_inbox` unless `--podcast-name` is explicitly provided
- derive readable episode titles from URL paths and use `Untitled capture` fallback when URL shape is not informative
- pass YouTube yt-dlp episode title metadata from pre-resolve into pipeline options for readable naming
- keep feed-mode behavior intact and documented with a devlog entry

## Testing
- `uv run pytest tests/unit/test_pipeline_orchestrator.py tests/unit/test_youtube_resolver.py tests/integration/test_cli.py`
- `uv run ruff check src/inkwell/cli.py src/inkwell/pipeline/orchestrator.py src/inkwell/feeds/youtube_resolver.py src/inkwell/utils/url_metadata.py tests/unit/test_pipeline_orchestrator.py tests/unit/test_youtube_resolver.py tests/integration/test_cli.py`

Closes #60
