### PR TITLE
fix(demo): handle malformed redirect Location as DemoUrlError (OBRA-88)

### DIFF
--- a/src/inkwell/demo/resolver.py
+++ b/src/inkwell/demo/resolver.py
@@ -264,7 +264,16 @@ async def _fetch_feed_safely(url: str) -> feedparser.FeedParserDict:
                     )
                 # Resolve the next target relative to the current URL and
                 # let the next iteration's top-of-loop guard validate it.
-                current = str(httpx.URL(current).join(location))
+                # ``httpx.URL(...).join`` raises ``httpx.InvalidURL`` on a
+                # malformed ``Location`` (e.g. NUL bytes, bad ports). Map
+                # that to a user-safe DemoUrlError instead of a 500.
+                try:
+                    current = str(httpx.URL(current).join(location))
+                except httpx.InvalidURL as exc:
+                    raise DemoUrlError(
+                        "That feed's redirect target is malformed.",
+                        reason=f"rss_redirect_malformed_location:{type(exc).__name__}",
+                    ) from exc
                 continue
 
             if response.status_code >= 400:

--- a/tests/unit/demo/test_resolver.py
+++ b/tests/unit/demo/test_resolver.py
@@ -564,6 +564,40 @@ class TestSafeFetchFeed:
         assert excinfo.value.reason.startswith("rss_redirect_to_unsafe_host:dns_resolution_failed:")
 
     @pytest.mark.asyncio
+    async def test_maps_malformed_redirect_location_to_demo_url_error(self) -> None:
+        # Codex P2 from PR #73 post-merge review: an RSS endpoint that
+        # 30x's with a malformed ``Location`` value would crash
+        # ``httpx.URL(current).join(location)`` with ``httpx.InvalidURL``
+        # and surface as a 500. Map it to a user-safe DemoUrlError with a
+        # structured reason so the worker doesn't leak internals.
+        #
+        # httpx.AsyncClient itself pre-validates the ``Location`` header
+        # in ``_send_handling_redirects`` and would raise
+        # ``RemoteProtocolError`` before our loop sees the response, so we
+        # patch ``_safe_get`` to hand the resolver a redirect Response
+        # with a malformed Location verbatim — that's the state our join()
+        # guard is defending against (e.g. if httpx loosens validation
+        # upstream, or a future change moves us off ``AsyncClient``).
+        from httpx import Response as _HttpxResponse
+
+        bad_response = _HttpxResponse(302, headers={"location": "invalid://[::1"})
+
+        async def _fake_safe_get(client: Any, url: str) -> _HttpxResponse:
+            return bad_response
+
+        with (
+            patch(
+                "inkwell.demo.classifier.socket.getaddrinfo",
+                side_effect=_fake_getaddrinfo("93.184.216.34"),
+            ),
+            patch("inkwell.demo.resolver._safe_get", side_effect=_fake_safe_get),
+        ):
+            with pytest.raises(DemoUrlError) as excinfo:
+                await _fetch_feed_safely("https://example.com/feed.rss")
+        assert excinfo.value.reason.startswith("rss_redirect_malformed_location:")
+        assert "InvalidURL" in excinfo.value.reason
+
+    @pytest.mark.asyncio
     @respx.mock
     async def test_rejects_redirect_chain_over_hop_budget(self) -> None:
         # Public → public → public … should hit the hop budget and refuse


### PR DESCRIPTION
## Summary

- Wraps `httpx.URL(current).join(location)` in `_fetch_feed_safely` with a `httpx.InvalidURL` guard so a malformed redirect `Location` surfaces as a user-safe `DemoUrlError` (`reason=rss_redirect_malformed_location:<exc-type>`) instead of a 500.
- Adds `tests/unit/demo/test_resolver.py::TestSafeFetchFeed::test_maps_malformed_redirect_location_to_demo_url_error` covering the join() failure path.

Closes OBRA-88. Follow-up to PR #73 (OBRA-76 m2) — codex P2 from the post-merge review on `9ac3ac1`.

### Why patch `_safe_get` in the test instead of using `respx`

`httpx.AsyncClient` itself pre-validates the `Location` header in `_send_handling_redirects` and raises `RemoteProtocolError` before our loop ever sees the response. So a respx-delivered bad Location is shaped into the existing `rss_fetch_network_error:RemoteProtocolError` path. The new defensive guard exists for the residual cases where the join can still raise (e.g. if httpx loosens validation upstream, or we move off `AsyncClient`); the test patches `_safe_get` to hand the resolver a `Response` with a malformed `Location` verbatim so the join() guard is actually exercised.

## Test plan

- [x] `uv run pytest tests/unit/demo/`
- [x] `uv run mypy src/inkwell/demo/`

@codex please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)