### PR TITLE
[codex] refresh model config language

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Current health baseline:
 uv tool install inkwell-cli
 ```
 
+Inkwell is distributed as the `inkwell-cli` package on PyPI. `uv tool install`
+is the recommended install path; Docker images and a Homebrew formula are not
+currently provided.
+
 ### API Keys
 
 ```bash
@@ -330,28 +334,30 @@ Edit `~/.config/inkwell/config.yaml`:
 ```yaml
 version: "1"
 log_level: INFO
-default_output_dir: ./output
-default_provider: gemini  # or "claude"
-youtube_check: true
+default_output_dir: ~/inkwell-notes
 max_episodes_per_run: 10
 
-# Optional API keys (or use environment variables)
-gemini_api_key: ""
-anthropic_api_key: ""
+transcription:
+  api_key: ""  # or use GOOGLE_API_KEY
+  model_name: gemini-2.5-flash
+  youtube_check: true
+
+extraction:
+  default_provider: gemini  # or "claude"
+  gemini_api_key: ""        # optional; falls back to transcription.api_key
+  claude_api_key: ""        # or use ANTHROPIC_API_KEY
 
 # Templates to enable
-templates_enabled:
+default_templates:
   - summary
   - quotes
   - key-concepts
-  - tools-mentioned
-  - books-mentioned
-  - people-mentioned
 
 # Obsidian features
-wikilinks_enabled: true
-tags_enabled: true
-dataview_frontmatter: true
+obsidian:
+  wikilinks: true
+  tags: true
+  dataview: true
 ```
 
 ### Editing Configuration

--- a/docs/getting-started/first-episode.md
+++ b/docs/getting-started/first-episode.md
@@ -64,6 +64,8 @@ inkwell config set transcription.api_key "your-google-ai-api-key-here"
 ```
 
 This stores the key in Inkwell's config file, scoped to this tool only.
+Gemini extraction uses this key too unless you set `extraction.gemini_api_key`
+separately.
 
 **Alternative: Environment Variables**
 
@@ -351,7 +353,7 @@ inkwell fetch syntax --latest
 
 ```bash
 # Edit config
-inkwell config --edit
+inkwell config edit
 
 # Try different settings:
 # - Change output directory

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -96,7 +96,7 @@ Inkwell requires API keys for transcription and extraction.
 
 ### Google AI (Required)
 
-Used for transcription (Gemini) and content extraction.
+Used for Gemini transcription and content extraction.
 
 1. Go to [Google AI Studio](https://aistudio.google.com/app/apikey)
 2. Click "Create API Key"
@@ -107,6 +107,11 @@ Used for transcription (Gemini) and content extraction.
 ```bash
 inkwell config set transcription.api_key "your-google-ai-api-key"
 ```
+
+This key is also used for Gemini extraction unless you set
+`extraction.gemini_api_key` separately. The Gemini transcription model is
+configurable at `transcription.model_name`; generated config files currently
+default to `gemini-2.5-flash`.
 
 **Or via environment variable:**
 
@@ -166,11 +171,13 @@ inkwell config show
 | Method | Status |
 |--------|--------|
 | `uv tool install inkwell-cli` | **Supported** (recommended) |
-| `pip install inkwell-cli` | **Supported** |
-| Docker image | Not currently provided |
-| Homebrew formula | Not currently provided |
+| PyPI package (`pip install inkwell-cli`) | **Supported** |
+| Docker image | Not yet supported |
+| Homebrew formula | Not yet supported |
 
-Docker and Homebrew are not on the current roadmap. If you'd like to see them, open a [GitHub issue](https://github.com/chekos/inkwell-cli/issues) to gauge interest.
+Docker and Homebrew packaging are not currently provided. If either install
+path would help your workflow, open a [GitHub issue](https://github.com/chekos/inkwell-cli/issues)
+so demand can be tracked.
 
 ---
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -18,6 +18,9 @@ Process your first podcast episode in under 5 minutes.
 inkwell config set transcription.api_key "your-google-ai-api-key"
 ```
 
+The same key is used for Gemini extraction unless you set
+`extraction.gemini_api_key` separately.
+
 Or use an environment variable:
 
 ```bash
@@ -37,7 +40,7 @@ inkwell fetch https://youtube.com/watch?v=your-video-id
 **What happens:**
 
 1. Inkwell checks for a free YouTube transcript
-2. If unavailable, it transcribes using Gemini
+2. If unavailable, it transcribes using the configured Gemini model
 3. AI extracts key information (summary, quotes, concepts)
 4. Markdown files are created in your output directory
 

--- a/docs/reference/config-options.md
+++ b/docs/reference/config-options.md
@@ -43,7 +43,7 @@ default_output_dir: $HOME/notes/podcasts
 |-----|------|---------|-------------|
 | `transcription.api_key` | string | `""` | Google AI API key |
 | `transcription.model_name` | string | `gemini-2.5-flash` | Gemini model for transcription |
-| `youtube_check` | boolean | `true` | Check YouTube for transcripts first |
+| `transcription.youtube_check` | boolean | `true` | Check YouTube for transcripts first |
 
 ### transcription.api_key
 
@@ -62,7 +62,7 @@ transcription:
 
 The Gemini model used when audio transcription is required (i.e. no free YouTube transcript is available).
 
-Default (matches the generated config template):
+Generated config default:
 
 ```yaml
 transcription:
@@ -77,14 +77,24 @@ transcription:
 ```
 
 The model name must start with `gemini-`. When in doubt, omit this key and let the default apply.
+Generated config files may still contain the legacy top-level
+`transcription_model` key with the same default. Prefer
+`transcription.model_name` for new edits.
 
-### youtube_check
+### transcription.youtube_check
 
 When `true`, Inkwell checks for free YouTube transcripts before using Gemini.
 
 ```yaml
-youtube_check: true  # Recommended: saves money
-youtube_check: false # Always use Gemini transcription
+transcription:
+  youtube_check: true  # Recommended: saves money
+```
+
+To force Gemini transcription without checking YouTube first:
+
+```yaml
+transcription:
+  youtube_check: false # Always use Gemini transcription
 ```
 
 ---
@@ -95,6 +105,8 @@ youtube_check: false # Always use Gemini transcription
 |-----|------|---------|-------------|
 | `max_episodes_per_run` | int | `10` | Maximum episodes per batch |
 | `extraction.default_provider` | enum | `gemini` | Default LLM provider |
+| `extraction.gemini_api_key` | string | `""` | Optional Google AI key for extraction |
+| `extraction.claude_api_key` | string | `""` | Optional Anthropic key for extraction |
 | `extraction.cache_days` | int | `30` | Cache duration in days |
 
 ### extraction.default_provider
@@ -104,6 +116,12 @@ Valid values: `gemini`, `claude`
 ```yaml
 extraction:
   default_provider: gemini  # Cost-effective (recommended)
+```
+
+To use Claude for extraction:
+
+```yaml
+extraction:
   default_provider: claude  # Higher quality, 40x more expensive
 ```
 
@@ -209,12 +227,15 @@ default_output_dir: ~/ObsidianVault/podcasts
 # Transcription
 transcription:
   api_key: "your-google-ai-key"
-youtube_check: true
+  model_name: gemini-2.5-flash
+  youtube_check: true
 
 # Extraction
 max_episodes_per_run: 10
 extraction:
   default_provider: gemini
+  gemini_api_key: ""  # optional; falls back to transcription.api_key
+  claude_api_key: ""  # optional; can also use ANTHROPIC_API_KEY
   cache_days: 30
 
 # Interview

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -35,15 +35,11 @@ inkwell config show
 Output:
 
 ```
-╭─────────────────────────────────────────────╮
-│            Configuration                     │
-├─────────────────────────────────────────────┤
-│ version: "1"                                 │
-│ log_level: INFO                              │
-│ default_output_dir: ~/podcasts               │
-│ youtube_check: true                          │
-│ max_episodes_per_run: 10                     │
-╰─────────────────────────────────────────────╯
+Config file: ~/.config/inkwell/config.yaml
+Output directory: ~/podcasts
+Log level: INFO
+YouTube check: ✓
+Transcription model: gemini-2.5-flash
 ```
 
 ---
@@ -90,7 +86,7 @@ Opens `config.yaml` in your `$EDITOR` (defaults to `vi`).
 |--------|------|---------|-------------|
 | `transcription.api_key` | string | `""` | Google AI API key |
 | `transcription.model_name` | string | `gemini-2.5-flash` | Gemini model for audio transcription |
-| `youtube_check` | boolean | `true` | Check YouTube for transcripts first |
+| `transcription.youtube_check` | boolean | `true` | Check YouTube for transcripts first |
 
 ### Extraction
 
@@ -98,6 +94,8 @@ Opens `config.yaml` in your `$EDITOR` (defaults to `vi`).
 |--------|------|---------|-------------|
 | `max_episodes_per_run` | integer | `10` | Max episodes per batch |
 | `extraction.default_provider` | string | `gemini` | Default LLM provider |
+| `extraction.gemini_api_key` | string | `""` | Optional Google AI key for extraction |
+| `extraction.claude_api_key` | string | `""` | Optional Anthropic key for extraction |
 | `extraction.cache_days` | integer | `30` | Extraction cache duration |
 
 ### Interview
@@ -135,12 +133,14 @@ default_output_dir: ~/ObsidianVault/podcasts
 # Transcription
 transcription:
   api_key: your-google-ai-key-here
-  model_name: gemini-2.5-flash   # omit to use the default
-youtube_check: true
+  model_name: gemini-2.5-flash   # omit to use the generated config default
+  youtube_check: true
 
 # Extraction
 extraction:
   default_provider: gemini
+  gemini_api_key: ""  # optional; falls back to transcription.api_key
+  claude_api_key: ""  # optional; can also use ANTHROPIC_API_KEY
   cache_days: 30
 max_episodes_per_run: 10
 
@@ -173,7 +173,7 @@ Environment variables provide fallback values when the corresponding config key 
 
 | Variable | Fallback for |
 |----------|-------------|
-| `GOOGLE_API_KEY` | `transcription.api_key` |
+| `GOOGLE_API_KEY` | `transcription.api_key` and Gemini extraction |
 | `ANTHROPIC_API_KEY` | Anthropic API key for interview |
 | `INKWELL_CONFIG_DIR` | Config directory location |
 | `INKWELL_OUTPUT_DIR` | `default_output_dir` |


### PR DESCRIPTION
## Summary

- Update public docs to describe the supported nested `transcription` / `extraction` config paths without rewriting historical DKS material.
- Reflect the current generated-config default for `transcription.model_name` as `gemini-2.5-flash`, with `gemini-3-flash-preview` shown only as an override example.
- Explain the Google API key fallback for Gemini extraction.
- Clarify distribution language: PyPI and `uv tool install` are supported; Docker and Homebrew are not yet supported.

## Why

OBRA-17 is the community docs and model-language slice split out from OBRA-8. PR #67 landed the community-health files and first model-config pass, but active public docs still mixed old top-level config examples with newer nested paths. Diego's review also caught that the generated config template still writes legacy `transcription_model: gemini-2.5-flash`, so this PR now documents the effective generated-config default instead of overstating `gemini-3-flash-preview` as the current default.

## Validation

- `uv run mkdocs build --strict`
- `git diff --check`
- Commit hooks passed

Refs OBRA-17. Follow-up to #67.
