### PR TITLE
fix(demo): m1 hardening follow-ups — DNS classifier check + config caps (OBRA-81)

### DIFF
--- a/src/inkwell/demo/classifier.py
+++ b/src/inkwell/demo/classifier.py
@@ -144,7 +144,7 @@ def assert_resolved_host_is_public(host: str) -> None:
 
     try:
         infos = socket.getaddrinfo(host, None, 0, socket.SOCK_STREAM)
-    except socket.gaierror as exc:
+    except (socket.gaierror, UnicodeError) as exc:
         raise DemoUrlError(
             "We couldn't resolve that host.",
             reason=f"dns_resolution_failed:{type(exc).__name__}",

--- a/src/inkwell/demo/classifier.py
+++ b/src/inkwell/demo/classifier.py
@@ -12,10 +12,14 @@ encodings that libc resolvers normalize back to those ranges (decimal
 ``2130706433``, hex ``0x7f000001``, octal ``0177.0.0.1``, short-form
 ``127.1``) — is rejected before anything reaches the inkwell pipeline.
 
-This is intentionally a pure function: no network calls. Network
-verification (HEAD on the RSS, ``yt-dlp`` metadata for YouTube duration)
-happens later in the resolver layer where it can be cached and rate
-limited.
+URL-shape and host-literal validation is pure; the only network call
+the classifier makes is a ``socket.getaddrinfo`` lookup against the
+parsed host so a public-looking name whose A/AAAA records resolve to
+loopback / RFC1918 / link-local space (DNS rebinding,
+attacker-controlled DNS, internal split-horizon resolvers) is rejected
+at submission time. Heavier verification (HEAD on the RSS, ``yt-dlp``
+metadata for YouTube duration) still happens later in the resolver
+layer where it can be cached and rate limited.
 
 **Redirect note for the resolver/fetcher (m2):** ``classify_demo_url``
 only validates the URL the user pasted. Any HTTP fetch in the demo path
@@ -101,11 +105,63 @@ def classify_demo_url(raw_url: str) -> ClassifiedUrl:
         raise DemoUrlError("URL is missing a host.", reason="missing_host")
 
     _reject_private_or_local_host(host)
+    assert_resolved_host_is_public(host)
 
     if host in YOUTUBE_HOSTS:
         return _classify_youtube(parsed, url)
 
     return ClassifiedUrl(kind=UrlKind.PUBLIC_RSS, normalized_url=url)
+
+
+def assert_resolved_host_is_public(host: str) -> None:
+    """Resolve ``host`` and reject if any address is private or reserved.
+
+    :func:`_reject_private_or_local_host` only inspects the host literal
+    in the URL string. This adds the next layer: a public-looking
+    hostname can still resolve to loopback / RFC1918 / link-local space
+    via DNS rebinding, attacker-controlled DNS, or an internal
+    split-horizon resolver. Both checks together close the SSRF surface
+    for the URL the user pasted.
+
+    No-op for IP literals — those are already covered by
+    :func:`_reject_private_or_local_host`, and ``getaddrinfo`` on a
+    literal would just echo it back.
+
+    Args:
+        host: Lowercased hostname extracted from the URL.
+
+    Raises:
+        DemoUrlError: When the host can't be resolved or any resolved
+            address falls in a disallowed range. ``reason`` is
+            ``dns_resolution_failed:<errtype>`` or
+            ``resolved_private_ip:<host>-><ip>`` for logging.
+    """
+    try:
+        ipaddress.ip_address(host)
+        return
+    except ValueError:
+        pass
+
+    try:
+        infos = socket.getaddrinfo(host, None, 0, socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise DemoUrlError(
+            "We couldn't resolve that host.",
+            reason=f"dns_resolution_failed:{type(exc).__name__}",
+        ) from exc
+
+    for info in infos:
+        sockaddr = info[4]
+        ip_str = sockaddr[0]
+        try:
+            ip = ipaddress.ip_address(ip_str)
+        except ValueError:
+            continue
+        if _ip_is_disallowed(ip):
+            raise DemoUrlError(
+                "URL resolves to a private address.",
+                reason=f"resolved_private_ip:{host}->{ip}",
+            )
 
 
 def assert_demo_safe_url(url: str) -> None:
@@ -116,6 +172,12 @@ def assert_demo_safe_url(url: str) -> None:
     :func:`classify_demo_url`. The recommended pattern with ``httpx`` is
     ``follow_redirects=False`` plus a manual loop that calls this on
     each ``Location`` header.
+
+    Note: this is a *string-only* check. The async redirect path in
+    :mod:`inkwell.demo.resolver` calls
+    :func:`_assert_resolved_host_is_public` alongside it (via
+    ``asyncio.to_thread``) to add the DNS layer without blocking the
+    event loop.
 
     Args:
         url: Absolute URL string to validate.

--- a/src/inkwell/demo/config.py
+++ b/src/inkwell/demo/config.py
@@ -85,7 +85,11 @@ class DemoConfig(BaseSettings):
     max_duration_seconds: int = Field(
         default=DEMO_MAX_DURATION_SECONDS_DEFAULT,
         ge=60,
-        le=60 * 60,
+        # Hard upper bound matches the documented 30-minute demo cap and
+        # the Cloud Tasks HTTP dispatch ceiling. Operators may tighten
+        # this via INKWELL_DEMO_MAX_DURATION_SECONDS but cannot widen
+        # past 1800s without a code change.
+        le=DEMO_MAX_DURATION_SECONDS_DEFAULT,
         description="Hard cap on episode/video duration accepted by the demo.",
     )
 
@@ -135,6 +139,18 @@ class DemoConfig(BaseSettings):
     def _validate_allowed_templates(cls, value: tuple[str, ...]) -> tuple[str, ...]:
         if not value:
             raise ValueError("allowed_templates must be non-empty")
+        # The canonical allowlist is code-defined and not user-toggleable.
+        # An env override may narrow it (subset) but never widen it: a
+        # superset value would let an operator silently re-enable
+        # high-cost or internal templates and break the demo budget
+        # envelope. Reject any template not in DEMO_ALLOWED_TEMPLATES.
+        invalid = sorted({t for t in value if t not in DEMO_ALLOWED_TEMPLATES})
+        if invalid:
+            raise ValueError(
+                "allowed_templates may only narrow the canonical demo "
+                f"allowlist {DEMO_ALLOWED_TEMPLATES!r}; got disallowed "
+                f"values {invalid!r}."
+            )
         return tuple(value)
 
 

--- a/tests/unit/demo/conftest.py
+++ b/tests/unit/demo/conftest.py
@@ -1,0 +1,31 @@
+"""Shared fixtures for demo tests."""
+
+from __future__ import annotations
+
+import socket
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def stub_classifier_dns_to_public_ip() -> Iterator[None]:
+    """Auto-stub the classifier's DNS lookup to a known-public IP.
+
+    The classifier (OBRA-81) calls ``socket.getaddrinfo`` on the
+    user-supplied host so hostnames that resolve to RFC1918 / loopback /
+    link-local space (DNS rebinding, attacker-controlled DNS, internal
+    split-horizon resolvers) are rejected at submission time. Most tests
+    use placeholder domains like ``example.com``; we don't want CI runs
+    to depend on real DNS, so this fixture returns ``93.184.216.34`` (a
+    canonical public address) by default. Tests that exercise the
+    rejection path patch the same target with their own ``side_effect``.
+    """
+
+    def _resolve(_host: str, *_args: Any, **_kwargs: Any) -> list[Any]:
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+
+    with patch("inkwell.demo.classifier.socket.getaddrinfo", side_effect=_resolve):
+        yield

--- a/tests/unit/demo/test_classifier.py
+++ b/tests/unit/demo/test_classifier.py
@@ -1,13 +1,27 @@
 """Tests for the demo URL classifier."""
 
+import socket
+from typing import Any
+from unittest.mock import patch
+
 import pytest
 
 from inkwell.demo.classifier import (
     DemoUrlError,
     UrlKind,
     assert_demo_safe_url,
+    assert_resolved_host_is_public,
     classify_demo_url,
 )
+
+
+def _fake_getaddrinfo(*ips: str):
+    """Return a getaddrinfo stub that resolves any host to ``ips``."""
+
+    def _resolve(_host: str, *_args: Any, **_kwargs: Any) -> list[Any]:
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (ip, 0)) for ip in ips]
+
+    return _resolve
 
 
 class TestYouTubeAcceptance:
@@ -188,3 +202,104 @@ class TestAssertDemoSafeUrl:
     def test_rejects_empty_input(self) -> None:
         with pytest.raises(DemoUrlError):
             assert_demo_safe_url("")
+
+
+class TestClassifierDnsResolution:
+    """OBRA-81 P1: classifier must reject hostnames that *resolve* to private IPs.
+
+    ``_reject_private_or_local_host`` only checks the host literal in
+    the URL string. A public-looking hostname whose A/AAAA records
+    point at RFC1918 / loopback / link-local space (DNS rebinding,
+    attacker-controlled DNS, internal split-horizon resolvers) used to
+    pass and only get caught later on redirect hops in the resolver.
+    The classifier now closes that gap at submission time.
+    """
+
+    @pytest.mark.parametrize(
+        ("resolved_ip", "expected_reason_prefix"),
+        [
+            ("10.0.0.5", "resolved_private_ip:"),
+            ("192.168.1.10", "resolved_private_ip:"),
+            ("172.16.0.1", "resolved_private_ip:"),
+            ("127.0.0.1", "resolved_private_ip:"),
+            ("169.254.169.254", "resolved_private_ip:"),  # link-local / IMDS
+            ("::1", "resolved_private_ip:"),
+        ],
+    )
+    def test_rejects_public_hostname_resolving_to_private_ip(
+        self, resolved_ip: str, expected_reason_prefix: str
+    ) -> None:
+        with patch(
+            "inkwell.demo.classifier.socket.getaddrinfo",
+            side_effect=_fake_getaddrinfo(resolved_ip),
+        ):
+            with pytest.raises(DemoUrlError) as excinfo:
+                classify_demo_url("https://internal.example.com/feed.rss")
+        assert excinfo.value.reason.startswith(expected_reason_prefix)
+        assert resolved_ip in excinfo.value.reason
+
+    def test_rejects_when_dns_resolution_fails(self) -> None:
+        def _gaierror(*_args: Any, **_kwargs: Any) -> list[Any]:
+            raise socket.gaierror(8, "nodename nor servname provided, or not known")
+
+        with patch(
+            "inkwell.demo.classifier.socket.getaddrinfo",
+            side_effect=_gaierror,
+        ):
+            with pytest.raises(DemoUrlError) as excinfo:
+                classify_demo_url("https://nxdomain.example.com/feed.rss")
+        assert excinfo.value.reason.startswith("dns_resolution_failed:")
+
+    def test_accepts_public_hostname_resolving_to_public_ip(self) -> None:
+        with patch(
+            "inkwell.demo.classifier.socket.getaddrinfo",
+            side_effect=_fake_getaddrinfo("93.184.216.34"),
+        ):
+            result = classify_demo_url("https://example.com/feed.rss")
+        assert result.kind is UrlKind.PUBLIC_RSS
+
+    def test_rejects_when_any_resolved_address_is_private(self) -> None:
+        # Mixed result (one public, one private) must still be refused —
+        # the worker would happily connect to the private one otherwise.
+        with patch(
+            "inkwell.demo.classifier.socket.getaddrinfo",
+            side_effect=_fake_getaddrinfo("93.184.216.34", "10.0.0.5"),
+        ):
+            with pytest.raises(DemoUrlError) as excinfo:
+                classify_demo_url("https://mixed.example.com/feed.rss")
+        assert excinfo.value.reason.startswith("resolved_private_ip:")
+
+
+class TestAssertResolvedHostIsPublic:
+    """Direct coverage of the standalone DNS-resolution helper."""
+
+    def test_skips_dns_for_ip_literal(self) -> None:
+        # IP literals are already covered by _reject_private_or_local_host;
+        # the DNS helper must short-circuit to avoid a redundant lookup.
+        with patch(
+            "inkwell.demo.classifier.socket.getaddrinfo",
+            side_effect=AssertionError("getaddrinfo should not be called for IP literals"),
+        ):
+            assert_resolved_host_is_public("93.184.216.34")
+            assert_resolved_host_is_public("::1")
+
+    def test_raises_on_private_resolution(self) -> None:
+        with patch(
+            "inkwell.demo.classifier.socket.getaddrinfo",
+            side_effect=_fake_getaddrinfo("10.0.0.5"),
+        ):
+            with pytest.raises(DemoUrlError) as excinfo:
+                assert_resolved_host_is_public("internal.example.com")
+        assert excinfo.value.reason == "resolved_private_ip:internal.example.com->10.0.0.5"
+
+    def test_raises_on_dns_failure(self) -> None:
+        def _gaierror(*_args: Any, **_kwargs: Any) -> list[Any]:
+            raise socket.gaierror(8, "nodename nor servname provided, or not known")
+
+        with patch(
+            "inkwell.demo.classifier.socket.getaddrinfo",
+            side_effect=_gaierror,
+        ):
+            with pytest.raises(DemoUrlError) as excinfo:
+                assert_resolved_host_is_public("nxdomain.example.com")
+        assert excinfo.value.reason == "dns_resolution_failed:gaierror"

--- a/tests/unit/demo/test_classifier.py
+++ b/tests/unit/demo/test_classifier.py
@@ -250,6 +250,18 @@ class TestClassifierDnsResolution:
                 classify_demo_url("https://nxdomain.example.com/feed.rss")
         assert excinfo.value.reason.startswith("dns_resolution_failed:")
 
+    def test_rejects_when_dns_resolution_raises_unicode_error(self) -> None:
+        def _unicode_error(*_args: Any, **_kwargs: Any) -> list[Any]:
+            raise UnicodeError("label empty or too long")
+
+        with patch(
+            "inkwell.demo.classifier.socket.getaddrinfo",
+            side_effect=_unicode_error,
+        ):
+            with pytest.raises(DemoUrlError) as excinfo:
+                classify_demo_url("https://malformed.example.com/feed.rss")
+        assert excinfo.value.reason == "dns_resolution_failed:UnicodeError"
+
     def test_accepts_public_hostname_resolving_to_public_ip(self) -> None:
         with patch(
             "inkwell.demo.classifier.socket.getaddrinfo",

--- a/tests/unit/demo/test_config.py
+++ b/tests/unit/demo/test_config.py
@@ -61,10 +61,58 @@ def test_allowed_templates_cannot_be_empty() -> None:
         DemoConfig(allowed_templates=())
 
 
-def test_max_duration_is_clamped_to_one_hour() -> None:
-    """Cloud Tasks max HTTP timeout is 30 minutes; enforce a guardrail upstream."""
+def test_max_duration_is_clamped_to_thirty_minutes() -> None:
+    """OBRA-81 P2: env override may not exceed the documented 30-minute cap.
+
+    The 30-minute number matches both the demo budget envelope and the
+    Cloud Tasks HTTP dispatch ceiling. An operator raising
+    INKWELL_DEMO_MAX_DURATION_SECONDS past 1800 used to validate (the
+    field allowed up to 3600); now the validator refuses any value over
+    1800 so widening the cap requires a code change.
+    """
+    # Exactly at the cap is accepted.
+    DemoConfig(max_duration_seconds=30 * 60)
+
+    # Anything over the cap is refused, including values that the prior
+    # 1-hour ceiling silently allowed.
+    for over_cap in (30 * 60 + 1, 45 * 60, 60 * 60):
+        with pytest.raises(PydanticValidationError):
+            DemoConfig(max_duration_seconds=over_cap)
+
+
+def test_max_duration_env_override_cannot_widen_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OBRA-81 P2: the env-var path enforces the same 30-minute ceiling."""
+    monkeypatch.setenv("INKWELL_DEMO_MAX_DURATION_SECONDS", str(45 * 60))
     with pytest.raises(PydanticValidationError):
-        DemoConfig(max_duration_seconds=60 * 60 + 1)
+        DemoConfig()
+
+
+def test_allowed_templates_env_override_cannot_widen_allowlist() -> None:
+    """OBRA-81 P2: env override may narrow the canonical allowlist but never widen it.
+
+    The canonical allowlist is code-defined: an operator must not be
+    able to silently re-enable internal or high-cost templates that
+    blow the demo budget envelope. Validation rejects supersets and
+    names the offending templates.
+    """
+    with pytest.raises(PydanticValidationError) as excinfo:
+        DemoConfig(allowed_templates=("summary", "evil"))
+    assert "evil" in str(excinfo.value)
+
+
+def test_allowed_templates_can_be_narrowed() -> None:
+    """Operators can still subset the allowlist (e.g., disable quotes)."""
+    config = DemoConfig(allowed_templates=("summary",))
+    assert config.allowed_templates == ("summary",)
+
+
+def test_allowed_templates_env_override_rejects_superset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The env-var path enforces the same subset constraint."""
+    # Pydantic-settings parses comma-separated lists for tuple fields.
+    monkeypatch.setenv("INKWELL_DEMO_ALLOWED_TEMPLATES", '["summary","evil"]')
+    with pytest.raises(PydanticValidationError) as excinfo:
+        DemoConfig()
+    assert "evil" in str(excinfo.value)
 
 
 def test_kill_switch_via_canonical_env(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Three findings codex flagged on the m1 PR (#72) that the m2 PR (#73) does not address. Filed as OBRA-81 so they don't slip behind m3.

- **P1 — `assert_demo_safe_url` is host-literal only, not DNS-aware.** `classify_demo_url` now invokes a new sync helper `assert_resolved_host_is_public(host)` that calls `socket.getaddrinfo` and rejects any address in the existing disallowed ranges (RFC1918 / loopback / link-local / reserved / multicast / unspecified). Reasons are `resolved_private_ip:<host>-><ip>` or `dns_resolution_failed:<errtype>`. IP literals short-circuit so we don't double-check what `_reject_private_or_local_host` already covered. The redirect path in `resolver.py` keeps its own async `_assert_resolved_host_is_public` (via `asyncio.to_thread`) — both surfaces are now DNS-aware.
- **P2 — `INKWELL_DEMO_MAX_DURATION_SECONDS` could exceed the documented cap.** Field validator narrowed from `le=60*60` to `le=DEMO_MAX_DURATION_SECONDS_DEFAULT` (1800s). Widening past 30 min now requires a code change rather than an env override.
- **P2 — `INKWELL_DEMO_ALLOWED_TEMPLATES` could expand the canonical allowlist.** `_validate_allowed_templates` now rejects any value not in `DEMO_ALLOWED_TEMPLATES` and names the offending entries. Operators may still narrow the allowlist (subset) but cannot widen it to re-enable internal or high-cost templates that blow the demo budget envelope.

Branched off `main` rather than the m2 branch so the changes can land independently of #73.

## Test plan

- [x] `uv run pytest tests/unit/demo/` → 79 passed
- [x] `uv run mypy src/inkwell/demo/` → no issues
- [x] `uv run ruff check .` and `uv run ruff format --check .` → clean
- [x] New `TestClassifierDnsResolution` covers RFC1918, loopback, link-local (incl. 169.254.169.254 IMDS), IPv6 `::1`, DNS failure, public-IP acceptance, and any-private mixed-result rejection.
- [x] New `TestAssertResolvedHostIsPublic` exercises the helper directly, including IP-literal short-circuit.
- [x] Config tests pin the tighter max-duration cap (exact-cap accept, over-cap reject including former 1-hour values), env-var override enforcement, and `allowed_templates` superset rejection (both direct and env).
- [x] Autouse fixture in `tests/unit/demo/conftest.py` stubs classifier DNS to a public IP so existing classifier tests stay hermetic.

Linked issue: OBRA-81 (m1 hardening follow-up to OBRA-74 / PR #72).

🤖 Generated with [Claude Code](https://claude.com/claude-code)