### PR TITLE
feat(demo): m2 pipeline glue — resolver + process_demo_job (OBRA-76)

### DIFF
--- a/src/inkwell/demo/__init__.py
+++ b/src/inkwell/demo/__init__.py
@@ -14,16 +14,31 @@ from inkwell.demo.classifier import (
 )
 from inkwell.demo.config import DemoConfig, get_demo_config
 from inkwell.demo.payload import DemoNoteFile, DemoResultPayload, build_demo_payload
+from inkwell.demo.resolver import ResolvedDemoSource, resolve_demo_source
+from inkwell.demo.service import (
+    DemoDurationBackstopError,
+    DemoJobResult,
+    DemoPipelineDisabledError,
+    configure_demo_runtime,
+    process_demo_job,
+)
 
 __all__ = [
     "ClassifiedUrl",
     "DemoConfig",
+    "DemoDurationBackstopError",
+    "DemoJobResult",
     "DemoNoteFile",
+    "DemoPipelineDisabledError",
     "DemoResultPayload",
     "DemoUrlError",
+    "ResolvedDemoSource",
     "UrlKind",
     "assert_demo_safe_url",
     "build_demo_payload",
     "classify_demo_url",
+    "configure_demo_runtime",
     "get_demo_config",
+    "process_demo_job",
+    "resolve_demo_source",
 ]

--- a/src/inkwell/demo/classifier.py
+++ b/src/inkwell/demo/classifier.py
@@ -348,11 +348,11 @@ def _reject_legacy_ipv4_encoding(host: str) -> None:
 
 
 def _ip_is_disallowed(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
-    return (
-        ip.is_private
-        or ip.is_loopback
-        or ip.is_link_local
-        or ip.is_reserved
-        or ip.is_multicast
-        or ip.is_unspecified
-    )
+    # ``not ip.is_global`` blocks every range Python flags as
+    # private/loopback/link_local/reserved/multicast/unspecified AND the
+    # ones it does NOT mark with those booleans — most importantly
+    # RFC6598 carrier-grade NAT space (100.64.0.0/10), which a public
+    # hostname can resolve to in deployments behind ISP CGN. Codex
+    # flagged this gap on PR #73; using ``is_global`` is the one-call
+    # answer recommended by the stdlib docs.
+    return not ip.is_global

--- a/src/inkwell/demo/resolver.py
+++ b/src/inkwell/demo/resolver.py
@@ -1,0 +1,367 @@
+"""Resolve a demo URL into a pipeline-ready source and reject overlong audio.
+
+The classifier already validated that the pasted URL is structurally a
+public RSS feed or a YouTube video URL. The resolver does the next layer
+of work *before* the inkwell pipeline spends any LLM/transcription
+budget:
+
+- For YouTube videos: pull duration from ``yt-dlp`` metadata (no
+  download) and reject anything over ``demo_config.max_duration_seconds``.
+- For RSS feeds: fetch the feed via :func:`_fetch_feed_safely` (manual
+  redirect loop that revalidates each hop with
+  :func:`assert_demo_safe_url`), pick the latest episode via
+  :class:`RSSParser`, and reject if the iTunes duration is missing or
+  over the cap. The audio enclosure URL is also revalidated before
+  handoff so a public feed can't list a localhost MP3.
+
+Episodes longer than the cap are rejected here; metadata that lies
+about duration (claims short, is actually long) is caught by the
+service's post-transcription backstop in :mod:`inkwell.demo.service`.
+
+The returned :class:`ResolvedDemoSource` is what
+:func:`inkwell.demo.service.process_demo_job` feeds to
+:class:`PipelineOrchestrator`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+import feedparser
+import httpx
+from yt_dlp import YoutubeDL  # type: ignore[import-untyped]
+from yt_dlp.utils import DownloadError, ExtractorError  # type: ignore[import-untyped]
+
+from inkwell.demo.classifier import ClassifiedUrl, DemoUrlError, UrlKind, assert_demo_safe_url
+from inkwell.demo.config import DemoConfig
+from inkwell.feeds.parser import RSSParser
+from inkwell.utils.errors import NotFoundError, ValidationError
+
+_YTDLP_SOCKET_TIMEOUT_SECONDS = 30
+
+_DEMO_RSS_PODCAST_FALLBACK = "Demo episode"
+
+# RSS fetch hardening (codex P1 carry-over from m1):
+# RSSParser.fetch_feed uses ``follow_redirects=True``, which would let a
+# public URL 302 to localhost / RFC1918 and bypass the m1 SSRF guard.
+# The demo path uses ``_fetch_feed_safely`` instead, which walks
+# redirects manually and revalidates each ``Location`` target via
+# ``assert_demo_safe_url``.
+_RSS_FETCH_TIMEOUT_SECONDS = 30
+_RSS_MAX_REDIRECT_HOPS = 5
+
+
+@dataclass(frozen=True)
+class ResolvedDemoSource:
+    """A demo URL that has cleared duration validation and is ready to run.
+
+    Attributes:
+        kind: Kind of source that was resolved.
+        pipeline_url: URL handed to :class:`PipelineOrchestrator`. For RSS
+            this is the audio enclosure URL of the latest episode; for
+            YouTube it is the original video URL (the transcription
+            manager handles YouTube URLs directly).
+        duration_seconds: Episode/video duration in seconds. Always a
+            concrete int — episodes with unknown duration are rejected
+            upstream.
+        podcast_name: Display name used for output naming and the
+            frontend payload.
+        episode_title: Episode/video title used for output naming and the
+            frontend payload.
+    """
+
+    kind: UrlKind
+    pipeline_url: str
+    duration_seconds: int
+    podcast_name: str
+    episode_title: str
+
+
+async def resolve_demo_source(
+    classified: ClassifiedUrl,
+    *,
+    demo_config: DemoConfig,
+) -> ResolvedDemoSource:
+    """Resolve a classified URL and reject anything over the duration cap.
+
+    Args:
+        classified: Output of :func:`classify_demo_url`.
+        demo_config: Demo runtime configuration; ``max_duration_seconds``
+            is the hard cap.
+
+    Returns:
+        A :class:`ResolvedDemoSource` ready to feed into the pipeline.
+
+    Raises:
+        DemoUrlError: If the URL can't be resolved, no episode is
+            available, duration is unknown, or duration exceeds the cap.
+            The ``user_message`` field is safe to surface verbatim.
+    """
+    if classified.kind is UrlKind.YOUTUBE_VIDEO:
+        return await _resolve_youtube_video(classified.normalized_url, demo_config)
+    if classified.kind is UrlKind.PUBLIC_RSS:
+        return await _resolve_public_rss(classified.normalized_url, demo_config)
+    # Defensive — UrlKind is closed; reachable only if a new variant is
+    # added without updating this function.
+    raise DemoUrlError(
+        "We can't run that kind of URL in the demo.",
+        reason=f"unknown_url_kind:{classified.kind!r}",
+    )
+
+
+async def _resolve_youtube_video(
+    url: str,
+    demo_config: DemoConfig,
+) -> ResolvedDemoSource:
+    info = await asyncio.to_thread(_fetch_youtube_video_info, url)
+    duration_seconds = _coerce_duration(info)
+    if duration_seconds is None:
+        raise DemoUrlError(
+            "We couldn't read this video's duration. Try another video.",
+            reason="youtube_missing_duration",
+        )
+    _enforce_duration_cap(duration_seconds, demo_config)
+
+    title = _coerce_str(info.get("title")) or "YouTube video"
+    podcast_name = (
+        _coerce_str(info.get("channel")) or _coerce_str(info.get("uploader")) or "YouTube"
+    )
+
+    return ResolvedDemoSource(
+        kind=UrlKind.YOUTUBE_VIDEO,
+        pipeline_url=url,
+        duration_seconds=duration_seconds,
+        podcast_name=podcast_name,
+        episode_title=title,
+    )
+
+
+async def _resolve_public_rss(
+    url: str,
+    demo_config: DemoConfig,
+) -> ResolvedDemoSource:
+    feed = await _fetch_feed_safely(url)
+
+    podcast_name = _coerce_str(getattr(feed.feed, "title", None)) or _DEMO_RSS_PODCAST_FALLBACK
+
+    try:
+        episode = RSSParser().get_latest_episode(feed, podcast_name)
+    except (ValidationError, NotFoundError) as exc:
+        raise DemoUrlError(
+            "That feed doesn't have a usable latest episode.",
+            reason=f"rss_no_latest_episode:{type(exc).__name__}",
+        ) from exc
+
+    if episode.duration_seconds is None:
+        raise DemoUrlError(
+            "The latest episode doesn't list a duration. Try a different feed.",
+            reason="rss_missing_duration",
+        )
+
+    _enforce_duration_cap(episode.duration_seconds, demo_config)
+
+    enclosure_url = str(episode.url)
+    try:
+        assert_demo_safe_url(enclosure_url)
+    except DemoUrlError as exc:
+        # Feed listed an enclosure URL pointing at a private host.
+        # Refuse the whole job — we can't trust this feed to hand us a
+        # download target that's safe for the worker to dereference.
+        raise DemoUrlError(
+            "The latest episode's audio URL points at a private address.",
+            reason=f"rss_unsafe_enclosure:{exc.reason}",
+        ) from exc
+
+    return ResolvedDemoSource(
+        kind=UrlKind.PUBLIC_RSS,
+        pipeline_url=enclosure_url,
+        duration_seconds=episode.duration_seconds,
+        podcast_name=episode.podcast_name,
+        episode_title=episode.title,
+    )
+
+
+async def _fetch_feed_safely(url: str) -> feedparser.FeedParserDict:
+    """Fetch RSS contents while revalidating every redirect hop.
+
+    This replaces :meth:`RSSParser.fetch_feed` for the demo path. The
+    upstream method passes ``follow_redirects=True`` to ``httpx``, which
+    would let a public URL 30x to localhost / RFC1918 and bypass the
+    classifier's host policy. Here we set ``follow_redirects=False`` and
+    walk up to :data:`_RSS_MAX_REDIRECT_HOPS` redirect hops manually,
+    calling :func:`assert_demo_safe_url` on each ``Location`` target
+    before issuing the next request.
+
+    Args:
+        url: Caller-supplied RSS URL. Already validated by
+            :func:`classify_demo_url`, but we revalidate the chain.
+
+    Returns:
+        Parsed feed dictionary from :func:`feedparser.parse`.
+
+    Raises:
+        DemoUrlError: With a user-safe message and structured ``reason``
+            when the fetch fails, hits an unsafe redirect, or exceeds
+            the redirect-hop budget.
+    """
+    current = url
+    async with httpx.AsyncClient(
+        timeout=_RSS_FETCH_TIMEOUT_SECONDS,
+        follow_redirects=False,
+    ) as client:
+        for _hop in range(_RSS_MAX_REDIRECT_HOPS + 1):
+            response = await _safe_get(client, current)
+
+            if response.status_code == 401:
+                raise DemoUrlError(
+                    "That feed is private. The demo only supports public RSS feeds.",
+                    reason="rss_authentication_required",
+                )
+
+            if response.is_redirect:
+                location = response.headers.get("location")
+                if not location:
+                    raise DemoUrlError(
+                        "We couldn't follow the RSS feed redirect.",
+                        reason="rss_redirect_no_location",
+                    )
+                next_target = str(httpx.URL(current).join(location))
+                # Revalidate before issuing the next request. assert_demo_safe_url
+                # raises DemoUrlError on private/loopback/legacy-encoding hosts;
+                # we wrap with a redirect-specific reason for log clarity.
+                try:
+                    assert_demo_safe_url(next_target)
+                except DemoUrlError as exc:
+                    raise DemoUrlError(
+                        "That feed redirects to a private address.",
+                        reason=f"rss_redirect_to_unsafe_host:{exc.reason}",
+                    ) from exc
+                current = next_target
+                continue
+
+            if response.status_code >= 400:
+                raise DemoUrlError(
+                    "We couldn't read that RSS feed. Check the URL and try again.",
+                    reason=f"rss_http_status:{response.status_code}",
+                )
+
+            feed = feedparser.parse(response.content)
+            if not feed.entries:
+                raise DemoUrlError(
+                    "That feed doesn't have any episodes.",
+                    reason="rss_no_entries",
+                )
+            return feed
+
+    raise DemoUrlError(
+        "Too many redirects while reading the RSS feed.",
+        reason="rss_too_many_redirects",
+    )
+
+
+async def _safe_get(client: httpx.AsyncClient, url: str) -> httpx.Response:
+    """Single httpx GET with demo-friendly error mapping."""
+    try:
+        return await client.get(url)
+    except httpx.TimeoutException as exc:
+        raise DemoUrlError(
+            "We couldn't reach that RSS feed in time.",
+            reason="rss_fetch_timeout",
+        ) from exc
+    except httpx.RequestError as exc:
+        raise DemoUrlError(
+            "We couldn't read that RSS feed. Check the URL and try again.",
+            reason=f"rss_fetch_network_error:{type(exc).__name__}",
+        ) from exc
+
+
+def _fetch_youtube_video_info(url: str) -> dict[str, Any]:
+    """Pull a YouTube video's metadata via yt-dlp without downloading audio."""
+    ydl_opts = {
+        "quiet": True,
+        "no_warnings": True,
+        "skip_download": True,
+        "socket_timeout": _YTDLP_SOCKET_TIMEOUT_SECONDS,
+    }
+    try:
+        with YoutubeDL(ydl_opts) as ydl:
+            info = ydl.extract_info(url, download=False) or {}
+    except (DownloadError, ExtractorError, OSError) as exc:
+        raise DemoUrlError(
+            "We couldn't reach that video. It may be private, region-blocked, or removed.",
+            reason=f"yt_dlp_extract_failed:{type(exc).__name__}",
+        ) from exc
+
+    if not isinstance(info, dict):
+        raise DemoUrlError(
+            "We couldn't read that video's metadata.",
+            reason="yt_dlp_unexpected_payload",
+        )
+    return info
+
+
+def _coerce_duration(info: dict[str, Any]) -> int | None:
+    """Normalize yt-dlp's duration field into integer seconds.
+
+    yt-dlp returns ``duration`` as a numeric (int or float) when known.
+    Some extractors only set ``duration_string`` (``"H:MM:SS"``); we
+    parse that as a fallback. Returns ``None`` if neither is usable.
+    """
+    raw = info.get("duration")
+    if isinstance(raw, (int, float)) and raw > 0:
+        return int(raw)
+
+    duration_string = info.get("duration_string")
+    if isinstance(duration_string, str) and duration_string.strip():
+        seconds = _parse_duration_string(duration_string)
+        if seconds is not None and seconds > 0:
+            return seconds
+
+    return None
+
+
+def _parse_duration_string(value: str) -> int | None:
+    """Parse ``H:MM:SS`` / ``M:SS`` / ``SSSS`` into seconds, else None."""
+    text = value.strip()
+    if not text:
+        return None
+    if ":" in text:
+        try:
+            parts = [int(part) for part in text.split(":")]
+        except ValueError:
+            return None
+        if len(parts) == 3:
+            hours, minutes, seconds = parts
+            return hours * 3600 + minutes * 60 + seconds
+        if len(parts) == 2:
+            minutes, seconds = parts
+            return minutes * 60 + seconds
+        return None
+    try:
+        return int(text)
+    except ValueError:
+        return None
+
+
+def _enforce_duration_cap(duration_seconds: int, demo_config: DemoConfig) -> None:
+    if duration_seconds > demo_config.max_duration_seconds:
+        cap_minutes = demo_config.max_duration_seconds // 60
+        raise DemoUrlError(
+            f"Episodes over {cap_minutes} minutes aren't supported in the demo.",
+            reason=(f"duration_over_cap:{duration_seconds}>{demo_config.max_duration_seconds}"),
+        )
+
+
+def _coerce_str(value: Any) -> str | None:
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return None
+
+
+__all__ = [
+    "ResolvedDemoSource",
+    "resolve_demo_source",
+]

--- a/src/inkwell/demo/resolver.py
+++ b/src/inkwell/demo/resolver.py
@@ -26,6 +26,8 @@ The returned :class:`ResolvedDemoSource` is what
 from __future__ import annotations
 
 import asyncio
+import ipaddress
+import socket
 from dataclasses import dataclass
 from typing import Any
 
@@ -229,10 +231,18 @@ async def _fetch_feed_safely(url: str) -> feedparser.FeedParserDict:
                     )
                 next_target = str(httpx.URL(current).join(location))
                 # Revalidate before issuing the next request. assert_demo_safe_url
-                # raises DemoUrlError on private/loopback/legacy-encoding hosts;
-                # we wrap with a redirect-specific reason for log clarity.
+                # checks the host literal; _assert_resolved_host_is_public adds
+                # DNS resolution so a public hostname that resolves to
+                # loopback / RFC1918 from the worker is rejected too.
                 try:
                     assert_demo_safe_url(next_target)
+                except DemoUrlError as exc:
+                    raise DemoUrlError(
+                        "That feed redirects to a private address.",
+                        reason=f"rss_redirect_to_unsafe_host:{exc.reason}",
+                    ) from exc
+                try:
+                    await _assert_resolved_host_is_public(next_target)
                 except DemoUrlError as exc:
                     raise DemoUrlError(
                         "That feed redirects to a private address.",
@@ -259,6 +269,67 @@ async def _fetch_feed_safely(url: str) -> feedparser.FeedParserDict:
         "Too many redirects while reading the RSS feed.",
         reason="rss_too_many_redirects",
     )
+
+
+async def _assert_resolved_host_is_public(url: str) -> None:
+    """Resolve the URL's hostname and reject if any IP is private or reserved.
+
+    :func:`assert_demo_safe_url` validates the host literal in the URL
+    string. This adds the next layer: a public-looking hostname can still
+    resolve to loopback / RFC1918 / link-local space (DNS rebinding,
+    attacker-controlled DNS, internal split-horizon resolvers). Both
+    checks together close the SSRF surface for redirect hops.
+
+    No-op for IP literals — :func:`assert_demo_safe_url` already covered
+    those, and ``getaddrinfo`` on a literal would just echo it back.
+
+    Args:
+        url: Fully-qualified URL whose host will be resolved.
+
+    Raises:
+        DemoUrlError: When the host can't be resolved or any resolved
+            address falls in a disallowed range.
+    """
+    host = httpx.URL(url).host
+    if not host:
+        raise DemoUrlError(
+            "URL is missing a host.",
+            reason="missing_host",
+        )
+
+    try:
+        ipaddress.ip_address(host)
+        return
+    except ValueError:
+        pass
+
+    try:
+        infos = await asyncio.to_thread(socket.getaddrinfo, host, None, 0, socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise DemoUrlError(
+            "We couldn't resolve that host.",
+            reason=f"dns_resolution_failed:{type(exc).__name__}",
+        ) from exc
+
+    for info in infos:
+        sockaddr = info[4]
+        ip_str = sockaddr[0]
+        try:
+            ip = ipaddress.ip_address(ip_str)
+        except ValueError:
+            continue
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_reserved
+            or ip.is_multicast
+            or ip.is_unspecified
+        ):
+            raise DemoUrlError(
+                "URL resolves to a private address.",
+                reason=f"resolved_private_ip:{host}->{ip}",
+            )
 
 
 async def _safe_get(client: httpx.AsyncClient, url: str) -> httpx.Response:

--- a/src/inkwell/demo/resolver.py
+++ b/src/inkwell/demo/resolver.py
@@ -199,15 +199,27 @@ async def _resolve_public_rss(
 
 
 async def _fetch_feed_safely(url: str) -> feedparser.FeedParserDict:
-    """Fetch RSS contents while revalidating every redirect hop.
+    """Fetch RSS contents while revalidating every hop's host.
 
     This replaces :meth:`RSSParser.fetch_feed` for the demo path. The
     upstream method passes ``follow_redirects=True`` to ``httpx``, which
     would let a public URL 30x to localhost / RFC1918 and bypass the
     classifier's host policy. Here we set ``follow_redirects=False`` and
-    walk up to :data:`_RSS_MAX_REDIRECT_HOPS` redirect hops manually,
-    calling :func:`assert_demo_safe_url` on each ``Location`` target
-    before issuing the next request.
+    walk up to :data:`_RSS_MAX_REDIRECT_HOPS` redirect hops manually.
+
+    Every iteration revalidates the target before issuing the GET:
+
+    - :func:`assert_demo_safe_url` (host-literal policy)
+    - :func:`assert_resolved_host_is_public` (DNS resolution +
+      ``not ip.is_global``)
+
+    The initial URL is included on purpose. The classifier already ran
+    these same checks at submission time, but classification and worker
+    execution are decoupled in the demo (m1 = synchronous classify, m5 =
+    Cloud Tasks delivery) — a DNS-rebinding attacker can submit a
+    hostname that resolves public at classify time and flips to
+    RFC1918/loopback before the worker fetches. Re-running the checks
+    here closes that TOCTOU window for every hop, including hop 0.
 
     Args:
         url: Caller-supplied RSS URL. Already validated by
@@ -218,15 +230,17 @@ async def _fetch_feed_safely(url: str) -> feedparser.FeedParserDict:
 
     Raises:
         DemoUrlError: With a user-safe message and structured ``reason``
-            when the fetch fails, hits an unsafe redirect, or exceeds
-            the redirect-hop budget.
+            when the fetch fails, the host is unsafe (initial or
+            redirected), or the hop budget is exhausted.
     """
     current = url
     async with httpx.AsyncClient(
         timeout=_RSS_FETCH_TIMEOUT_SECONDS,
         follow_redirects=False,
     ) as client:
-        for _hop in range(_RSS_MAX_REDIRECT_HOPS + 1):
+        for hop in range(_RSS_MAX_REDIRECT_HOPS + 1):
+            await _assert_safe_to_fetch(current, is_redirect_hop=hop > 0)
+
             response = await _safe_get(client, current)
 
             if response.status_code == 401:
@@ -242,26 +256,9 @@ async def _fetch_feed_safely(url: str) -> feedparser.FeedParserDict:
                         "We couldn't follow the RSS feed redirect.",
                         reason="rss_redirect_no_location",
                     )
-                next_target = str(httpx.URL(current).join(location))
-                next_host = httpx.URL(next_target).host
-                # Revalidate before issuing the next request:
-                # - ``assert_demo_safe_url`` checks the host literal.
-                # - ``assert_resolved_host_is_public`` resolves the host
-                #   and rejects any address Python doesn't flag as
-                #   global (covers RFC1918, loopback, link-local,
-                #   reserved, multicast, *and* RFC6598 carrier-grade NAT
-                #   space — which boolean disjunctions miss).
-                # ``getaddrinfo`` is sync; run it off the event loop.
-                try:
-                    assert_demo_safe_url(next_target)
-                    if next_host:
-                        await asyncio.to_thread(assert_resolved_host_is_public, next_host)
-                except DemoUrlError as exc:
-                    raise DemoUrlError(
-                        "That feed redirects to a private address.",
-                        reason=f"rss_redirect_to_unsafe_host:{exc.reason}",
-                    ) from exc
-                current = next_target
+                # Resolve the next target relative to the current URL and
+                # let the next iteration's top-of-loop guard validate it.
+                current = str(httpx.URL(current).join(location))
                 continue
 
             if response.status_code >= 400:
@@ -282,6 +279,31 @@ async def _fetch_feed_safely(url: str) -> feedparser.FeedParserDict:
         "Too many redirects while reading the RSS feed.",
         reason="rss_too_many_redirects",
     )
+
+
+async def _assert_safe_to_fetch(url: str, *, is_redirect_hop: bool) -> None:
+    """Run the host-literal + DNS checks before any GET.
+
+    Wraps the underlying ``DemoUrlError`` so log filters can distinguish
+    a redirect-driven rejection (``rss_redirect_to_unsafe_host:*``) from
+    a TOCTOU-driven rejection on the initial URL
+    (``rss_unsafe_host:*``).
+    """
+    host = httpx.URL(url).host
+    try:
+        assert_demo_safe_url(url)
+        if host:
+            await asyncio.to_thread(assert_resolved_host_is_public, host)
+    except DemoUrlError as exc:
+        if is_redirect_hop:
+            raise DemoUrlError(
+                "That feed redirects to a private address.",
+                reason=f"rss_redirect_to_unsafe_host:{exc.reason}",
+            ) from exc
+        raise DemoUrlError(
+            "That feed's host can't be safely fetched.",
+            reason=f"rss_unsafe_host:{exc.reason}",
+        ) from exc
 
 
 async def _safe_get(client: httpx.AsyncClient, url: str) -> httpx.Response:

--- a/src/inkwell/demo/resolver.py
+++ b/src/inkwell/demo/resolver.py
@@ -32,6 +32,7 @@ from typing import Any
 
 import feedparser
 import httpx
+import pydantic
 from yt_dlp import YoutubeDL  # type: ignore[import-untyped]
 from yt_dlp.utils import DownloadError, ExtractorError  # type: ignore[import-untyped]
 
@@ -155,7 +156,11 @@ async def _resolve_public_rss(
 
     try:
         episode = RSSParser().get_latest_episode(feed, podcast_name)
-    except (ValidationError, NotFoundError) as exc:
+    except (ValidationError, NotFoundError, pydantic.ValidationError) as exc:
+        # ``pydantic.ValidationError`` covers feed entries that fail the
+        # ``Episode`` model itself — e.g., an enclosure URL that fails
+        # ``HttpUrl`` validation. Without it those land as 500s instead of
+        # a user-safe DemoUrlError.
         raise DemoUrlError(
             "That feed doesn't have a usable latest episode.",
             reason=f"rss_no_latest_episode:{type(exc).__name__}",

--- a/src/inkwell/demo/resolver.py
+++ b/src/inkwell/demo/resolver.py
@@ -169,8 +169,17 @@ async def _resolve_public_rss(
     _enforce_duration_cap(episode.duration_seconds, demo_config)
 
     enclosure_url = str(episode.url)
+    enclosure_host = httpx.URL(enclosure_url).host
     try:
+        # Two layers, same as the redirect guard: assert_demo_safe_url
+        # validates the host literal; assert_resolved_host_is_public
+        # resolves it and rejects RFC1918 / loopback / link-local /
+        # RFC6598 / etc. A feed on a public domain can still publish an
+        # enclosure whose host *resolves* to private space (codex P1
+        # follow-up), so both checks are needed here too.
         assert_demo_safe_url(enclosure_url)
+        if enclosure_host:
+            await asyncio.to_thread(assert_resolved_host_is_public, enclosure_host)
     except DemoUrlError as exc:
         # Feed listed an enclosure URL pointing at a private host.
         # Refuse the whole job — we can't trust this feed to hand us a

--- a/src/inkwell/demo/resolver.py
+++ b/src/inkwell/demo/resolver.py
@@ -26,6 +26,7 @@ The returned :class:`ResolvedDemoSource` is what
 from __future__ import annotations
 
 import asyncio
+import math
 from dataclasses import dataclass
 from typing import Any
 
@@ -353,10 +354,16 @@ def _coerce_duration(info: dict[str, Any]) -> int | None:
     yt-dlp returns ``duration`` as a numeric (int or float) when known.
     Some extractors only set ``duration_string`` (``"H:MM:SS"``); we
     parse that as a fallback. Returns ``None`` if neither is usable.
+
+    Float values are rounded up via :func:`math.ceil` so a video that
+    is fractionally over the cap (``1800.9`` against a 1800s cap) is
+    rejected at the resolver — truncation would let it through and
+    defer rejection to a post-transcription backstop, after the
+    pipeline has already spent budget.
     """
     raw = info.get("duration")
     if isinstance(raw, (int, float)) and raw > 0:
-        return int(raw)
+        return math.ceil(raw)
 
     duration_string = info.get("duration_string")
     if isinstance(duration_string, str) and duration_string.strip():

--- a/src/inkwell/demo/resolver.py
+++ b/src/inkwell/demo/resolver.py
@@ -26,8 +26,6 @@ The returned :class:`ResolvedDemoSource` is what
 from __future__ import annotations
 
 import asyncio
-import ipaddress
-import socket
 from dataclasses import dataclass
 from typing import Any
 
@@ -36,7 +34,13 @@ import httpx
 from yt_dlp import YoutubeDL  # type: ignore[import-untyped]
 from yt_dlp.utils import DownloadError, ExtractorError  # type: ignore[import-untyped]
 
-from inkwell.demo.classifier import ClassifiedUrl, DemoUrlError, UrlKind, assert_demo_safe_url
+from inkwell.demo.classifier import (
+    ClassifiedUrl,
+    DemoUrlError,
+    UrlKind,
+    assert_demo_safe_url,
+    assert_resolved_host_is_public,
+)
 from inkwell.demo.config import DemoConfig
 from inkwell.feeds.parser import RSSParser
 from inkwell.utils.errors import NotFoundError, ValidationError
@@ -230,19 +234,19 @@ async def _fetch_feed_safely(url: str) -> feedparser.FeedParserDict:
                         reason="rss_redirect_no_location",
                     )
                 next_target = str(httpx.URL(current).join(location))
-                # Revalidate before issuing the next request. assert_demo_safe_url
-                # checks the host literal; _assert_resolved_host_is_public adds
-                # DNS resolution so a public hostname that resolves to
-                # loopback / RFC1918 from the worker is rejected too.
+                next_host = httpx.URL(next_target).host
+                # Revalidate before issuing the next request:
+                # - ``assert_demo_safe_url`` checks the host literal.
+                # - ``assert_resolved_host_is_public`` resolves the host
+                #   and rejects any address Python doesn't flag as
+                #   global (covers RFC1918, loopback, link-local,
+                #   reserved, multicast, *and* RFC6598 carrier-grade NAT
+                #   space — which boolean disjunctions miss).
+                # ``getaddrinfo`` is sync; run it off the event loop.
                 try:
                     assert_demo_safe_url(next_target)
-                except DemoUrlError as exc:
-                    raise DemoUrlError(
-                        "That feed redirects to a private address.",
-                        reason=f"rss_redirect_to_unsafe_host:{exc.reason}",
-                    ) from exc
-                try:
-                    await _assert_resolved_host_is_public(next_target)
+                    if next_host:
+                        await asyncio.to_thread(assert_resolved_host_is_public, next_host)
                 except DemoUrlError as exc:
                     raise DemoUrlError(
                         "That feed redirects to a private address.",
@@ -269,67 +273,6 @@ async def _fetch_feed_safely(url: str) -> feedparser.FeedParserDict:
         "Too many redirects while reading the RSS feed.",
         reason="rss_too_many_redirects",
     )
-
-
-async def _assert_resolved_host_is_public(url: str) -> None:
-    """Resolve the URL's hostname and reject if any IP is private or reserved.
-
-    :func:`assert_demo_safe_url` validates the host literal in the URL
-    string. This adds the next layer: a public-looking hostname can still
-    resolve to loopback / RFC1918 / link-local space (DNS rebinding,
-    attacker-controlled DNS, internal split-horizon resolvers). Both
-    checks together close the SSRF surface for redirect hops.
-
-    No-op for IP literals — :func:`assert_demo_safe_url` already covered
-    those, and ``getaddrinfo`` on a literal would just echo it back.
-
-    Args:
-        url: Fully-qualified URL whose host will be resolved.
-
-    Raises:
-        DemoUrlError: When the host can't be resolved or any resolved
-            address falls in a disallowed range.
-    """
-    host = httpx.URL(url).host
-    if not host:
-        raise DemoUrlError(
-            "URL is missing a host.",
-            reason="missing_host",
-        )
-
-    try:
-        ipaddress.ip_address(host)
-        return
-    except ValueError:
-        pass
-
-    try:
-        infos = await asyncio.to_thread(socket.getaddrinfo, host, None, 0, socket.SOCK_STREAM)
-    except socket.gaierror as exc:
-        raise DemoUrlError(
-            "We couldn't resolve that host.",
-            reason=f"dns_resolution_failed:{type(exc).__name__}",
-        ) from exc
-
-    for info in infos:
-        sockaddr = info[4]
-        ip_str = sockaddr[0]
-        try:
-            ip = ipaddress.ip_address(ip_str)
-        except ValueError:
-            continue
-        if (
-            ip.is_private
-            or ip.is_loopback
-            or ip.is_link_local
-            or ip.is_reserved
-            or ip.is_multicast
-            or ip.is_unspecified
-        ):
-            raise DemoUrlError(
-                "URL resolves to a private address.",
-                reason=f"resolved_private_ip:{host}->{ip}",
-            )
 
 
 async def _safe_get(client: httpx.AsyncClient, url: str) -> httpx.Response:

--- a/src/inkwell/demo/service.py
+++ b/src/inkwell/demo/service.py
@@ -208,6 +208,11 @@ class _DurationBackstop:
     transcription just measured. We raise inside the
     ``transcription_complete`` step so the orchestrator stops before
     spending any LLM extraction budget.
+
+    Reads ``media_duration_seconds`` from the orchestrator payload, not
+    ``duration_seconds`` — the latter carries
+    :attr:`TranscriptionResult.duration_seconds`, which is wall-clock
+    transcription time, not media length.
     """
 
     __slots__ = ("_cap_seconds", "_metadata_duration_seconds")
@@ -219,7 +224,7 @@ class _DurationBackstop:
     def __call__(self, step: str, data: dict) -> None:
         if step != "transcription_complete":
             return
-        actual_duration = data.get("duration_seconds")
+        actual_duration = data.get("media_duration_seconds")
         if not isinstance(actual_duration, (int, float)):
             return
         if actual_duration > self._cap_seconds:

--- a/src/inkwell/demo/service.py
+++ b/src/inkwell/demo/service.py
@@ -1,0 +1,240 @@
+"""Glue between :mod:`inkwell.demo` and :class:`PipelineOrchestrator`.
+
+This module owns the demo-only invariants that the OBRA-73 plan calls
+out as non-negotiable for the public try-it surface:
+
+- The Gemini extractor model is forced down to ``gemini-2.5-flash``.
+  The CLI's higher-quality default (``gemini-3-pro-preview``) blows the
+  $50/mo demo budget on its own.
+- Pipeline output lands in a per-job temporary directory that is
+  removed after the markdown payload is serialized — the demo never
+  persists a vault.
+- Only the templates listed in
+  :attr:`DemoConfig.allowed_templates` are produced and surfaced.
+- A post-transcription duration backstop aborts before any extraction
+  spend if the real audio length disagrees with the yt-dlp/iTunes
+  metadata that the resolver trusted.
+
+The Cloud Run worker imports this module and calls
+:func:`configure_demo_runtime` once at process start, then dispatches
+:func:`process_demo_job` per Cloud Tasks delivery. The worker is
+configured for ``--concurrency=1`` (m5) so the class-level model pin
+isn't a thread-safety hazard.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from inkwell.config.schema import GlobalConfig
+from inkwell.demo.classifier import ClassifiedUrl
+from inkwell.demo.config import DemoConfig
+from inkwell.demo.payload import DemoResultPayload, build_demo_payload
+from inkwell.demo.resolver import ResolvedDemoSource, resolve_demo_source
+from inkwell.extraction.extractors.gemini import GeminiExtractor
+from inkwell.pipeline.models import PipelineOptions, PipelineResult
+from inkwell.pipeline.orchestrator import PipelineOrchestrator
+
+logger = logging.getLogger(__name__)
+
+
+class DemoPipelineDisabledError(RuntimeError):
+    """Raised when :data:`DemoConfig.enabled` is ``False``.
+
+    The kill switch (``INKWELL_DEMO_ENABLED=false``) lets us pause
+    processing without a redeploy. Callers should catch this and return
+    the user-facing maintenance response.
+    """
+
+
+class DemoDurationBackstopError(RuntimeError):
+    """Raised when the post-transcription duration check rejects a job.
+
+    The resolver trusts metadata; this fires when the real audio turns
+    out to be longer than the cap. Wrapped by :func:`process_demo_job`
+    so callers see a single failure surface.
+    """
+
+
+@dataclass(frozen=True)
+class DemoJobResult:
+    """Result of a successful :func:`process_demo_job` call.
+
+    Attributes:
+        payload: Frontend-shaped :class:`DemoResultPayload`.
+        resolved_source: Source metadata captured before the pipeline
+            ran. Useful for logging and Firestore (m4).
+        total_cost_usd: Realized total cost for this run, taken from
+            :attr:`PipelineResult.total_cost_usd`.
+    """
+
+    payload: DemoResultPayload
+    resolved_source: ResolvedDemoSource
+    total_cost_usd: float
+
+
+def configure_demo_runtime(demo_config: DemoConfig) -> None:
+    """Pin the Gemini extractor model to the demo's forced flash variant.
+
+    Idempotent: safe to call at FastAPI startup and again at the top of
+    every job. The Cloud Run worker runs single-threaded per container
+    instance (concurrency=1) so the class-attribute mutation is safe.
+
+    Args:
+        demo_config: Demo runtime configuration whose
+            ``forced_extraction_model`` is applied.
+    """
+    target_model = demo_config.forced_extraction_model
+    if GeminiExtractor.MODEL != target_model:
+        logger.info(
+            "Pinning GeminiExtractor.MODEL for demo runtime: %s -> %s",
+            GeminiExtractor.MODEL,
+            target_model,
+        )
+        GeminiExtractor.MODEL = target_model
+
+
+async def process_demo_job(
+    classified_url: ClassifiedUrl,
+    *,
+    demo_config: DemoConfig,
+    global_config: GlobalConfig,
+) -> DemoJobResult:
+    """Run a classified demo URL through the full inkwell pipeline.
+
+    The demo invariants are enforced here before
+    :class:`PipelineOrchestrator` is invoked so we fail closed rather
+    than ship a degraded result:
+
+    1. Reject immediately if ``demo_config.enabled`` is ``False``.
+    2. Re-pin :attr:`GeminiExtractor.MODEL` (defensive — startup should
+       have already done this).
+    3. Resolve the URL via :func:`resolve_demo_source`, which rejects
+       audio over the duration cap based on cheap metadata.
+    4. Run the orchestrator into a per-job ``tempfile.TemporaryDirectory``
+       with the demo-allowlisted templates only. The temp directory is
+       cleaned up automatically on success or failure.
+    5. Verify the post-transcription duration before returning. If the
+       real audio is longer than the cap, raise so callers can refund
+       the daily counter and report the truthy duration.
+
+    Args:
+        classified_url: Output of :func:`classify_demo_url` for the
+            user-supplied URL.
+        demo_config: Demo runtime configuration.
+        global_config: Project :class:`GlobalConfig` (API keys,
+            transcription/extraction config, etc.). The CLI's
+            ``ConfigManager`` builds this; the demo passes through
+            whatever the FastAPI app loads.
+
+    Returns:
+        :class:`DemoJobResult` carrying the JSON-serializable frontend
+        payload plus the resolved source and realized cost.
+
+    Raises:
+        DemoPipelineDisabledError: When the kill switch is set.
+        DemoUrlError: Re-raised from the resolver when a URL can't be
+            run (invalid duration, unreachable feed, etc.).
+        DemoDurationBackstopError: When real audio exceeds the cap.
+        InkwellError: Re-raised from the orchestrator on transcription
+            or extraction failures.
+    """
+    if not demo_config.enabled:
+        raise DemoPipelineDisabledError("Demo pipeline is paused (INKWELL_DEMO_ENABLED=false).")
+
+    configure_demo_runtime(demo_config)
+
+    resolved = await resolve_demo_source(classified_url, demo_config=demo_config)
+
+    with tempfile.TemporaryDirectory(prefix="inkwell-demo-") as tmpdir:
+        options = _build_pipeline_options(
+            resolved=resolved,
+            demo_config=demo_config,
+            output_dir=Path(tmpdir),
+        )
+
+        backstop = _DurationBackstop(
+            cap_seconds=demo_config.max_duration_seconds,
+            metadata_duration_seconds=resolved.duration_seconds,
+        )
+
+        orchestrator = PipelineOrchestrator(global_config)
+        result: PipelineResult = await orchestrator.process_episode(
+            options,
+            progress_callback=backstop,
+        )
+
+        payload = build_demo_payload(
+            episode_output=result.episode_output,
+            config=demo_config,
+            extraction_cost_usd=result.extraction_cost_usd,
+            total_cost_usd=result.total_cost_usd,
+        )
+
+    return DemoJobResult(
+        payload=payload,
+        resolved_source=resolved,
+        total_cost_usd=result.total_cost_usd,
+    )
+
+
+def _build_pipeline_options(
+    *,
+    resolved: ResolvedDemoSource,
+    demo_config: DemoConfig,
+    output_dir: Path,
+) -> PipelineOptions:
+    """Assemble :class:`PipelineOptions` with demo-locked invariants."""
+    return PipelineOptions(
+        url=resolved.pipeline_url,
+        templates=list(demo_config.allowed_templates),
+        output_dir=output_dir,
+        overwrite=True,
+        skip_cache=True,
+        interview=False,
+        episode_title=resolved.episode_title,
+        podcast_name=resolved.podcast_name,
+        extractor=demo_config.forced_extractor,
+    )
+
+
+class _DurationBackstop:
+    """Progress callback that aborts before extraction if audio is too long.
+
+    The resolver guards on metadata; this guards on the real audio that
+    transcription just measured. We raise inside the
+    ``transcription_complete`` step so the orchestrator stops before
+    spending any LLM extraction budget.
+    """
+
+    __slots__ = ("_cap_seconds", "_metadata_duration_seconds")
+
+    def __init__(self, *, cap_seconds: int, metadata_duration_seconds: int) -> None:
+        self._cap_seconds = cap_seconds
+        self._metadata_duration_seconds = metadata_duration_seconds
+
+    def __call__(self, step: str, data: dict) -> None:
+        if step != "transcription_complete":
+            return
+        actual_duration = data.get("duration_seconds")
+        if not isinstance(actual_duration, (int, float)):
+            return
+        if actual_duration > self._cap_seconds:
+            cap_minutes = self._cap_seconds // 60
+            raise DemoDurationBackstopError(
+                f"Audio is longer than the {cap_minutes}-minute demo cap "
+                f"(metadata claimed {self._metadata_duration_seconds}s, "
+                f"transcription reported {int(actual_duration)}s)."
+            )
+
+
+__all__ = [
+    "DemoDurationBackstopError",
+    "DemoJobResult",
+    "DemoPipelineDisabledError",
+    "configure_demo_runtime",
+    "process_demo_job",
+]

--- a/src/inkwell/demo/service.py
+++ b/src/inkwell/demo/service.py
@@ -44,9 +44,10 @@ logger = logging.getLogger(__name__)
 class DemoPipelineDisabledError(RuntimeError):
     """Raised when :data:`DemoConfig.enabled` is ``False``.
 
-    The kill switch (``INKWELL_DEMO_ENABLED=false``) lets us pause
-    processing without a redeploy. Callers should catch this and return
-    the user-facing maintenance response.
+    The kill switch (``DEMO_PIPELINE_ENABLED=false`` — canonical;
+    ``INKWELL_DEMO_ENABLED=false`` is accepted as an alias) lets us
+    pause processing without a redeploy. Callers should catch this and
+    return the user-facing maintenance response.
     """
 
 
@@ -143,7 +144,7 @@ async def process_demo_job(
             or extraction failures.
     """
     if not demo_config.enabled:
-        raise DemoPipelineDisabledError("Demo pipeline is paused (INKWELL_DEMO_ENABLED=false).")
+        raise DemoPipelineDisabledError("Demo pipeline is paused (DEMO_PIPELINE_ENABLED=false).")
 
     configure_demo_runtime(demo_config)
 

--- a/src/inkwell/pipeline/orchestrator.py
+++ b/src/inkwell/pipeline/orchestrator.py
@@ -200,6 +200,7 @@ class PipelineOrchestrator:
                 {
                     "source": transcript.source,
                     "duration_seconds": transcript_result.duration_seconds,
+                    "media_duration_seconds": transcript.duration_seconds,
                     "word_count": len(transcript.full_text.split()),
                     "from_cache": transcript_result.from_cache,
                 },

--- a/tests/unit/demo/test_classifier.py
+++ b/tests/unit/demo/test_classifier.py
@@ -315,3 +315,17 @@ class TestAssertResolvedHostIsPublic:
             with pytest.raises(DemoUrlError) as excinfo:
                 assert_resolved_host_is_public("nxdomain.example.com")
         assert excinfo.value.reason == "dns_resolution_failed:gaierror"
+
+    def test_raises_on_rfc6598_resolution(self) -> None:
+        # Codex flagged this gap on PR #73: Python doesn't set
+        # ``is_private`` or ``is_reserved`` on RFC6598 carrier-grade NAT
+        # space (100.64.0.0/10), so a hostname that resolves into that
+        # range slipped past a boolean-disjunction check. ``not is_global``
+        # catches it.
+        with patch(
+            "inkwell.demo.classifier.socket.getaddrinfo",
+            side_effect=_fake_getaddrinfo("100.64.0.42"),
+        ):
+            with pytest.raises(DemoUrlError) as excinfo:
+                assert_resolved_host_is_public("cgn.example.com")
+        assert excinfo.value.reason == "resolved_private_ip:cgn.example.com->100.64.0.42"

--- a/tests/unit/demo/test_resolver.py
+++ b/tests/unit/demo/test_resolver.py
@@ -7,6 +7,7 @@ path is covered with an explicit reason.
 
 from __future__ import annotations
 
+import socket
 from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -20,6 +21,15 @@ from inkwell.demo.config import DemoConfig
 from inkwell.demo.resolver import _fetch_feed_safely, resolve_demo_source
 from inkwell.feeds.models import Episode
 from inkwell.utils.errors import ValidationError
+
+
+def _fake_getaddrinfo(*ips: str):
+    """Return a getaddrinfo stub that resolves any host to ``ips``."""
+
+    def _resolve(host: str, *args: Any, **kwargs: Any) -> list[Any]:
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (ip, 0)) for ip in ips]
+
+    return _resolve
 
 
 def _config(**overrides: Any) -> DemoConfig:
@@ -316,9 +326,73 @@ class TestSafeFetchFeed:
             return_value=Response(200, content=rss_xml),
         )
 
-        feed = await _fetch_feed_safely("https://old.example.com/feed.rss")
+        with patch(
+            "inkwell.demo.resolver.socket.getaddrinfo",
+            side_effect=_fake_getaddrinfo("93.184.216.34"),
+        ):
+            feed = await _fetch_feed_safely("https://old.example.com/feed.rss")
         assert feed.entries
         assert feed.entries[0]["title"] == "Ep 1"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_blocks_redirect_when_hostname_resolves_to_private_ip(self) -> None:
+        # Public-looking hostname; assert_demo_safe_url passes the host
+        # literal, but DNS resolution returns RFC1918. The redirect guard
+        # must reject before issuing the next request.
+        respx.get("https://example.com/feed.rss").mock(
+            return_value=Response(
+                302,
+                headers={"location": "https://internal.example.net/feed.rss"},
+            ),
+        )
+
+        with patch(
+            "inkwell.demo.resolver.socket.getaddrinfo",
+            side_effect=_fake_getaddrinfo("10.0.0.5"),
+        ):
+            with pytest.raises(DemoUrlError) as excinfo:
+                await _fetch_feed_safely("https://example.com/feed.rss")
+        assert excinfo.value.reason.startswith("rss_redirect_to_unsafe_host:resolved_private_ip:")
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_blocks_redirect_when_hostname_resolves_to_loopback(self) -> None:
+        respx.get("https://example.com/feed.rss").mock(
+            return_value=Response(
+                302,
+                headers={"location": "https://rebind.example.net/feed.rss"},
+            ),
+        )
+
+        with patch(
+            "inkwell.demo.resolver.socket.getaddrinfo",
+            side_effect=_fake_getaddrinfo("127.0.0.1"),
+        ):
+            with pytest.raises(DemoUrlError) as excinfo:
+                await _fetch_feed_safely("https://example.com/feed.rss")
+        assert excinfo.value.reason.startswith("rss_redirect_to_unsafe_host:resolved_private_ip:")
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_blocks_redirect_when_hostname_dns_fails(self) -> None:
+        respx.get("https://example.com/feed.rss").mock(
+            return_value=Response(
+                302,
+                headers={"location": "https://nxdomain.example.net/feed.rss"},
+            ),
+        )
+
+        def _gaierror(*args: Any, **kwargs: Any) -> list[Any]:
+            raise socket.gaierror(8, "nodename nor servname provided, or not known")
+
+        with patch(
+            "inkwell.demo.resolver.socket.getaddrinfo",
+            side_effect=_gaierror,
+        ):
+            with pytest.raises(DemoUrlError) as excinfo:
+                await _fetch_feed_safely("https://example.com/feed.rss")
+        assert excinfo.value.reason.startswith("rss_redirect_to_unsafe_host:dns_resolution_failed:")
 
     @pytest.mark.asyncio
     @respx.mock
@@ -332,8 +406,12 @@ class TestSafeFetchFeed:
             ),
         )
 
-        with pytest.raises(DemoUrlError) as excinfo:
-            await _fetch_feed_safely("https://example.com/feed.rss")
+        with patch(
+            "inkwell.demo.resolver.socket.getaddrinfo",
+            side_effect=_fake_getaddrinfo("93.184.216.34"),
+        ):
+            with pytest.raises(DemoUrlError) as excinfo:
+                await _fetch_feed_safely("https://example.com/feed.rss")
         assert excinfo.value.reason == "rss_too_many_redirects"
 
     @pytest.mark.asyncio

--- a/tests/unit/demo/test_resolver.py
+++ b/tests/unit/demo/test_resolver.py
@@ -327,7 +327,7 @@ class TestSafeFetchFeed:
         )
 
         with patch(
-            "inkwell.demo.resolver.socket.getaddrinfo",
+            "inkwell.demo.classifier.socket.getaddrinfo",
             side_effect=_fake_getaddrinfo("93.184.216.34"),
         ):
             feed = await _fetch_feed_safely("https://old.example.com/feed.rss")
@@ -348,7 +348,7 @@ class TestSafeFetchFeed:
         )
 
         with patch(
-            "inkwell.demo.resolver.socket.getaddrinfo",
+            "inkwell.demo.classifier.socket.getaddrinfo",
             side_effect=_fake_getaddrinfo("10.0.0.5"),
         ):
             with pytest.raises(DemoUrlError) as excinfo:
@@ -366,8 +366,30 @@ class TestSafeFetchFeed:
         )
 
         with patch(
-            "inkwell.demo.resolver.socket.getaddrinfo",
+            "inkwell.demo.classifier.socket.getaddrinfo",
             side_effect=_fake_getaddrinfo("127.0.0.1"),
+        ):
+            with pytest.raises(DemoUrlError) as excinfo:
+                await _fetch_feed_safely("https://example.com/feed.rss")
+        assert excinfo.value.reason.startswith("rss_redirect_to_unsafe_host:resolved_private_ip:")
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_blocks_redirect_when_hostname_resolves_to_rfc6598(self) -> None:
+        # 100.64.0.0/10 is RFC6598 carrier-grade NAT space. Python flags
+        # neither ``is_private`` nor ``is_reserved`` on it, so the
+        # boolean-disjunction check codex flagged on PR #73 missed it.
+        # ``not ip.is_global`` catches it.
+        respx.get("https://example.com/feed.rss").mock(
+            return_value=Response(
+                302,
+                headers={"location": "https://cgn.example.net/feed.rss"},
+            ),
+        )
+
+        with patch(
+            "inkwell.demo.classifier.socket.getaddrinfo",
+            side_effect=_fake_getaddrinfo("100.64.0.5"),
         ):
             with pytest.raises(DemoUrlError) as excinfo:
                 await _fetch_feed_safely("https://example.com/feed.rss")
@@ -387,7 +409,7 @@ class TestSafeFetchFeed:
             raise socket.gaierror(8, "nodename nor servname provided, or not known")
 
         with patch(
-            "inkwell.demo.resolver.socket.getaddrinfo",
+            "inkwell.demo.classifier.socket.getaddrinfo",
             side_effect=_gaierror,
         ):
             with pytest.raises(DemoUrlError) as excinfo:
@@ -407,7 +429,7 @@ class TestSafeFetchFeed:
         )
 
         with patch(
-            "inkwell.demo.resolver.socket.getaddrinfo",
+            "inkwell.demo.classifier.socket.getaddrinfo",
             side_effect=_fake_getaddrinfo("93.184.216.34"),
         ):
             with pytest.raises(DemoUrlError) as excinfo:

--- a/tests/unit/demo/test_resolver.py
+++ b/tests/unit/demo/test_resolver.py
@@ -309,6 +309,38 @@ class TestRSSResolution:
         assert excinfo.value.reason.startswith("rss_no_latest_episode:")
 
     @pytest.mark.asyncio
+    async def test_maps_pydantic_validation_error_to_demo_url_error(self) -> None:
+        # Codex P2: when a feed entry has a malformed enclosure URL, the
+        # ``Episode`` Pydantic model raises ``pydantic.ValidationError``
+        # (not the inkwell error). Without this catch the demo returns a
+        # 500 instead of a clean DemoUrlError.
+        import pydantic
+        from pydantic import BaseModel, HttpUrl
+
+        class _Probe(BaseModel):
+            url: HttpUrl
+
+        try:
+            _Probe(url="not a real url")  # type: ignore[arg-type]
+        except pydantic.ValidationError as real_error:
+            pyd_error = real_error
+        else:  # pragma: no cover — Pydantic must raise here
+            raise AssertionError("expected pydantic.ValidationError to be raised")
+
+        feed = _stub_feed()
+
+        with _patch_safe_fetch(feed), patch("inkwell.demo.resolver.RSSParser") as parser_cls:
+            parser_cls.return_value.get_latest_episode = MagicMock(side_effect=pyd_error)
+
+            with pytest.raises(DemoUrlError) as excinfo:
+                await resolve_demo_source(
+                    _classified("https://example.com/feed.rss", UrlKind.PUBLIC_RSS),
+                    demo_config=_config(),
+                )
+        assert excinfo.value.reason.startswith("rss_no_latest_episode:")
+        assert "ValidationError" in excinfo.value.reason
+
+    @pytest.mark.asyncio
     async def test_rejects_unsafe_audio_enclosure_url(self) -> None:
         # Even if the feed itself is on a public host, the latest episode's
         # enclosure URL might point at private infrastructure. The resolver

--- a/tests/unit/demo/test_resolver.py
+++ b/tests/unit/demo/test_resolver.py
@@ -131,6 +131,33 @@ class TestYouTubeResolution:
         assert "duration_over_cap" in excinfo.value.reason
 
     @pytest.mark.asyncio
+    async def test_rejects_fractional_duration_over_cap(self) -> None:
+        # Codex P2: ``int(1800.9)`` truncates to 1800 and slips past a
+        # 1800s cap, deferring rejection to post-transcription backstops
+        # after pipeline spend has started. ``math.ceil`` rounds up so
+        # any fractional value strictly over the cap rejects here.
+        info = {"duration": 30 * 60 + 0.9, "title": "Just over"}
+        with patch("inkwell.demo.resolver._fetch_youtube_video_info", return_value=info):
+            with pytest.raises(DemoUrlError) as excinfo:
+                await resolve_demo_source(
+                    _classified("https://youtu.be/fractional"),
+                    demo_config=_config(),
+                )
+        assert "duration_over_cap" in excinfo.value.reason
+
+    @pytest.mark.asyncio
+    async def test_accepts_fractional_duration_at_cap(self) -> None:
+        # ``1800.0`` is exactly at the cap; ``math.ceil`` keeps it at
+        # 1800 so the resolver still accepts boundary-correct durations.
+        info = {"duration": float(30 * 60), "title": "At cap"}
+        with patch("inkwell.demo.resolver._fetch_youtube_video_info", return_value=info):
+            result = await resolve_demo_source(
+                _classified("https://youtu.be/at-cap"),
+                demo_config=_config(),
+            )
+        assert result.duration_seconds == 30 * 60
+
+    @pytest.mark.asyncio
     async def test_rejects_video_with_unknown_duration(self) -> None:
         info = {"title": "No duration", "channel": "Acme"}
         with patch("inkwell.demo.resolver._fetch_youtube_video_info", return_value=info):

--- a/tests/unit/demo/test_resolver.py
+++ b/tests/unit/demo/test_resolver.py
@@ -1,0 +1,365 @@
+"""Tests for the demo URL resolver.
+
+The resolver layer is what enforces the duration cap *before* the
+inkwell pipeline spends transcription/LLM budget, so each rejection
+path is covered with an explicit reason.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import respx
+from httpx import Response
+
+from inkwell.demo.classifier import ClassifiedUrl, DemoUrlError, UrlKind
+from inkwell.demo.config import DemoConfig
+from inkwell.demo.resolver import _fetch_feed_safely, resolve_demo_source
+from inkwell.feeds.models import Episode
+from inkwell.utils.errors import ValidationError
+
+
+def _config(**overrides: Any) -> DemoConfig:
+    base: dict[str, Any] = {"max_duration_seconds": 30 * 60}
+    base.update(overrides)
+    return DemoConfig(**base)
+
+
+def _classified(url: str, kind: UrlKind = UrlKind.YOUTUBE_VIDEO) -> ClassifiedUrl:
+    return ClassifiedUrl(kind=kind, normalized_url=url)
+
+
+def _episode(
+    *,
+    title: str = "Latest episode",
+    audio_url: str = "https://example.com/audio.mp3",
+    duration_seconds: int | None = 600,
+    podcast_name: str = "Demo Pod",
+) -> Episode:
+    return Episode(
+        title=title,
+        url=audio_url,  # type: ignore[arg-type]
+        published=datetime(2026, 5, 7, tzinfo=timezone.utc),
+        description="",
+        duration_seconds=duration_seconds,
+        podcast_name=podcast_name,
+    )
+
+
+class TestYouTubeResolution:
+    @pytest.mark.asyncio
+    async def test_returns_resolved_source_under_cap(self) -> None:
+        info = {
+            "duration": 1200,
+            "title": "Some video",
+            "channel": "Some Channel",
+        }
+        with patch(
+            "inkwell.demo.resolver._fetch_youtube_video_info", return_value=info
+        ) as mock_fetch:
+            result = await resolve_demo_source(
+                _classified("https://www.youtube.com/watch?v=abc"),
+                demo_config=_config(),
+            )
+
+        mock_fetch.assert_called_once_with("https://www.youtube.com/watch?v=abc")
+        assert result.kind is UrlKind.YOUTUBE_VIDEO
+        assert result.pipeline_url == "https://www.youtube.com/watch?v=abc"
+        assert result.duration_seconds == 1200
+        assert result.episode_title == "Some video"
+        assert result.podcast_name == "Some Channel"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_uploader_when_channel_missing(self) -> None:
+        info = {"duration": 60.0, "title": "Vid", "uploader": "Some Uploader"}
+        with patch("inkwell.demo.resolver._fetch_youtube_video_info", return_value=info):
+            result = await resolve_demo_source(
+                _classified("https://youtu.be/xyz"),
+                demo_config=_config(),
+            )
+        assert result.podcast_name == "Some Uploader"
+
+    @pytest.mark.asyncio
+    async def test_uses_default_titles_when_metadata_blank(self) -> None:
+        info = {"duration": 30, "title": "  ", "channel": ""}
+        with patch("inkwell.demo.resolver._fetch_youtube_video_info", return_value=info):
+            result = await resolve_demo_source(
+                _classified("https://youtu.be/xyz"),
+                demo_config=_config(),
+            )
+        assert result.episode_title == "YouTube video"
+        assert result.podcast_name == "YouTube"
+
+    @pytest.mark.asyncio
+    async def test_rejects_video_over_cap(self) -> None:
+        info = {"duration": 30 * 60 + 1, "title": "Long video"}
+        with patch("inkwell.demo.resolver._fetch_youtube_video_info", return_value=info):
+            with pytest.raises(DemoUrlError) as excinfo:
+                await resolve_demo_source(
+                    _classified("https://youtu.be/long"),
+                    demo_config=_config(),
+                )
+        assert "30 minutes" in excinfo.value.user_message
+        assert "duration_over_cap" in excinfo.value.reason
+
+    @pytest.mark.asyncio
+    async def test_rejects_video_with_unknown_duration(self) -> None:
+        info = {"title": "No duration", "channel": "Acme"}
+        with patch("inkwell.demo.resolver._fetch_youtube_video_info", return_value=info):
+            with pytest.raises(DemoUrlError) as excinfo:
+                await resolve_demo_source(
+                    _classified("https://youtu.be/no-dur"),
+                    demo_config=_config(),
+                )
+        assert excinfo.value.reason == "youtube_missing_duration"
+
+    @pytest.mark.asyncio
+    async def test_parses_duration_string_when_numeric_missing(self) -> None:
+        info = {"duration_string": "12:34", "title": "Tee"}
+        with patch("inkwell.demo.resolver._fetch_youtube_video_info", return_value=info):
+            result = await resolve_demo_source(
+                _classified("https://youtu.be/xyz"),
+                demo_config=_config(),
+            )
+        assert result.duration_seconds == 12 * 60 + 34
+
+    @pytest.mark.asyncio
+    async def test_rejects_zero_duration(self) -> None:
+        info = {"duration": 0, "title": "Empty"}
+        with patch("inkwell.demo.resolver._fetch_youtube_video_info", return_value=info):
+            with pytest.raises(DemoUrlError) as excinfo:
+                await resolve_demo_source(
+                    _classified("https://youtu.be/empty"),
+                    demo_config=_config(),
+                )
+        assert excinfo.value.reason == "youtube_missing_duration"
+
+
+def _stub_feed(title: str | None = "Cool Pod") -> MagicMock:
+    """Build a feedparser-shaped object the resolver can read a title from."""
+    feed = MagicMock()
+    feed.feed = MagicMock(spec=[]) if title is None else MagicMock(title=title)
+    return feed
+
+
+def _patch_safe_fetch(feed: Any) -> Any:
+    """Replace ``_fetch_feed_safely`` with one that returns ``feed`` directly."""
+    return patch("inkwell.demo.resolver._fetch_feed_safely", AsyncMock(return_value=feed))
+
+
+class TestRSSResolution:
+    @pytest.mark.asyncio
+    async def test_returns_latest_episode_under_cap(self) -> None:
+        feed = _stub_feed("Cool Pod")
+        episode = _episode(podcast_name="Cool Pod", duration_seconds=900)
+
+        with (
+            _patch_safe_fetch(feed) as safe_fetch,
+            patch("inkwell.demo.resolver.RSSParser") as parser_cls,
+        ):
+            parser_cls.return_value.get_latest_episode = MagicMock(return_value=episode)
+
+            result = await resolve_demo_source(
+                _classified("https://example.com/feed.rss", UrlKind.PUBLIC_RSS),
+                demo_config=_config(),
+            )
+
+        safe_fetch.assert_awaited_once_with("https://example.com/feed.rss")
+        parser_cls.return_value.get_latest_episode.assert_called_once_with(feed, "Cool Pod")
+        assert result.kind is UrlKind.PUBLIC_RSS
+        assert result.pipeline_url == str(episode.url)
+        assert result.podcast_name == "Cool Pod"
+        assert result.episode_title == "Latest episode"
+        assert result.duration_seconds == 900
+
+    @pytest.mark.asyncio
+    async def test_uses_fallback_podcast_name_when_feed_missing_title(self) -> None:
+        feed = _stub_feed(title=None)
+        episode = _episode(podcast_name="Demo episode")
+
+        with _patch_safe_fetch(feed), patch("inkwell.demo.resolver.RSSParser") as parser_cls:
+            parser_cls.return_value.get_latest_episode = MagicMock(return_value=episode)
+
+            result = await resolve_demo_source(
+                _classified("https://example.com/feed.rss", UrlKind.PUBLIC_RSS),
+                demo_config=_config(),
+            )
+
+        parser_cls.return_value.get_latest_episode.assert_called_once_with(feed, "Demo episode")
+        assert result.podcast_name == "Demo episode"
+
+    @pytest.mark.asyncio
+    async def test_rejects_episode_over_cap(self) -> None:
+        feed = _stub_feed()
+        long_episode = _episode(duration_seconds=30 * 60 + 1)
+
+        with _patch_safe_fetch(feed), patch("inkwell.demo.resolver.RSSParser") as parser_cls:
+            parser_cls.return_value.get_latest_episode = MagicMock(return_value=long_episode)
+
+            with pytest.raises(DemoUrlError) as excinfo:
+                await resolve_demo_source(
+                    _classified("https://example.com/feed.rss", UrlKind.PUBLIC_RSS),
+                    demo_config=_config(),
+                )
+        assert "duration_over_cap" in excinfo.value.reason
+
+    @pytest.mark.asyncio
+    async def test_rejects_episode_with_unknown_duration(self) -> None:
+        feed = _stub_feed()
+        episode = _episode(duration_seconds=None)
+
+        with _patch_safe_fetch(feed), patch("inkwell.demo.resolver.RSSParser") as parser_cls:
+            parser_cls.return_value.get_latest_episode = MagicMock(return_value=episode)
+
+            with pytest.raises(DemoUrlError) as excinfo:
+                await resolve_demo_source(
+                    _classified("https://example.com/feed.rss", UrlKind.PUBLIC_RSS),
+                    demo_config=_config(),
+                )
+        assert excinfo.value.reason == "rss_missing_duration"
+
+    @pytest.mark.asyncio
+    async def test_propagates_safe_fetch_demo_url_errors_unchanged(self) -> None:
+        # ``_fetch_feed_safely`` already produces user-safe DemoUrlError
+        # instances; the resolver must not re-wrap them.
+        original = DemoUrlError(
+            "That feed is private. The demo only supports public RSS feeds.",
+            reason="rss_authentication_required",
+        )
+        with patch(
+            "inkwell.demo.resolver._fetch_feed_safely",
+            AsyncMock(side_effect=original),
+        ):
+            with pytest.raises(DemoUrlError) as excinfo:
+                await resolve_demo_source(
+                    _classified("https://example.com/feed.rss", UrlKind.PUBLIC_RSS),
+                    demo_config=_config(),
+                )
+        assert excinfo.value is original
+
+    @pytest.mark.asyncio
+    async def test_maps_no_latest_episode_to_demo_url_error(self) -> None:
+        feed = _stub_feed()
+
+        with _patch_safe_fetch(feed), patch("inkwell.demo.resolver.RSSParser") as parser_cls:
+            parser_cls.return_value.get_latest_episode = MagicMock(
+                side_effect=ValidationError("No episodes found in feed")
+            )
+
+            with pytest.raises(DemoUrlError) as excinfo:
+                await resolve_demo_source(
+                    _classified("https://example.com/feed.rss", UrlKind.PUBLIC_RSS),
+                    demo_config=_config(),
+                )
+        assert excinfo.value.reason.startswith("rss_no_latest_episode:")
+
+    @pytest.mark.asyncio
+    async def test_rejects_unsafe_audio_enclosure_url(self) -> None:
+        # Even if the feed itself is on a public host, the latest episode's
+        # enclosure URL might point at private infrastructure. The resolver
+        # must revalidate it via assert_demo_safe_url before handing the
+        # URL to the orchestrator.
+        feed = _stub_feed()
+        episode = _episode(audio_url="http://127.0.0.1/audio.mp3", duration_seconds=600)
+
+        with _patch_safe_fetch(feed), patch("inkwell.demo.resolver.RSSParser") as parser_cls:
+            parser_cls.return_value.get_latest_episode = MagicMock(return_value=episode)
+
+            with pytest.raises(DemoUrlError) as excinfo:
+                await resolve_demo_source(
+                    _classified("https://example.com/feed.rss", UrlKind.PUBLIC_RSS),
+                    demo_config=_config(),
+                )
+        assert excinfo.value.reason.startswith("rss_unsafe_enclosure:")
+
+
+class TestSafeFetchFeed:
+    """Direct tests for ``_fetch_feed_safely`` redirect-revalidation."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_blocks_redirect_to_private_host(self) -> None:
+        # Public URL responds with 302 -> http://127.0.0.1/feed.rss.
+        # The redirect target must trip assert_demo_safe_url and fail.
+        respx.get("https://example.com/feed.rss").mock(
+            return_value=Response(302, headers={"location": "http://127.0.0.1/feed.rss"}),
+        )
+
+        with pytest.raises(DemoUrlError) as excinfo:
+            await _fetch_feed_safely("https://example.com/feed.rss")
+        assert excinfo.value.reason.startswith("rss_redirect_to_unsafe_host:")
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_follows_safe_redirect_chain(self) -> None:
+        # 302 to a different public host should be followed and parsed.
+        rss_xml = (
+            b"<?xml version='1.0'?>\n"
+            b"<rss xmlns:itunes='http://www.itunes.com/dtds/podcast-1.0.dtd' "
+            b"version='2.0'><channel>"
+            b"<title>Acme</title>"
+            b"<item><title>Ep 1</title>"
+            b"<enclosure url='https://example.com/audio.mp3' type='audio/mpeg'/>"
+            b"<itunes:duration>600</itunes:duration>"
+            b"</item></channel></rss>"
+        )
+        respx.get("https://old.example.com/feed.rss").mock(
+            return_value=Response(
+                302,
+                headers={"location": "https://feeds.example.net/acme.rss"},
+            ),
+        )
+        respx.get("https://feeds.example.net/acme.rss").mock(
+            return_value=Response(200, content=rss_xml),
+        )
+
+        feed = await _fetch_feed_safely("https://old.example.com/feed.rss")
+        assert feed.entries
+        assert feed.entries[0]["title"] == "Ep 1"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_rejects_redirect_chain_over_hop_budget(self) -> None:
+        # Public → public → public … should hit the hop budget and refuse
+        # rather than spinning forever.
+        respx.get(url__regex=r"https://[^/]*example\.com/feed\.rss").mock(
+            return_value=Response(
+                302,
+                headers={"location": "https://other.example.com/feed.rss"},
+            ),
+        )
+
+        with pytest.raises(DemoUrlError) as excinfo:
+            await _fetch_feed_safely("https://example.com/feed.rss")
+        assert excinfo.value.reason == "rss_too_many_redirects"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_maps_401_to_authentication_required(self) -> None:
+        respx.get("https://example.com/private.rss").mock(return_value=Response(401))
+        with pytest.raises(DemoUrlError) as excinfo:
+            await _fetch_feed_safely("https://example.com/private.rss")
+        assert excinfo.value.reason == "rss_authentication_required"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_maps_other_4xx_to_http_status_reason(self) -> None:
+        respx.get("https://example.com/missing.rss").mock(return_value=Response(404))
+        with pytest.raises(DemoUrlError) as excinfo:
+            await _fetch_feed_safely("https://example.com/missing.rss")
+        assert excinfo.value.reason == "rss_http_status:404"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_rejects_empty_feed(self) -> None:
+        respx.get("https://example.com/empty.rss").mock(
+            return_value=Response(
+                200, content=b"<?xml version='1.0'?><rss><channel></channel></rss>"
+            ),
+        )
+        with pytest.raises(DemoUrlError) as excinfo:
+            await _fetch_feed_safely("https://example.com/empty.rss")
+        assert excinfo.value.reason == "rss_no_entries"

--- a/tests/unit/demo/test_resolver.py
+++ b/tests/unit/demo/test_resolver.py
@@ -285,6 +285,60 @@ class TestRSSResolution:
                 )
         assert excinfo.value.reason.startswith("rss_unsafe_enclosure:")
 
+    @pytest.mark.asyncio
+    async def test_rejects_enclosure_when_hostname_resolves_to_private_ip(self) -> None:
+        # Codex P1 follow-up: the enclosure URL host literal can be
+        # public-looking (passes assert_demo_safe_url) while resolving to
+        # RFC1918 / loopback / RFC6598 space at fetch time. The resolver
+        # must apply assert_resolved_host_is_public before handoff.
+        feed = _stub_feed()
+        episode = _episode(
+            audio_url="https://audio.attacker.tld/file.mp3",
+            duration_seconds=600,
+        )
+
+        with (
+            _patch_safe_fetch(feed),
+            patch("inkwell.demo.resolver.RSSParser") as parser_cls,
+            patch(
+                "inkwell.demo.classifier.socket.getaddrinfo",
+                side_effect=_fake_getaddrinfo("10.0.0.5"),
+            ),
+        ):
+            parser_cls.return_value.get_latest_episode = MagicMock(return_value=episode)
+
+            with pytest.raises(DemoUrlError) as excinfo:
+                await resolve_demo_source(
+                    _classified("https://example.com/feed.rss", UrlKind.PUBLIC_RSS),
+                    demo_config=_config(),
+                )
+        assert excinfo.value.reason.startswith("rss_unsafe_enclosure:resolved_private_ip:")
+
+    @pytest.mark.asyncio
+    async def test_rejects_enclosure_when_hostname_resolves_to_rfc6598(self) -> None:
+        feed = _stub_feed()
+        episode = _episode(
+            audio_url="https://cgn.attacker.tld/file.mp3",
+            duration_seconds=600,
+        )
+
+        with (
+            _patch_safe_fetch(feed),
+            patch("inkwell.demo.resolver.RSSParser") as parser_cls,
+            patch(
+                "inkwell.demo.classifier.socket.getaddrinfo",
+                side_effect=_fake_getaddrinfo("100.64.0.5"),
+            ),
+        ):
+            parser_cls.return_value.get_latest_episode = MagicMock(return_value=episode)
+
+            with pytest.raises(DemoUrlError) as excinfo:
+                await resolve_demo_source(
+                    _classified("https://example.com/feed.rss", UrlKind.PUBLIC_RSS),
+                    demo_config=_config(),
+                )
+        assert excinfo.value.reason.startswith("rss_unsafe_enclosure:resolved_private_ip:")
+
 
 class TestSafeFetchFeed:
     """Direct tests for ``_fetch_feed_safely`` redirect-revalidation."""

--- a/tests/unit/demo/test_resolver.py
+++ b/tests/unit/demo/test_resolver.py
@@ -32,6 +32,21 @@ def _fake_getaddrinfo(*ips: str):
     return _resolve
 
 
+def _fake_getaddrinfo_by_host(mapping: dict[str, str], default: str = "93.184.216.34"):
+    """Return a getaddrinfo stub that maps specific hosts to specific IPs.
+
+    Hosts not in ``mapping`` resolve to ``default`` (a public IP). Useful
+    when a redirect chain needs the *initial* host to be public and a
+    later hop to be private.
+    """
+
+    def _resolve(host: str, *args: Any, **kwargs: Any) -> list[Any]:
+        ip = mapping.get(host, default)
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (ip, 0))]
+
+    return _resolve
+
+
 def _config(**overrides: Any) -> DemoConfig:
     base: dict[str, Any] = {"max_duration_seconds": 30 * 60}
     base.update(overrides)
@@ -403,7 +418,7 @@ class TestSafeFetchFeed:
 
         with patch(
             "inkwell.demo.classifier.socket.getaddrinfo",
-            side_effect=_fake_getaddrinfo("10.0.0.5"),
+            side_effect=_fake_getaddrinfo_by_host({"internal.example.net": "10.0.0.5"}),
         ):
             with pytest.raises(DemoUrlError) as excinfo:
                 await _fetch_feed_safely("https://example.com/feed.rss")
@@ -421,7 +436,7 @@ class TestSafeFetchFeed:
 
         with patch(
             "inkwell.demo.classifier.socket.getaddrinfo",
-            side_effect=_fake_getaddrinfo("127.0.0.1"),
+            side_effect=_fake_getaddrinfo_by_host({"rebind.example.net": "127.0.0.1"}),
         ):
             with pytest.raises(DemoUrlError) as excinfo:
                 await _fetch_feed_safely("https://example.com/feed.rss")
@@ -443,7 +458,7 @@ class TestSafeFetchFeed:
 
         with patch(
             "inkwell.demo.classifier.socket.getaddrinfo",
-            side_effect=_fake_getaddrinfo("100.64.0.5"),
+            side_effect=_fake_getaddrinfo_by_host({"cgn.example.net": "100.64.0.5"}),
         ):
             with pytest.raises(DemoUrlError) as excinfo:
                 await _fetch_feed_safely("https://example.com/feed.rss")
@@ -451,7 +466,24 @@ class TestSafeFetchFeed:
 
     @pytest.mark.asyncio
     @respx.mock
+    async def test_blocks_initial_url_when_dns_rebinds_to_private_ip(self) -> None:
+        # Codex P1 follow-up: classify time and worker fetch time are
+        # decoupled (m1 + m5), so a DNS-rebinding attacker can submit a
+        # name that resolves public at classify and flips to private
+        # before the worker calls _fetch_feed_safely. The first hop
+        # must rerun the host-literal + DNS checks.
+        with patch(
+            "inkwell.demo.classifier.socket.getaddrinfo",
+            side_effect=_fake_getaddrinfo("10.0.0.5"),
+        ):
+            with pytest.raises(DemoUrlError) as excinfo:
+                await _fetch_feed_safely("https://example.com/feed.rss")
+        assert excinfo.value.reason.startswith("rss_unsafe_host:resolved_private_ip:")
+
+    @pytest.mark.asyncio
+    @respx.mock
     async def test_blocks_redirect_when_hostname_dns_fails(self) -> None:
+        # Initial host resolves public; redirect target raises gaierror.
         respx.get("https://example.com/feed.rss").mock(
             return_value=Response(
                 302,
@@ -459,12 +491,14 @@ class TestSafeFetchFeed:
             ),
         )
 
-        def _gaierror(*args: Any, **kwargs: Any) -> list[Any]:
-            raise socket.gaierror(8, "nodename nor servname provided, or not known")
+        def _resolve(host: str, *args: Any, **kwargs: Any) -> list[Any]:
+            if host == "nxdomain.example.net":
+                raise socket.gaierror(8, "nodename nor servname provided, or not known")
+            return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
 
         with patch(
             "inkwell.demo.classifier.socket.getaddrinfo",
-            side_effect=_gaierror,
+            side_effect=_resolve,
         ):
             with pytest.raises(DemoUrlError) as excinfo:
                 await _fetch_feed_safely("https://example.com/feed.rss")

--- a/tests/unit/demo/test_service.py
+++ b/tests/unit/demo/test_service.py
@@ -1,0 +1,244 @@
+"""Tests for the demo service glue layer.
+
+Covers the m2 invariants: kill switch, forced extractor + model,
+allowlisted templates, temp-dir cleanup, and the post-transcription
+duration backstop.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from inkwell.config.schema import GlobalConfig
+from inkwell.demo.classifier import ClassifiedUrl, UrlKind
+from inkwell.demo.config import DemoConfig
+from inkwell.demo.resolver import ResolvedDemoSource
+from inkwell.demo.service import (
+    DemoDurationBackstopError,
+    DemoPipelineDisabledError,
+    _DurationBackstop,
+    configure_demo_runtime,
+    process_demo_job,
+)
+
+
+def _resolved(duration_seconds: int = 600) -> ResolvedDemoSource:
+    return ResolvedDemoSource(
+        kind=UrlKind.PUBLIC_RSS,
+        pipeline_url="https://cdn.example.com/audio.mp3",
+        duration_seconds=duration_seconds,
+        podcast_name="Demo Pod",
+        episode_title="Latest episode",
+    )
+
+
+def _classified(url: str = "https://example.com/feed.rss") -> ClassifiedUrl:
+    return ClassifiedUrl(kind=UrlKind.PUBLIC_RSS, normalized_url=url)
+
+
+def _demo_config(**overrides: Any) -> DemoConfig:
+    base: dict[str, Any] = {"max_duration_seconds": 30 * 60}
+    base.update(overrides)
+    # ``enabled`` uses validation_alias for env-var binding, so direct
+    # constructor kwargs don't reach it. ``model_validate`` accepts the
+    # alias and lets tests flip the kill switch.
+    return DemoConfig.model_validate(base)
+
+
+class TestDurationBackstop:
+    """The backstop must compare against media duration, not wall-time.
+
+    Codex flagged this as a P1 on PR #73: ``transcription_complete`` was
+    carrying ``TranscriptionResult.duration_seconds`` (elapsed
+    transcription wall time) under the ``duration_seconds`` key, and the
+    backstop was reading that field. Fix is to read
+    ``media_duration_seconds`` from the orchestrator payload.
+    """
+
+    def test_aborts_when_media_duration_exceeds_cap(self) -> None:
+        backstop = _DurationBackstop(cap_seconds=1800, metadata_duration_seconds=600)
+        with pytest.raises(DemoDurationBackstopError) as excinfo:
+            backstop(
+                "transcription_complete",
+                {"media_duration_seconds": 1801, "duration_seconds": 5.0},
+            )
+        assert "30-minute" in str(excinfo.value)
+        assert "1801s" in str(excinfo.value)
+
+    def test_ignores_wall_time_field(self) -> None:
+        # Old buggy behavior would read ``duration_seconds`` (wall time)
+        # and reject this. The fix means we only react to
+        # ``media_duration_seconds``, so a long transcription on a short
+        # episode passes through.
+        backstop = _DurationBackstop(cap_seconds=1800, metadata_duration_seconds=600)
+        backstop(
+            "transcription_complete",
+            {"media_duration_seconds": 600, "duration_seconds": 9999.0},
+        )
+
+    def test_noop_when_under_cap(self) -> None:
+        backstop = _DurationBackstop(cap_seconds=1800, metadata_duration_seconds=600)
+        backstop(
+            "transcription_complete",
+            {"media_duration_seconds": 600, "duration_seconds": 5.0},
+        )
+
+    def test_noop_when_media_duration_missing(self) -> None:
+        # If the orchestrator doesn't carry ``media_duration_seconds``
+        # (e.g., a transcript with no segment data), don't reject the
+        # job — fall through to the metadata cap that already passed.
+        backstop = _DurationBackstop(cap_seconds=1800, metadata_duration_seconds=600)
+        backstop("transcription_complete", {"duration_seconds": 5.0})
+
+    def test_noop_on_other_steps(self) -> None:
+        backstop = _DurationBackstop(cap_seconds=1800, metadata_duration_seconds=600)
+        backstop("transcription_start", {})
+        backstop(
+            "extraction_complete",
+            {"media_duration_seconds": 9999},
+        )
+
+
+class TestConfigureDemoRuntime:
+    def test_pins_gemini_model(self) -> None:
+        from inkwell.extraction.extractors.gemini import GeminiExtractor
+
+        original = GeminiExtractor.MODEL
+        try:
+            GeminiExtractor.MODEL = "gemini-3-pro-preview"
+            configure_demo_runtime(_demo_config())
+            assert GeminiExtractor.MODEL == "gemini-2.5-flash"
+        finally:
+            GeminiExtractor.MODEL = original
+
+    def test_idempotent_when_already_pinned(self) -> None:
+        from inkwell.extraction.extractors.gemini import GeminiExtractor
+
+        original = GeminiExtractor.MODEL
+        try:
+            GeminiExtractor.MODEL = "gemini-2.5-flash"
+            configure_demo_runtime(_demo_config())
+            assert GeminiExtractor.MODEL == "gemini-2.5-flash"
+        finally:
+            GeminiExtractor.MODEL = original
+
+
+class TestProcessDemoJob:
+    @pytest.mark.asyncio
+    async def test_kill_switch_refuses_jobs(self) -> None:
+        with pytest.raises(DemoPipelineDisabledError):
+            await process_demo_job(
+                _classified(),
+                demo_config=_demo_config(DEMO_PIPELINE_ENABLED=False),
+                global_config=GlobalConfig(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_runs_orchestrator_with_demo_invariants(self) -> None:
+        # Verifies process_demo_job constructs PipelineOptions with the
+        # forced extractor + demo template allowlist, that it pins the
+        # Gemini model before invoking the orchestrator, and that the
+        # temp directory used as output_dir is cleaned up after.
+        from inkwell.extraction.extractors.gemini import GeminiExtractor
+
+        captured: dict[str, Any] = {}
+
+        async def _fake_process_episode(
+            options: Any,
+            *,
+            progress_callback: Any | None = None,
+        ) -> Any:
+            captured["options"] = options
+            captured["output_dir"] = options.output_dir
+            captured["output_dir_exists"] = (
+                options.output_dir is not None and Path(options.output_dir).exists()
+            )
+            captured["model_at_call"] = GeminiExtractor.MODEL
+            return _build_pipeline_result()
+
+        original_model = GeminiExtractor.MODEL
+        try:
+            GeminiExtractor.MODEL = "gemini-3-pro-preview"
+            with (
+                patch(
+                    "inkwell.demo.service.resolve_demo_source",
+                    AsyncMock(return_value=_resolved(duration_seconds=900)),
+                ),
+                patch("inkwell.demo.service.PipelineOrchestrator") as orch_cls,
+                patch(
+                    "inkwell.demo.service.build_demo_payload",
+                    return_value=MagicMock(),
+                ),
+            ):
+                orch_cls.return_value.process_episode = _fake_process_episode
+                result = await process_demo_job(
+                    _classified(),
+                    demo_config=_demo_config(),
+                    global_config=GlobalConfig(),
+                )
+        finally:
+            GeminiExtractor.MODEL = original_model
+
+        opts = captured["options"]
+        assert opts.extractor == "gemini"
+        assert opts.overwrite is True
+        assert opts.skip_cache is True
+        assert opts.interview is False
+        # Forced templates: allowlist enforced even though GlobalConfig
+        # has its own defaults.
+        assert opts.templates == list(_demo_config().allowed_templates)
+        assert opts.url == "https://cdn.example.com/audio.mp3"
+        assert opts.episode_title == "Latest episode"
+        assert opts.podcast_name == "Demo Pod"
+
+        # Model is pinned by the time the orchestrator gets invoked.
+        assert captured["model_at_call"] == "gemini-2.5-flash"
+        # Temp dir existed during the call …
+        assert captured["output_dir_exists"] is True
+        # … and is cleaned up by the time process_demo_job returns.
+        assert not Path(captured["output_dir"]).exists()
+
+        assert result.resolved_source.duration_seconds == 900
+
+    @pytest.mark.asyncio
+    async def test_temp_dir_cleaned_up_on_failure(self) -> None:
+        captured: dict[str, Any] = {}
+
+        async def _failing_process_episode(
+            options: Any,
+            *,
+            progress_callback: Any | None = None,
+        ) -> Any:
+            captured["output_dir"] = options.output_dir
+            raise RuntimeError("orchestrator boom")
+
+        with (
+            patch(
+                "inkwell.demo.service.resolve_demo_source",
+                AsyncMock(return_value=_resolved()),
+            ),
+            patch("inkwell.demo.service.PipelineOrchestrator") as orch_cls,
+        ):
+            orch_cls.return_value.process_episode = _failing_process_episode
+            with pytest.raises(RuntimeError, match="orchestrator boom"):
+                await process_demo_job(
+                    _classified(),
+                    demo_config=_demo_config(),
+                    global_config=GlobalConfig(),
+                )
+
+        assert captured["output_dir"] is not None
+        assert not Path(captured["output_dir"]).exists()
+
+
+def _build_pipeline_result() -> Any:
+    """Minimal PipelineResult-shaped object for happy-path tests."""
+    result = MagicMock()
+    result.episode_output = MagicMock()
+    result.extraction_cost_usd = 0.01
+    result.total_cost_usd = 0.01
+    return result


### PR DESCRIPTION
## Summary

Second milestone of [OBRA-74](https://github.com/chekos/inkwell-cli/issues) — wires the m1 demo scaffolding into `PipelineOrchestrator` and adds the URL/duration resolver.

The OBRA-73 hard requirements that depend on the pipeline are now enforced in code:

- **`inkwell.demo.resolver`** — duration cap enforced *before* API spend.
  - YouTube: `yt-dlp` metadata only (no download). Reject if duration unknown or > `demo_config.max_duration_seconds`.
  - Public RSS: fetched via `_fetch_feed_safely`, a manual-redirect `httpx` loop that revalidates each `Location` target with `assert_demo_safe_url` from m1. `RSSParser.fetch_feed` defaults to `follow_redirects=True`, which would let a public URL 30x to localhost / RFC1918 — this closes that gap as flagged in codex's m1 P1 follow-up.
  - The latest episode's audio enclosure URL is itself revalidated via `assert_demo_safe_url` before handoff, so a public feed can't list a localhost MP3 and slip past the classifier.

- **`inkwell.demo.service`** — kill switch + forced budget extractor + temp-dir lifecycle.
  - `configure_demo_runtime` pins `GeminiExtractor.MODEL` to `demo_config.forced_extraction_model` (`gemini-2.5-flash`) — replaces the CLI's `gemini-3-pro-preview` default that blows the $50/mo cap.
  - `process_demo_job` constructs `PipelineOptions` with the forced extractor + demo template allowlist, runs the orchestrator into a per-job `tempfile.TemporaryDirectory` (auto-cleaned), and a `_DurationBackstop` progress callback raises before extraction if the real audio duration exceeds the cap (catches metadata that lies about duration).
  - `DEMO_PIPELINE_ENABLED=false` short-circuits before any work.

## Tests

- 14 resolver tests: YouTube happy path, channel/uploader fallback, duration parsing, all rejection paths, RSS happy path, fallback podcast name, oversize, missing duration, no-latest-episode mapping, **unsafe-enclosure rejection**.
- 6 `_fetch_feed_safely` tests via `respx`: redirect-to-private blocked, safe-redirect chain followed, hop budget exhausted, 401 → auth required, 4xx → `http_status` reason, empty feed → `no_entries`.
- 83 demo unit tests passing total. Full project lint / format / mypy / unit suite green.

## What's deliberately not in this PR

- `ffprobe` post-download backstop. The `_DurationBackstop` callback uses the orchestrator's `transcription_complete` step, which already provides `duration_seconds` from the transcription manager — sufficient for v1. A separate `ffprobe` check duplicates that signal; we'll only add it if a real episode slips past the metadata cap.
- m3 (FastAPI routes), m4 (Firestore), m5 (deploy), m6 (smoke test) — separate child issues.

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy src/`
- [x] `uv run pytest tests/unit/ -q` (full unit suite, no regressions)
- [x] `uv run pytest tests/unit/demo/ -q` (83 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)