### PR TITLE
feat(demo): m4 guards — email capture, rate limits, spend cap (OBRA-78)

### DIFF
--- a/src/inkwell/demo/app.py
+++ b/src/inkwell/demo/app.py
@@ -140,22 +140,33 @@ def _normalize_email(raw: str) -> str:
     return address.lower()
 
 
-def _client_ip(request: Request) -> str:
-    """Best-effort client IP extraction.
+def _client_ip(request: Request, *, trusted_proxy_count: int) -> str:
+    """Extract the per-rate-limit client IP from a request.
 
-    Cloud Run terminates TLS at the load balancer and forwards the
-    real client IP via ``X-Forwarded-For``. We pick the leftmost
-    address in the header (the original client) and fall back to the
-    socket peer if the header is absent — useful for local dev.
+    Cloud Run terminates TLS at a Google Cloud Load Balancer that
+    *appends* one entry to the end of ``X-Forwarded-For`` containing
+    the real client IP. The LEFTmost values are attacker-controlled —
+    clients can put anything they want there. The codex P1 on PR #77
+    flagged the original leftmost-takes-all implementation as a
+    rate-limit bypass.
 
-    The value is hashed with the demo salt before storage; we never
-    persist the raw IP.
+    Algorithm: with ``N = trusted_proxy_count`` we expect the rightmost
+    ``N`` entries to come from our own LB chain. The ``N``-from-the-end
+    entry (``parts[-N]``) is the real client IP — it's the leftmost
+    entry our chain appended, attacker cannot influence its position.
+
+    Falls back to the socket peer when ``X-Forwarded-For`` is absent,
+    when there are fewer entries than ``trusted_proxy_count``, or when
+    ``trusted_proxy_count == 0`` (direct-internet deploys without an
+    LB — no LB means no trusted XFF). The value is hashed with the
+    demo salt before storage; we never persist the raw IP.
     """
-    forwarded = request.headers.get("x-forwarded-for")
-    if forwarded:
-        first = forwarded.split(",", 1)[0].strip()
-        if first:
-            return first
+    if trusted_proxy_count > 0:
+        forwarded = request.headers.get("x-forwarded-for")
+        if forwarded:
+            parts = [p.strip() for p in forwarded.split(",") if p.strip()]
+            if len(parts) >= trusted_proxy_count:
+                return parts[-trusted_proxy_count]
     if request.client is not None and request.client.host:
         return request.client.host
     return "unknown"
@@ -435,7 +446,10 @@ def create_app(
 
         # Now the request looks credible. Burn one of the IP's daily
         # attempts (failures count too — that's the OBRA-73 contract).
-        ip_hash = hash_with_salt(_client_ip(request), salt=config.hash_salt)
+        ip_hash = hash_with_salt(
+            _client_ip(request, trusted_proxy_count=config.trusted_proxy_count),
+            salt=config.hash_salt,
+        )
         ip_decision = await limiter.record_attempt_and_check(
             ip_hash=ip_hash,
             cap=config.daily_attempts_per_ip,

--- a/src/inkwell/demo/app.py
+++ b/src/inkwell/demo/app.py
@@ -43,12 +43,16 @@ from inkwell.config.schema import GlobalConfig
 from inkwell.demo.classifier import DemoUrlError, classify_demo_url
 from inkwell.demo.config import DemoConfig, get_demo_config
 from inkwell.demo.dispatcher import Dispatcher, InProcessDispatcher
+from inkwell.demo.email_store import EmailStore, InMemoryEmailStore
+from inkwell.demo.hashing import hash_with_salt
 from inkwell.demo.jobs import DemoJob, InMemoryJobStore, JobStatus, JobStore
+from inkwell.demo.rate_limits import InMemoryRateLimiter, RateLimiter
 from inkwell.demo.service import (
     DemoDurationBackstopError,
     DemoPipelineDisabledError,
     process_demo_job,
 )
+from inkwell.demo.spend_tracker import InMemorySpendTracker, SpendTracker
 from inkwell.utils.errors import InkwellError
 
 logger = logging.getLogger(__name__)
@@ -136,6 +140,35 @@ def _normalize_email(raw: str) -> str:
     return address.lower()
 
 
+def _client_ip(request: Request) -> str:
+    """Best-effort client IP extraction.
+
+    Cloud Run terminates TLS at the load balancer and forwards the
+    real client IP via ``X-Forwarded-For``. We pick the leftmost
+    address in the header (the original client) and fall back to the
+    socket peer if the header is absent — useful for local dev.
+
+    The value is hashed with the demo salt before storage; we never
+    persist the raw IP.
+    """
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        first = forwarded.split(",", 1)[0].strip()
+        if first:
+            return first
+    if request.client is not None and request.client.host:
+        return request.client.host
+    return "unknown"
+
+
+def _refuse(status_code: int, reason: str, message: str) -> JSONResponse:
+    """Compact rate-limit refusal payload — same shape on every counter."""
+    return JSONResponse(
+        status_code=status_code,
+        content={"detail": {"reason": reason, "message": message}},
+    )
+
+
 # ---------------------------------------------------------------------------
 # worker
 # ---------------------------------------------------------------------------
@@ -147,6 +180,8 @@ WorkerCallable = Callable[[str], Awaitable[None]]
 def _build_worker(
     *,
     job_store: JobStore,
+    rate_limiter: RateLimiter,
+    spend_tracker: SpendTracker,
     demo_config: DemoConfig,
     global_config: GlobalConfig,
 ) -> WorkerCallable:
@@ -155,6 +190,11 @@ def _build_worker(
     The dispatcher invokes the returned callable per job id. We keep
     the binding lazy so tests can construct an ``InMemoryJobStore`` and
     a ``DemoConfig`` for assertion without touching real API keys.
+
+    On a successful run the worker also records the spend (monthly cap)
+    and the per-email + global success counters (daily caps) — both
+    side-effects belong on the worker so a Cloud Tasks retry that
+    races a fresh attempt doesn't double-count.
     """
 
     async def _worker(job_id: str) -> None:
@@ -225,6 +265,10 @@ def _build_worker(
             payload=result.payload,
             cost_usd=result.total_cost_usd,
         )
+        # Side-effects only after mark_complete so a crash mid-write
+        # never reports a job as complete with stale counters.
+        await spend_tracker.record_spend(cost_usd=result.total_cost_usd)
+        await rate_limiter.record_success(email_hash=job.email_hash)
         logger.info("demo job %s complete cost=$%.4f", job_id, result.total_cost_usd)
 
     return _worker
@@ -240,6 +284,9 @@ def create_app(
     demo_config: DemoConfig | None = None,
     global_config: GlobalConfig | None = None,
     job_store: JobStore | None = None,
+    email_store: EmailStore | None = None,
+    rate_limiter: RateLimiter | None = None,
+    spend_tracker: SpendTracker | None = None,
     dispatcher: Dispatcher | None = None,
     worker_secret: str | None = None,
 ) -> FastAPI:
@@ -255,7 +302,13 @@ def create_app(
             (API keys, defaults). Loaded via :class:`ConfigManager` if
             omitted.
         job_store: :class:`JobStore` implementation. Defaults to
-            in-memory; m4 swaps in Firestore.
+            in-memory; the Firestore swap lands in a follow-up issue.
+        email_store: :class:`EmailStore` implementation. Defaults to
+            in-memory; same Firestore-swap path.
+        rate_limiter: :class:`RateLimiter` implementation. Defaults to
+            in-memory daily counters.
+        spend_tracker: :class:`SpendTracker` implementation. Defaults
+            to in-memory monthly accumulator.
         dispatcher: :class:`Dispatcher` implementation. Defaults to
             in-process asyncio tasks; m5 swaps in Cloud Tasks.
         worker_secret: Shared secret expected on the
@@ -266,9 +319,14 @@ def create_app(
     config = demo_config or get_demo_config()
     global_cfg = global_config or ConfigManager().load_config()
     store: JobStore = job_store or InMemoryJobStore()
+    emails: EmailStore = email_store or InMemoryEmailStore()
+    limiter: RateLimiter = rate_limiter or InMemoryRateLimiter()
+    spend: SpendTracker = spend_tracker or InMemorySpendTracker()
 
     worker = _build_worker(
         job_store=store,
+        rate_limiter=limiter,
+        spend_tracker=spend,
         demo_config=config,
         global_config=global_cfg,
     )
@@ -337,12 +395,18 @@ def create_app(
 
     @app.post("/jobs", status_code=status.HTTP_202_ACCEPTED)
     async def create_job(
+        request: Request,
         store: Annotated[JobStore, Depends(get_store)],
         dispatcher: Annotated[Dispatcher, Depends(get_dispatch)],
         config: Annotated[DemoConfig, Depends(get_config)],
         email: Annotated[str, Form(...)],
         url: Annotated[str, Form(...)],
     ) -> JSONResponse:
+        # OBRA-74 hard requirement #5: capture the email *before* any
+        # refusal path so a kill switch / rate limit / spend cap pause
+        # still preserves acquisition signal. Email format errors do
+        # short-circuit, but anything that gets past _normalize_email
+        # is recorded.
         try:
             normalized_email = _normalize_email(email)
         except DemoUrlError as exc:
@@ -351,8 +415,16 @@ def create_app(
                 detail={"reason": exc.reason, "message": exc.user_message},
             ) from exc
 
+        await emails.capture(
+            email=normalized_email,
+            salt=config.hash_salt,
+            consent_version=config.consent_version,
+        )
+
         # Run the cheap classifier synchronously so users get immediate
-        # feedback on bad URLs instead of polling for a failure.
+        # feedback on bad URLs instead of polling for a failure. Bad
+        # URLs do not consume a per-IP attempt — there's no point
+        # punishing a typo.
         try:
             classify_demo_url(url)
         except DemoUrlError as exc:
@@ -361,11 +433,57 @@ def create_app(
                 detail={"reason": exc.reason, "message": exc.user_message},
             ) from exc
 
-        job = await store.create(email=normalized_email, url=url)
+        # Now the request looks credible. Burn one of the IP's daily
+        # attempts (failures count too — that's the OBRA-73 contract).
+        ip_hash = hash_with_salt(_client_ip(request), salt=config.hash_salt)
+        ip_decision = await limiter.record_attempt_and_check(
+            ip_hash=ip_hash,
+            cap=config.daily_attempts_per_ip,
+        )
+        if not ip_decision.allowed:
+            return _refuse(
+                status.HTTP_429_TOO_MANY_REQUESTS,
+                ip_decision.outcome.value,
+                ip_decision.user_message,
+            )
+
+        # Per-email success quota — read-only check, the success isn't
+        # consumed until the worker confirms the run completed.
+        email_hash = hash_with_salt(normalized_email, salt=config.hash_salt)
+        email_decision = await limiter.check_email_quota(
+            email_hash=email_hash,
+            cap=config.daily_runs_per_email,
+        )
+        if not email_decision.allowed:
+            return _refuse(
+                status.HTTP_429_TOO_MANY_REQUESTS,
+                email_decision.outcome.value,
+                email_decision.user_message,
+            )
+
+        # Global daily success cap.
+        global_decision = await limiter.check_global_cap(cap=config.daily_run_cap)
+        if not global_decision.allowed:
+            return _refuse(
+                status.HTTP_429_TOO_MANY_REQUESTS,
+                global_decision.outcome.value,
+                global_decision.user_message,
+            )
+
+        # Monthly spend cap.
+        spend_decision = await spend.check_cap(cap_usd=config.monthly_spend_cap_usd)
+        if spend_decision.paused:
+            return JSONResponse(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                content=MaintenanceResponse(detail=spend_decision.user_message).model_dump(),
+            )
+
+        job = await store.create(email=normalized_email, url=url, salt=config.hash_salt)
 
         if not config.enabled:
-            # Kill switch on: keep the email captured for acquisition
-            # signal, but don't run the pipeline.
+            # Kill switch on: email is already captured above. Mark
+            # the job failed so it shows in admin/audit views and
+            # return the maintenance response.
             await store.mark_failed(
                 job.id,
                 error_code="demo_pipeline_disabled",

--- a/src/inkwell/demo/config.py
+++ b/src/inkwell/demo/config.py
@@ -113,6 +113,20 @@ class DemoConfig(BaseSettings):
         ge=1,
         description="Total attempts (success or failure) allowed per IP per day.",
     )
+    trusted_proxy_count: int = Field(
+        default=1,
+        ge=0,
+        le=10,
+        description=(
+            "Number of trusted proxy hops in front of the demo service. "
+            "Cloud Run sits behind one Google Cloud Load Balancer that "
+            "appends the real client IP to the end of `X-Forwarded-For`, "
+            "so the default `1` is correct there. Anything to the left of "
+            "the trusted suffix is treated as attacker-controlled and "
+            "ignored when extracting the per-IP rate-limit identity. Set "
+            "to `0` only for direct-internet deployments without an LB."
+        ),
+    )
 
     monthly_spend_cap_usd: float = Field(
         default=50.0,

--- a/src/inkwell/demo/config.py
+++ b/src/inkwell/demo/config.py
@@ -125,6 +125,19 @@ class DemoConfig(BaseSettings):
         description="Version label written alongside captured emails.",
     )
 
+    hash_salt: str = Field(
+        default="inkwell-demo-dev-salt",
+        min_length=8,
+        description=(
+            "Per-deploy salt mixed into SHA-256 hashes of email and IP "
+            "before they are stored in Firestore. Production overrides "
+            "via Secret Manager (`INKWELL_DEMO_HASH_SALT`); the default "
+            "is a deterministic dev fixture so tests are reproducible. "
+            "Rotating the salt invalidates all rate-limit counters and "
+            "is the documented operator action for an abuse incident."
+        ),
+    )
+
     allowed_templates: tuple[str, ...] = Field(
         default=DEMO_ALLOWED_TEMPLATES,
         description="Templates the demo is allowed to render. Not user-toggleable.",

--- a/src/inkwell/demo/email_store.py
+++ b/src/inkwell/demo/email_store.py
@@ -1,0 +1,126 @@
+"""Email capture for the public try-it demo.
+
+OBRA-74 hard requirement #5: every submission records the email
+*before* anything else can refuse it (kill switch, rate limit, spend
+cap). The collected emails are the primary acquisition signal during
+the try-it window — losing them on a refusal path defeats the whole
+strategy.
+
+This module isolates that contract behind :class:`EmailStore` so the
+in-memory implementation we ship in m4 can be swapped for the
+Firestore-backed implementation without touching the route layer. The
+Firestore schema in the OBRA-73 plan is::
+
+    emails/{emailHash}: {
+        email: <plaintext, only stored once>,
+        firstSeenAt: <timestamp>,
+        latestSeenAt: <timestamp>,
+        source: "try_it_demo",
+        consentVersion: <DemoConfig.consent_version>,
+        requestCount: <int>,
+    }
+
+The in-memory implementation keeps the same field set so the swap is a
+direct mapping.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from inkwell.demo.hashing import hash_with_salt
+
+_DEFAULT_SOURCE = "try_it_demo"
+
+
+@dataclass
+class EmailRecord:
+    """Single emails-collection row.
+
+    The plaintext ``email`` is stored exactly once — m4's Firestore
+    schema flags it as PII and rotates the hash salt as the abuse
+    response, leaving the plaintext column untouched until we hand it
+    to an ESP. Storing both lets us correlate within a deploy without
+    leaking identity to anyone who only has post-rotation hashes.
+    """
+
+    email_hash: str
+    email: str
+    first_seen_at: float
+    latest_seen_at: float
+    source: str
+    consent_version: str
+    request_count: int = 1
+    extra: dict[str, object] = field(default_factory=dict)
+
+
+class EmailStore(Protocol):
+    """Storage protocol for captured emails."""
+
+    async def capture(
+        self,
+        *,
+        email: str,
+        salt: str,
+        consent_version: str,
+        source: str = _DEFAULT_SOURCE,
+    ) -> EmailRecord:
+        """Insert or update the email row and return the persisted state."""
+        ...
+
+    async def get(self, email_hash: str) -> EmailRecord | None: ...
+
+
+class InMemoryEmailStore:
+    """Process-local :class:`EmailStore`.
+
+    Single-instance only; appropriate for tests and local dev. The
+    Firestore implementation in a follow-up issue maps these methods
+    onto a transactional update against ``emails/{email_hash}``.
+    """
+
+    def __init__(self) -> None:
+        self._rows: dict[str, EmailRecord] = {}
+        self._lock = asyncio.Lock()
+
+    async def capture(
+        self,
+        *,
+        email: str,
+        salt: str,
+        consent_version: str,
+        source: str = _DEFAULT_SOURCE,
+    ) -> EmailRecord:
+        normalized = email.strip().lower()
+        email_hash = hash_with_salt(normalized, salt=salt)
+        now = time.time()
+
+        async with self._lock:
+            existing = self._rows.get(email_hash)
+            if existing is None:
+                record = EmailRecord(
+                    email_hash=email_hash,
+                    email=normalized,
+                    first_seen_at=now,
+                    latest_seen_at=now,
+                    source=source,
+                    consent_version=consent_version,
+                    request_count=1,
+                )
+                self._rows[email_hash] = record
+                return record
+
+            existing.latest_seen_at = now
+            existing.request_count += 1
+            # Consent version may bump between deploys; record the
+            # latest the user saw on submit so we can prove acceptance
+            # of the current copy if challenged.
+            existing.consent_version = consent_version
+            return existing
+
+    async def get(self, email_hash: str) -> EmailRecord | None:
+        async with self._lock:
+            return self._rows.get(email_hash)

--- a/src/inkwell/demo/hashing.py
+++ b/src/inkwell/demo/hashing.py
@@ -1,0 +1,43 @@
+"""SHA-256 hashing with a per-deploy salt.
+
+Centralizes the rule that **every** stored identifier (email address,
+IP address, URL key) goes through this helper before it lands in
+Firestore or any in-memory counter that survives a request boundary.
+The salt is loaded once from :class:`DemoConfig` and rotating it (in
+the runbook for an abuse incident) invalidates all rate-limit counters
+without touching code.
+
+The hash is unkeyed SHA-256 over ``salt:value`` rather than HMAC. We're
+not authenticating anything — the goal is "make stored values opaque
+to anyone who reads a Firestore export and break cross-deploy
+correlation when we rotate the salt." Plain SHA-256 with a salt prefix
+is exactly that, in fewer characters.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+_SEPARATOR = b":"
+
+
+def hash_with_salt(value: str, *, salt: str) -> str:
+    """Return the salted SHA-256 hex digest of ``value``.
+
+    Args:
+        value: Identifier to hash. Caller is expected to normalize
+            (lowercase + strip) before passing if equivalence under
+            those operations matters — this helper does *not* alter
+            the input.
+        salt: Per-deploy salt loaded from
+            :attr:`DemoConfig.hash_salt`. Required keyword so call
+            sites cannot accidentally pass an unsalted hash.
+
+    Returns:
+        Hexadecimal SHA-256 digest as a 64-character string.
+    """
+    digest = hashlib.sha256()
+    digest.update(salt.encode("utf-8"))
+    digest.update(_SEPARATOR)
+    digest.update(value.encode("utf-8"))
+    return digest.hexdigest()

--- a/src/inkwell/demo/jobs.py
+++ b/src/inkwell/demo/jobs.py
@@ -2,29 +2,31 @@
 
 The OBRA-73 plan splits the demo storage layer into two stages:
 
-- m3 (this file) — an in-memory store that lives for the lifetime of
-  the Cloud Run instance. Good enough for one box, plenty for tests
-  and local dev, but loses every job on restart and doesn't share
-  state across instances.
-- m4 — a Firestore-backed implementation that satisfies the
-  ``emails`` / ``demo_jobs`` / ``rate_limits`` schema in the plan and
-  carries job state across instance churn.
+- m3 — an in-memory store that lives for the lifetime of the Cloud Run
+  instance. Good enough for one box, plenty for tests and local dev,
+  but loses every job on restart and doesn't share state across
+  instances.
+- m4 (in progress) layers email capture, rate limiting, and a monthly
+  spend cap on top. The Firestore swap of these stores ships in a
+  follow-up issue once we have the GCP project provisioned; the
+  protocols here are the contract that swap honors.
 
-m3 keeps both behind :class:`JobStore` so m4's swap is a single import
-change in ``app.py``. The route layer never sees ``InMemoryJobStore``
-directly.
+Hashing is centralized in :mod:`inkwell.demo.hashing` so a single salt
+rotation invalidates every counter that depends on email/URL/IP
+identity. ``JobStore.create`` requires the caller to pass a salt
+explicitly so an unsalted hash can never reach storage.
 """
 
 from __future__ import annotations
 
 import asyncio
 import enum
-import hashlib
 import time
 import uuid
 from dataclasses import dataclass, field
 from typing import Protocol
 
+from inkwell.demo.hashing import hash_with_salt
 from inkwell.demo.payload import DemoResultPayload
 
 
@@ -71,10 +73,10 @@ class JobStore(Protocol):
     Implementations must be safe to call from inside an ``asyncio`` task
     spawned by the FastAPI route handler. The in-memory implementation
     achieves that with a single ``asyncio.Lock``; the Firestore
-    implementation in m4 will rely on Firestore's own atomic updates.
+    implementation will rely on Firestore's own atomic updates.
     """
 
-    async def create(self, *, email: str, url: str) -> DemoJob: ...
+    async def create(self, *, email: str, url: str, salt: str) -> DemoJob: ...
 
     async def get(self, job_id: str) -> DemoJob | None: ...
 
@@ -89,7 +91,7 @@ class JobStore(Protocol):
         This is the idempotency primitive for the internal worker
         route. Cloud Tasks delivers at-least-once and retries any
         non-2xx response, so duplicate deliveries (or a retry after a
-        transient blip) must not re-spend the per-job budget. m4's
+        transient blip) must not re-spend the per-job budget. The
         Firestore implementation will back this with a transactional
         update against ``demo_jobs/{id}``.
         """
@@ -116,18 +118,18 @@ class InMemoryJobStore:
     """Process-local :class:`JobStore`. Single-instance only.
 
     Suitable for m3 (one Cloud Run revision, ``--concurrency=1``) and
-    for tests. Replaced by the Firestore implementation in m4.
+    for tests. Replaced by the Firestore implementation in a follow-up.
     """
 
     def __init__(self) -> None:
         self._jobs: dict[str, DemoJob] = {}
         self._lock = asyncio.Lock()
 
-    async def create(self, *, email: str, url: str) -> DemoJob:
+    async def create(self, *, email: str, url: str, salt: str) -> DemoJob:
         job = DemoJob(
             id=uuid.uuid4().hex,
-            email_hash=_hash(email.strip().lower()),
-            url_hash=_hash(url.strip()),
+            email_hash=hash_with_salt(email.strip().lower(), salt=salt),
+            url_hash=hash_with_salt(url.strip(), salt=salt),
             submitted_url=url,
             submitted_at=time.time(),
         )
@@ -183,13 +185,3 @@ class InMemoryJobStore:
             job.error_code = error_code
             job.error_message = error_message
             job.completed_at = time.time()
-
-
-def _hash(value: str) -> str:
-    """SHA-256 hex digest of an unsalted lowercased string.
-
-    m4 layers a per-deploy salt on top via Secret Manager. For m3 the
-    raw hash is sufficient — the goal here is "don't print the email
-    into logs", not cross-deploy unlinkability.
-    """
-    return hashlib.sha256(value.encode("utf-8")).hexdigest()

--- a/src/inkwell/demo/rate_limits.py
+++ b/src/inkwell/demo/rate_limits.py
@@ -1,0 +1,206 @@
+"""Daily rate limits for the demo (m4 of OBRA-74).
+
+The OBRA-73 plan locks three counters that we track per UTC day:
+
+- ``daily_attempts_per_ip`` (default ``3``) — every submission that
+  passes URL classification counts. Failures count too; the goal is to
+  cap a single IP from spamming us, not to reward bad URLs.
+- ``daily_runs_per_email`` (default ``1``) — successful runs only.
+  Multiple submissions are allowed if the earlier ones failed; only the
+  successful run consumes the quota.
+- ``daily_run_cap`` (default ``20``) — global success ceiling, applied
+  before we enqueue. Once we have real cost data the operator widens
+  this in :class:`DemoConfig`.
+
+The protocol exposes one *check-and-record* call per counter so a
+Firestore implementation can do the work in a single transactional
+increment instead of two round trips. ``record_success`` is separate
+because it fires from the worker, not from the route handler.
+
+Day boundaries are UTC midnight to keep counters deterministic across
+Cloud Run regions and for testing. The in-memory implementation keys
+counters by ``(<counter-name>, <YYYY-MM-DD>, <hash-or-global>)`` and
+trims old entries opportunistically; Firestore will use TTL fields.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import enum
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Protocol
+
+
+class RateLimitOutcome(str, enum.Enum):
+    """Why a rate-limit decision allowed or refused a submission."""
+
+    ALLOWED = "allowed"
+    IP_ATTEMPTS_EXHAUSTED = "ip_attempts_exhausted"
+    EMAIL_ALREADY_USED = "email_already_used"
+    GLOBAL_CAP_EXHAUSTED = "global_cap_exhausted"
+
+
+@dataclass(frozen=True)
+class RateLimitDecision:
+    """Result of a rate-limit check."""
+
+    allowed: bool
+    outcome: RateLimitOutcome
+    user_message: str
+    """User-safe message the route layer surfaces verbatim."""
+
+
+_ALLOWED = RateLimitDecision(
+    allowed=True,
+    outcome=RateLimitOutcome.ALLOWED,
+    user_message="",
+)
+
+
+def _ip_exhausted_message(cap: int) -> str:
+    return (
+        f"You've hit the daily limit of {cap} attempts from your IP. "
+        "Try again tomorrow or use the CLI in the meantime."
+    )
+
+
+def _email_used_message() -> str:
+    return (
+        "This email already ran a demo today. The CLI does the same thing "
+        "without the daily cap if you want more — see the install steps below."
+    )
+
+
+def _global_cap_message() -> str:
+    return (
+        "We've hit the global demo cap for today. Try again tomorrow or "
+        "install the CLI to keep going now."
+    )
+
+
+class RateLimiter(Protocol):
+    """Daily rate-limit protocol the route + worker depend on."""
+
+    async def record_attempt_and_check(
+        self,
+        *,
+        ip_hash: str,
+        cap: int,
+    ) -> RateLimitDecision:
+        """Increment the IP attempt counter and decide whether to proceed.
+
+        The increment happens unconditionally so a refused submission
+        still burns one attempt of the IP's daily allowance. Returns
+        :class:`RateLimitOutcome.IP_ATTEMPTS_EXHAUSTED` if the counter
+        is now over ``cap``.
+        """
+        ...
+
+    async def check_email_quota(
+        self,
+        *,
+        email_hash: str,
+        cap: int,
+    ) -> RateLimitDecision:
+        """Read-only check on the per-email success counter.
+
+        Does NOT increment — the success is reserved by
+        :meth:`record_success` from the worker only when the pipeline
+        actually completes.
+        """
+        ...
+
+    async def check_global_cap(self, *, cap: int) -> RateLimitDecision: ...
+
+    async def record_success(self, *, email_hash: str) -> None:
+        """Bump the per-email and global success counters atomically."""
+        ...
+
+
+class InMemoryRateLimiter:
+    """Process-local :class:`RateLimiter`.
+
+    Single-instance only. The Firestore implementation in a follow-up
+    issue keys counters by ``rate_limits/{day}/{counter}/{key}`` and
+    uses ``Increment`` for the atomic update.
+    """
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        # Counters keyed by (date, counter_name, key).
+        self._counters: dict[tuple[str, str, str], int] = {}
+
+    async def record_attempt_and_check(
+        self,
+        *,
+        ip_hash: str,
+        cap: int,
+    ) -> RateLimitDecision:
+        day = _today()
+        async with self._lock:
+            self._trim(day)
+            count = self._counters.get((day, "ip_attempts", ip_hash), 0) + 1
+            self._counters[(day, "ip_attempts", ip_hash)] = count
+        if count > cap:
+            return RateLimitDecision(
+                allowed=False,
+                outcome=RateLimitOutcome.IP_ATTEMPTS_EXHAUSTED,
+                user_message=_ip_exhausted_message(cap),
+            )
+        return _ALLOWED
+
+    async def check_email_quota(
+        self,
+        *,
+        email_hash: str,
+        cap: int,
+    ) -> RateLimitDecision:
+        day = _today()
+        async with self._lock:
+            self._trim(day)
+            count = self._counters.get((day, "email_successes", email_hash), 0)
+        if count >= cap:
+            return RateLimitDecision(
+                allowed=False,
+                outcome=RateLimitOutcome.EMAIL_ALREADY_USED,
+                user_message=_email_used_message(),
+            )
+        return _ALLOWED
+
+    async def check_global_cap(self, *, cap: int) -> RateLimitDecision:
+        day = _today()
+        async with self._lock:
+            self._trim(day)
+            count = self._counters.get((day, "global_successes", ""), 0)
+        if count >= cap:
+            return RateLimitDecision(
+                allowed=False,
+                outcome=RateLimitOutcome.GLOBAL_CAP_EXHAUSTED,
+                user_message=_global_cap_message(),
+            )
+        return _ALLOWED
+
+    async def record_success(self, *, email_hash: str) -> None:
+        day = _today()
+        async with self._lock:
+            self._trim(day)
+            self._counters[(day, "email_successes", email_hash)] = (
+                self._counters.get((day, "email_successes", email_hash), 0) + 1
+            )
+            self._counters[(day, "global_successes", "")] = (
+                self._counters.get((day, "global_successes", ""), 0) + 1
+            )
+
+    def _trim(self, today: str) -> None:
+        # Drop counters from prior days. Cheap because we only keep at
+        # most a handful of keys per day and trim on every mutation
+        # under the lock.
+        stale = [key for key in self._counters if key[0] != today]
+        for key in stale:
+            del self._counters[key]
+
+
+def _today() -> str:
+    """UTC YYYY-MM-DD; counters reset at midnight UTC."""
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")

--- a/src/inkwell/demo/spend_tracker.py
+++ b/src/inkwell/demo/spend_tracker.py
@@ -1,0 +1,106 @@
+"""Monthly spend cap for the demo (m4 of OBRA-74).
+
+The OBRA-73 plan budgets the demo at ``$50/month`` of API spend across
+Gemini transcription + extraction. Once we've crossed that cap the
+demo accepts emails (acquisition signal stays on) but refuses to run
+the pipeline until the next calendar month. Spend is recorded after
+each successful run from the worker.
+
+The protocol matches the rate-limit module: a route-time check that
+looks at the current month's accumulated cost, and a worker-time
+record that adds to it. The Firestore implementation in a follow-up
+issue lives under ``rate_limits/{YYYY-MM}/spend`` with an atomic
+``Increment``.
+
+Months reset at UTC midnight on day 1 — same convention as the daily
+rate-limit counters so the operator runbook only has to know one
+clock.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class SpendDecision:
+    """Result of a spend-cap check before enqueueing a pipeline run."""
+
+    paused: bool
+    spent_usd: float
+    cap_usd: float
+
+    @property
+    def remaining_usd(self) -> float:
+        return max(self.cap_usd - self.spent_usd, 0.0)
+
+    @property
+    def user_message(self) -> str:
+        if not self.paused:
+            return ""
+        return (
+            "We've hit this month's API spend cap. The demo is paused "
+            "until the budget resets. The CLI works against your own "
+            "API key without any cap — see the install steps below."
+        )
+
+
+class SpendTracker(Protocol):
+    """Monthly spend tracker the route + worker depend on."""
+
+    async def check_cap(self, *, cap_usd: float) -> SpendDecision: ...
+
+    async def record_spend(self, *, cost_usd: float) -> None: ...
+
+    async def total_for_current_month(self) -> float: ...
+
+
+class InMemorySpendTracker:
+    """Process-local :class:`SpendTracker`.
+
+    Single-instance only. The Firestore implementation will use a
+    transactional ``Increment`` on ``rate_limits/{YYYY-MM}/spend``.
+    """
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        # Map of YYYY-MM -> accumulated USD.
+        self._totals: dict[str, float] = {}
+
+    async def check_cap(self, *, cap_usd: float) -> SpendDecision:
+        month = _this_month()
+        async with self._lock:
+            self._trim(month)
+            spent = self._totals.get(month, 0.0)
+        return SpendDecision(
+            paused=spent >= cap_usd,
+            spent_usd=spent,
+            cap_usd=cap_usd,
+        )
+
+    async def record_spend(self, *, cost_usd: float) -> None:
+        if cost_usd <= 0:
+            return
+        month = _this_month()
+        async with self._lock:
+            self._trim(month)
+            self._totals[month] = self._totals.get(month, 0.0) + cost_usd
+
+    async def total_for_current_month(self) -> float:
+        month = _this_month()
+        async with self._lock:
+            self._trim(month)
+            return self._totals.get(month, 0.0)
+
+    def _trim(self, current: str) -> None:
+        stale = [m for m in self._totals if m != current]
+        for m in stale:
+            del self._totals[m]
+
+
+def _this_month() -> str:
+    """UTC YYYY-MM; spend counters reset at the start of each month."""
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m")

--- a/tests/unit/demo/test_app.py
+++ b/tests/unit/demo/test_app.py
@@ -298,6 +298,7 @@ class TestGetJob:
         job = await store.create(
             email="user@example.com",
             url="https://example.com/feed.rss",
+            salt="test-salt",
         )
         await store.mark_complete(job.id, payload=_payload(), cost_usd=0.07)
 
@@ -433,6 +434,7 @@ class TestInternalWorkerRoute:
         job = await store.create(
             email="user@example.com",
             url="https://example.com/feed.rss",
+            salt="test-salt",
         )
 
         with _make_client(
@@ -488,6 +490,7 @@ class TestInternalWorkerRoute:
         job = await store.create(
             email="user@example.com",
             url="https://example.com/feed.rss",
+            salt="test-salt",
         )
 
         with _make_client(
@@ -530,6 +533,7 @@ class TestInternalWorkerRoute:
         job = await store.create(
             email="user@example.com",
             url="https://example.com/feed.rss",
+            salt="test-salt",
         )
         first = await store.try_claim_for_run(job.id)
         second = await store.try_claim_for_run(job.id)

--- a/tests/unit/demo/test_guards.py
+++ b/tests/unit/demo/test_guards.py
@@ -219,7 +219,7 @@ class TestRateLimits:
 
         import asyncio
 
-        asyncio.get_event_loop().run_until_complete(_seed())
+        asyncio.run(_seed())
 
         with client:
             response = client.post(
@@ -251,7 +251,7 @@ class TestRateLimits:
 
         import asyncio
 
-        asyncio.get_event_loop().run_until_complete(_seed_global())
+        asyncio.run(_seed_global())
 
         with client:
             response = client.post(
@@ -308,6 +308,66 @@ class TestRateLimits:
         assert r1.status_code == 202
         assert r2.status_code == 202
 
+    def test_spoof_prefix_does_not_bypass_ip_cap(
+        self,
+        global_config: GlobalConfig,
+    ) -> None:
+        # Codex P1 on PR #77: an attacker can rotate the leftmost XFF
+        # entries to dodge per-IP rate limits if we trust the leftmost
+        # value. With the trusted-suffix algorithm (default
+        # trusted_proxy_count=1), the IP we extract is the rightmost
+        # entry — the one GCLB appended — and attacker rotation in
+        # the prefix doesn't change it.
+        config = DemoConfig(hash_salt=_TEST_SALT, daily_attempts_per_ip=1)
+        client, _ = _build(config, global_config)
+        with client:
+            ok = client.post(
+                "/jobs",
+                data={"email": "u@example.com", "url": "https://example.com/feed.rss"},
+                # GCLB appended "203.0.113.10" — that's the real client.
+                # The attacker prefix cannot influence what we count.
+                headers={"X-Forwarded-For": "1.2.3.4, 5.6.7.8, 203.0.113.10"},
+            )
+            # Same real IP, attacker rotates a different fake prefix.
+            blocked = client.post(
+                "/jobs",
+                data={"email": "u2@example.com", "url": "https://example.com/feed.rss"},
+                headers={"X-Forwarded-For": "9.9.9.9, 203.0.113.10"},
+            )
+        assert ok.status_code == 202
+        # Attacker burned the IP's only allowed daily attempt; the
+        # second request must be refused even though the leftmost XFF
+        # entry rotated.
+        assert blocked.status_code == 429
+        assert blocked.json()["detail"]["reason"] == "ip_attempts_exhausted"
+
+    def test_trusted_proxy_count_zero_ignores_xff(
+        self,
+        global_config: GlobalConfig,
+    ) -> None:
+        # With no LB in front (direct-internet deploy), XFF is fully
+        # untrusted and we always use the socket peer. Two different
+        # XFF values therefore share the same per-IP budget.
+        config = DemoConfig(
+            hash_salt=_TEST_SALT,
+            daily_attempts_per_ip=1,
+            trusted_proxy_count=0,
+        )
+        client, _ = _build(config, global_config)
+        with client:
+            r1 = client.post(
+                "/jobs",
+                data={"email": "u@example.com", "url": "https://example.com/feed.rss"},
+                headers={"X-Forwarded-For": "203.0.113.10"},
+            )
+            r2 = client.post(
+                "/jobs",
+                data={"email": "u2@example.com", "url": "https://example.com/feed.rss"},
+                headers={"X-Forwarded-For": "203.0.113.20"},
+            )
+        assert r1.status_code == 202
+        assert r2.status_code == 429
+
 
 # ---------------------------------------------------------------------------
 # spend cap
@@ -329,7 +389,7 @@ class TestSpendCap:
 
         import asyncio
 
-        asyncio.get_event_loop().run_until_complete(_seed_spend())
+        asyncio.run(_seed_spend())
 
         with client:
             response = client.post(

--- a/tests/unit/demo/test_guards.py
+++ b/tests/unit/demo/test_guards.py
@@ -1,0 +1,406 @@
+"""Tests for the m4 guard layer: email capture, rate limits, spend cap.
+
+These tests stand the FastAPI app up with in-memory backends and
+exercise the guard sequence via ``TestClient``. They specifically
+verify the OBRA-74 acceptance contract that the email is captured even
+when the request is later refused (kill switch, rate limit, spend cap).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from inkwell.config.schema import GlobalConfig
+from inkwell.demo.app import create_app
+from inkwell.demo.classifier import ClassifiedUrl
+from inkwell.demo.config import DemoConfig
+from inkwell.demo.email_store import InMemoryEmailStore
+from inkwell.demo.hashing import hash_with_salt
+from inkwell.demo.jobs import InMemoryJobStore
+from inkwell.demo.payload import DemoNoteFile, DemoResultPayload
+from inkwell.demo.rate_limits import InMemoryRateLimiter
+from inkwell.demo.service import DemoJobResult
+from inkwell.demo.spend_tracker import InMemorySpendTracker
+
+_TEST_SALT = "test-salt-deadbeef"
+
+
+class _RecordingDispatcher:
+    def __init__(self) -> None:
+        self.dispatched: list[str] = []
+
+    async def dispatch(self, job_id: str) -> None:
+        self.dispatched.append(job_id)
+
+
+@pytest.fixture
+def demo_config() -> DemoConfig:
+    return DemoConfig(hash_salt=_TEST_SALT)
+
+
+@pytest.fixture
+def global_config() -> GlobalConfig:
+    return GlobalConfig()
+
+
+def _build(
+    demo_config: DemoConfig,
+    global_config: GlobalConfig,
+    *,
+    email_store: InMemoryEmailStore | None = None,
+    rate_limiter: InMemoryRateLimiter | None = None,
+    spend_tracker: InMemorySpendTracker | None = None,
+    job_store: InMemoryJobStore | None = None,
+) -> tuple[TestClient, dict[str, Any]]:
+    es = email_store or InMemoryEmailStore()
+    rl = rate_limiter or InMemoryRateLimiter()
+    st = spend_tracker or InMemorySpendTracker()
+    js = job_store or InMemoryJobStore()
+    dispatcher = _RecordingDispatcher()
+    app = create_app(
+        demo_config=demo_config,
+        global_config=global_config,
+        job_store=js,
+        email_store=es,
+        rate_limiter=rl,
+        spend_tracker=st,
+        dispatcher=dispatcher,
+    )
+    return TestClient(app), {
+        "email_store": es,
+        "rate_limiter": rl,
+        "spend_tracker": st,
+        "job_store": js,
+        "dispatcher": dispatcher,
+    }
+
+
+def _payload() -> DemoResultPayload:
+    return DemoResultPayload(
+        podcast_name="Acme",
+        episode_title="Ep 1",
+        episode_url="https://example.com/audio.mp3",
+        duration_seconds=600.0,
+        transcription_source="gemini",
+        files=[
+            DemoNoteFile(template="summary", filename="summary.md", title="Summary", markdown="x")
+        ],
+        extraction_cost_usd=0.04,
+        total_cost_usd=0.07,
+    )
+
+
+# ---------------------------------------------------------------------------
+# email capture
+# ---------------------------------------------------------------------------
+
+
+class TestEmailCapture:
+    def test_captures_email_on_successful_submission(
+        self,
+        demo_config: DemoConfig,
+        global_config: GlobalConfig,
+    ) -> None:
+        client, deps = _build(demo_config, global_config)
+        with client:
+            response = client.post(
+                "/jobs",
+                data={"email": "user@example.com", "url": "https://example.com/feed.rss"},
+            )
+        assert response.status_code == 202
+        email_hash = hash_with_salt("user@example.com", salt=_TEST_SALT)
+        record = deps["email_store"]._rows.get(email_hash)  # noqa: SLF001
+        assert record is not None
+        assert record.email == "user@example.com"
+        assert record.consent_version == demo_config.consent_version
+        assert record.request_count == 1
+
+    def test_captures_email_when_kill_switch_active(
+        self,
+        global_config: GlobalConfig,
+    ) -> None:
+        # OBRA-74 hard requirement #5 explicitly: capture the email even
+        # when processing is paused.
+        config = DemoConfig(hash_salt=_TEST_SALT, enabled=False)
+        client, deps = _build(config, global_config)
+        with client:
+            response = client.post(
+                "/jobs",
+                data={"email": "u@example.com", "url": "https://example.com/feed.rss"},
+            )
+        assert response.status_code == 503
+        assert response.json()["status"] == "maintenance"
+        assert len(deps["email_store"]._rows) == 1  # noqa: SLF001
+
+    def test_does_not_capture_invalid_email(
+        self,
+        demo_config: DemoConfig,
+        global_config: GlobalConfig,
+    ) -> None:
+        client, deps = _build(demo_config, global_config)
+        with client:
+            response = client.post(
+                "/jobs",
+                data={"email": "not-an-email", "url": "https://example.com/feed.rss"},
+            )
+        assert response.status_code == 400
+        assert deps["email_store"]._rows == {}  # noqa: SLF001
+
+    def test_increments_request_count_on_repeat_submission(
+        self,
+        demo_config: DemoConfig,
+        global_config: GlobalConfig,
+    ) -> None:
+        # Increase the per-email + per-IP cap so two submissions both pass.
+        config = DemoConfig(
+            hash_salt=_TEST_SALT,
+            daily_attempts_per_ip=10,
+            daily_runs_per_email=10,
+        )
+        client, deps = _build(config, global_config)
+        with client:
+            for _ in range(2):
+                client.post(
+                    "/jobs",
+                    data={"email": "u@example.com", "url": "https://example.com/feed.rss"},
+                )
+        records = list(deps["email_store"]._rows.values())  # noqa: SLF001
+        assert len(records) == 1
+        assert records[0].request_count == 2
+
+
+# ---------------------------------------------------------------------------
+# rate limits
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimits:
+    def test_ip_attempt_cap_returns_429(
+        self,
+        demo_config: DemoConfig,
+        global_config: GlobalConfig,
+    ) -> None:
+        # Default is 3 attempts/IP/day; the 4th attempt must be refused.
+        client, deps = _build(demo_config, global_config)
+        with client:
+            for _ in range(demo_config.daily_attempts_per_ip):
+                ok = client.post(
+                    "/jobs",
+                    data={"email": "u@example.com", "url": "https://example.com/feed.rss"},
+                )
+                # Each one returns 202 OR 429 (email cap kicks in after 1) —
+                # we only care that the IP cap kicks in eventually.
+                assert ok.status_code in (202, 429)
+            blocked = client.post(
+                "/jobs",
+                data={"email": "u@example.com", "url": "https://example.com/feed.rss"},
+            )
+        assert blocked.status_code == 429
+        assert blocked.json()["detail"]["reason"] == "ip_attempts_exhausted"
+
+    def test_email_quota_returns_429_after_success(
+        self,
+        demo_config: DemoConfig,
+        global_config: GlobalConfig,
+    ) -> None:
+        # Pre-record a success for the email so the read-only quota
+        # check refuses the next submission. We bypass the route layer
+        # for the success because the InMemoryRateLimiter exposes the
+        # ``record_success`` primitive directly.
+        client, deps = _build(demo_config, global_config)
+        rl = deps["rate_limiter"]
+        email_hash = hash_with_salt("u@example.com", salt=_TEST_SALT)
+
+        async def _seed() -> None:
+            await rl.record_success(email_hash=email_hash)
+
+        import asyncio
+
+        asyncio.get_event_loop().run_until_complete(_seed())
+
+        with client:
+            response = client.post(
+                "/jobs",
+                data={"email": "u@example.com", "url": "https://example.com/feed.rss"},
+            )
+        assert response.status_code == 429
+        assert response.json()["detail"]["reason"] == "email_already_used"
+
+    def test_global_cap_returns_429(
+        self,
+        demo_config: DemoConfig,
+        global_config: GlobalConfig,
+    ) -> None:
+        # Tiny global cap so we can prove the third decision tier
+        # without burning the email or IP counters.
+        config = DemoConfig(
+            hash_salt=_TEST_SALT,
+            daily_run_cap=1,
+            daily_attempts_per_ip=10,
+            daily_runs_per_email=10,
+        )
+        client, deps = _build(config, global_config)
+        rl = deps["rate_limiter"]
+
+        async def _seed_global() -> None:
+            # Use a different email so the email-quota check passes.
+            await rl.record_success(email_hash="other-email-hash")
+
+        import asyncio
+
+        asyncio.get_event_loop().run_until_complete(_seed_global())
+
+        with client:
+            response = client.post(
+                "/jobs",
+                data={"email": "u@example.com", "url": "https://example.com/feed.rss"},
+            )
+        assert response.status_code == 429
+        assert response.json()["detail"]["reason"] == "global_cap_exhausted"
+
+    def test_classifier_failure_does_not_burn_ip_attempt(
+        self,
+        demo_config: DemoConfig,
+        global_config: GlobalConfig,
+    ) -> None:
+        # Bad URLs should not consume the per-IP attempt budget.
+        config = DemoConfig(hash_salt=_TEST_SALT, daily_attempts_per_ip=1)
+        client, deps = _build(config, global_config)
+        with client:
+            bad = client.post(
+                "/jobs",
+                data={"email": "u@example.com", "url": "http://127.0.0.1/feed.rss"},
+            )
+            assert bad.status_code == 400
+            # IP attempt counter is still 0 — the next valid submission
+            # passes the IP check.
+            ok = client.post(
+                "/jobs",
+                data={"email": "u@example.com", "url": "https://example.com/feed.rss"},
+            )
+        assert ok.status_code == 202
+
+    def test_uses_x_forwarded_for_for_ip_hash(
+        self,
+        demo_config: DemoConfig,
+        global_config: GlobalConfig,
+    ) -> None:
+        # Cloud Run forwards real client IPs in X-Forwarded-For. Two
+        # different XFF values should each have their own attempt
+        # budget (i.e. the second submission isn't blocked even though
+        # the underlying TCP peer is the same TestClient).
+        config = DemoConfig(hash_salt=_TEST_SALT, daily_attempts_per_ip=1)
+        client, _ = _build(config, global_config)
+        with client:
+            r1 = client.post(
+                "/jobs",
+                data={"email": "u1@example.com", "url": "https://example.com/feed.rss"},
+                headers={"X-Forwarded-For": "203.0.113.10"},
+            )
+            r2 = client.post(
+                "/jobs",
+                data={"email": "u2@example.com", "url": "https://example.com/feed.rss"},
+                headers={"X-Forwarded-For": "203.0.113.20"},
+            )
+        assert r1.status_code == 202
+        assert r2.status_code == 202
+
+
+# ---------------------------------------------------------------------------
+# spend cap
+# ---------------------------------------------------------------------------
+
+
+class TestSpendCap:
+    def test_spend_cap_pauses_with_503(
+        self,
+        demo_config: DemoConfig,
+        global_config: GlobalConfig,
+    ) -> None:
+        config = DemoConfig(hash_salt=_TEST_SALT, monthly_spend_cap_usd=1.0)
+        client, deps = _build(config, global_config)
+        st = deps["spend_tracker"]
+
+        async def _seed_spend() -> None:
+            await st.record_spend(cost_usd=1.0)
+
+        import asyncio
+
+        asyncio.get_event_loop().run_until_complete(_seed_spend())
+
+        with client:
+            response = client.post(
+                "/jobs",
+                data={"email": "u@example.com", "url": "https://example.com/feed.rss"},
+            )
+        assert response.status_code == 503
+        assert response.json()["status"] == "maintenance"
+        # Email was still captured.
+        assert len(deps["email_store"]._rows) == 1  # noqa: SLF001
+
+    @pytest.mark.asyncio
+    async def test_worker_records_spend_and_success(
+        self,
+        demo_config: DemoConfig,
+        global_config: GlobalConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Mock the pipeline so the worker reaches mark_complete.
+        async def fake_process_demo_job(
+            classified: ClassifiedUrl,
+            *,
+            demo_config: DemoConfig,
+            global_config: GlobalConfig,
+        ) -> DemoJobResult:
+            return DemoJobResult(
+                payload=_payload(),
+                resolved_source=Any,  # type: ignore[arg-type]
+                total_cost_usd=0.07,
+            )
+
+        monkeypatch.setattr("inkwell.demo.app.process_demo_job", fake_process_demo_job)
+
+        client, deps = _build(demo_config, global_config)
+        # We need the internal-route entrypoint to drive the worker
+        # synchronously; rebuild with worker_secret set.
+        es = InMemoryEmailStore()
+        rl = InMemoryRateLimiter()
+        st = InMemorySpendTracker()
+        js = InMemoryJobStore()
+        app = create_app(
+            demo_config=demo_config,
+            global_config=global_config,
+            job_store=js,
+            email_store=es,
+            rate_limiter=rl,
+            spend_tracker=st,
+            dispatcher=_RecordingDispatcher(),
+            worker_secret="real-secret",
+        )
+        client = TestClient(app)
+
+        job = await js.create(
+            email="u@example.com",
+            url="https://example.com/feed.rss",
+            salt=_TEST_SALT,
+        )
+
+        with client:
+            response = client.post(
+                f"/_internal/jobs/{job.id}/run",
+                headers={"X-Demo-Worker-Secret": "real-secret"},
+            )
+        assert response.status_code == 200
+
+        # Spend tracker took the hit.
+        assert await st.total_for_current_month() == pytest.approx(0.07)
+        # Email's per-day success counter ticked over (1 of 1), so a
+        # second submission for the same email today would now refuse.
+        decision = await rl.check_email_quota(
+            email_hash=job.email_hash,
+            cap=demo_config.daily_runs_per_email,
+        )
+        assert decision.allowed is False


### PR DESCRIPTION
## Summary

Fourth milestone of [OBRA-74](https://github.com/chekos/inkwell-cli/issues). Adds the OBRA-74 guard layer on top of m3. Cloud Run can now serve the demo with the rate limits and spend cap the plan locks; **the Firestore-backed implementations of these stores ship in a follow-up child issue** once Lucas provisions GCP.

## Architecture — protocols + in-memory now, Firestore later

Same pattern m3 used for `JobStore` / `Dispatcher`: every new store is a `Protocol` with an in-memory implementation injectable via `create_app` keyword args. The Firestore swap is a single new module per store; the route layer never sees the concrete type.

New modules:

- **`inkwell.demo.hashing`** — single salted-SHA256 helper. Every stored identifier (email, URL, IP) goes through this. Salt rotation is the documented operator action for an abuse incident; rotating invalidates all rate-limit counters without code changes.
- **`inkwell.demo.email_store`** — `EmailStore` protocol + `InMemoryEmailStore`. Captures email + first/latest seen + consent version + request count, schema-compatible with the plan's `emails/{emailHash}` doc.
- **`inkwell.demo.rate_limits`** — `RateLimiter` protocol + `InMemoryRateLimiter`. Three counters keyed by UTC day:
  - `record_attempt_and_check(ip_hash, cap=3)` — burns one IP attempt and decides.
  - `check_email_quota(email_hash, cap=1)` — read-only check; the actual consume happens via `record_success`.
  - `check_global_cap(cap=20)` — read-only on global success counter.
- **`inkwell.demo.spend_tracker`** — `SpendTracker` protocol + `InMemorySpendTracker`. Monthly accumulator + cap pause.

## Wiring

- `DemoConfig.hash_salt` env-injected (`INKWELL_DEMO_HASH_SALT`) with a deterministic dev default.
- `JobStore.create` now requires `salt=` so an unsalted hash can never reach storage.
- `POST /jobs` reordered to the OBRA-74 contract:
  1. Validate + normalize email (400 on bad email).
  2. **Capture email** — regardless of any later refusal.
  3. Run classifier (400 on bad URL — does not burn IP attempt).
  4. Burn one IP attempt; refuse 429 `ip_attempts_exhausted` if over cap.
  5. Read-only check email quota; refuse 429 `email_already_used`.
  6. Read-only check global cap; refuse 429 `global_cap_exhausted`.
  7. Check spend cap; refuse 503 maintenance if paused.
  8. Check kill switch; refuse 503 maintenance.
  9. Create job + dispatch.
- IP extracted from `X-Forwarded-For` (Cloud Run convention) with a peer-address fallback for local dev. The raw IP is hashed before storage.
- Worker records spend + per-email + global success **after** `mark_complete` so a Cloud Tasks retry doesn't double-count.

## Tests

11 new TestClient cases in `tests/unit/demo/test_guards.py`:

- email captured on success, on kill switch, NOT on bad email
- email `request_count` increments on repeat submission
- IP attempt cap (default 3) refuses 4th attempt
- email quota refuses after seeded success
- global cap refuses with seeded global success
- bad URL does NOT burn IP attempt
- `X-Forwarded-For` separates per-IP budgets
- spend cap pauses with 503 + email still captured
- worker records spend + per-email success on completion

Full results:
- 149 demo tests passing (138 from m1-m3 + 11 from m4)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src/`
- `uv run pytest tests/unit/ -q`
- Uvicorn smoke verified IP cap kicks in at attempt 4 with the correct user-safe message.

## What's deliberately not in this PR

- **Firestore implementations** of `EmailStore` / `RateLimiter` / `SpendTracker`. Cut as a child issue: needs `google-cloud-firestore` dep + GCP project provisioning. The protocols here are the contract that swap honors.
- **Cloud Tasks dispatcher** (m5 / [OBRA-79](/OBRA/issues/OBRA-79)) — m3's `InProcessDispatcher` still drives jobs; m5 swaps to a Cloud Tasks variant + provisions the worker shared secret in Secret Manager.
- **Email verification** (planned for after we have conversion data, per OBRA-73).
- **CSS / copy polish** — Clara owns post-launch.

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy src/`
- [x] `uv run pytest tests/unit/ -q`
- [x] `uv run pytest tests/unit/demo/test_guards.py -q` (11 new tests)
- [x] Manual uvicorn smoke: 1st submission 202, IP cap kicks in at attempt 4 with `ip_attempts_exhausted`

🤖 Generated with [Claude Code](https://claude.com/claude-code)