### PR TITLE
feat(demo): m5a Dockerfile + GitHub Actions deploy workflow (OBRA-79)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# Keep the build context small. The Dockerfile only needs pyproject /
+# uv.lock / src/, but Docker copies the whole working tree by default.
+
+.git/
+.github/
+.venv/
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+__pycache__/
+**/__pycache__/
+**/*.pyc
+*.egg-info/
+
+# Documentation + dev tooling — not shipped.
+docs/
+docs-site/
+benchmarks/
+tests/
+scripts/
+
+# Local config that mustn't leak into images.
+.env
+.env.*
+*.log

--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -1,0 +1,291 @@
+name: Demo Deploy (OBRA-79)
+
+# Builds and deploys the public try-it demo (OBRA-74) to Cloud Run.
+#
+# Two trigger paths:
+#   - pull_request → build the Docker image, run it through Trivy, and
+#     deploy a tagged Cloud Run revision with no production traffic.
+#     The preview URL gets posted as a comment on the PR. CI builds
+#     are gated on the `gcp-deploy` repository environment so a fork
+#     PR can't trigger a deploy.
+#   - push to main → build, push to Artifact Registry, and roll a new
+#     production Cloud Run revision.
+#
+# All GCP credentials live in the `gcp-deploy` environment as repo
+# secrets:
+#   - GCP_PROJECT_ID         — e.g. inkwell-demo-prod
+#   - GCP_REGION             — e.g. us-central1
+#   - GCP_SERVICE_NAME       — e.g. inkwell-demo
+#   - GCP_ARTIFACT_REPO      — Artifact Registry Docker repo name
+#   - GCP_WIF_PROVIDER       — Workload Identity Federation provider
+#                              (full resource name, used by google-github-actions/auth)
+#   - GCP_WIF_SERVICE_ACCOUNT — Service account the workflow impersonates
+#
+# Until Lucas provisions the GCP project, the deploy job stays gated
+# on the `should-deploy` flag: the build/test job still runs on every
+# PR (catches Dockerfile breakage early), the deploy job only runs
+# when the project secret is present.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/inkwell/demo/**"
+      - "src/inkwell/**.py"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "Dockerfile"
+      - ".dockerignore"
+      - ".github/workflows/demo-deploy.yml"
+  pull_request:
+    paths:
+      - "src/inkwell/demo/**"
+      - "src/inkwell/**.py"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "Dockerfile"
+      - ".dockerignore"
+      - ".github/workflows/demo-deploy.yml"
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write  # required by google-github-actions/auth for WIF
+
+concurrency:
+  group: demo-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Always-on build + smoke job. Catches Dockerfile breakage before the
+  # deploy step needs GCP secrets. Runs on PRs from forks too — no
+  # secrets exposed at this stage.
+  build:
+    name: Build & smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      image-tag: ${{ steps.compute-tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Compute image tag
+        id: compute-tag
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            tag="pr-${{ github.event.pull_request.number }}-${GITHUB_SHA::7}"
+          else
+            tag="main-${GITHUB_SHA::7}"
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build demo image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          tags: inkwell-demo:${{ steps.compute-tag.outputs.tag }}
+          push: false
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke-test container starts and serves /healthz
+        run: |
+          docker run -d --name demo-smoke \
+            -e DEMO_PIPELINE_ENABLED=true \
+            -e GOOGLE_API_KEY=stub-test-key \
+            -e INKWELL_DEMO_HASH_SALT=ci-smoke-salt \
+            -p 18080:8080 \
+            inkwell-demo:${{ steps.compute-tag.outputs.tag }}
+          # wait up to 30s for /healthz
+          for i in {1..30}; do
+            if curl -sf http://127.0.0.1:18080/healthz > /dev/null; then
+              echo "container healthy after ${i}s"
+              docker logs demo-smoke
+              docker stop demo-smoke
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "container failed to become healthy"
+          docker logs demo-smoke
+          docker stop demo-smoke
+          exit 1
+
+  # Production deploy. Only runs after a push to main, gated on the
+  # GCP project secret being present so the workflow doesn't fail on
+  # repos that haven't provisioned GCP yet.
+  deploy-prod:
+    name: Deploy to production Cloud Run
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: gcp-deploy
+      url: ${{ steps.deploy.outputs.url }}
+    steps:
+      - name: Skip if GCP not provisioned
+        id: skip-check
+        run: |
+          if [[ -z "${{ vars.GCP_PROJECT_ID }}" ]]; then
+            echo "GCP project not provisioned yet; skipping deploy."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v6
+        if: steps.skip-check.outputs.skip != 'true'
+
+      - id: auth
+        if: steps.skip-check.outputs.skip != 'true'
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_WIF_SERVICE_ACCOUNT }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+        if: steps.skip-check.outputs.skip != 'true'
+
+      - name: Configure Docker for Artifact Registry
+        if: steps.skip-check.outputs.skip != 'true'
+        run: gcloud auth configure-docker ${{ vars.GCP_REGION }}-docker.pkg.dev --quiet
+
+      - name: Set up Docker Buildx
+        if: steps.skip-check.outputs.skip != 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build & push image
+        if: steps.skip-check.outputs.skip != 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          tags: ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.GCP_ARTIFACT_REPO }}/inkwell-demo:${{ needs.build.outputs.image-tag }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Deploy Cloud Run revision
+        id: deploy
+        if: steps.skip-check.outputs.skip != 'true'
+        run: |
+          set -eu
+          gcloud run deploy "${{ vars.GCP_SERVICE_NAME }}" \
+            --project="${{ vars.GCP_PROJECT_ID }}" \
+            --region="${{ vars.GCP_REGION }}" \
+            --image="${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.GCP_ARTIFACT_REPO }}/inkwell-demo:${{ needs.build.outputs.image-tag }}" \
+            --concurrency=1 \
+            --max-instances=3 \
+            --timeout=1800 \
+            --memory=2Gi \
+            --cpu=1 \
+            --quiet
+          url=$(gcloud run services describe "${{ vars.GCP_SERVICE_NAME }}" \
+            --project="${{ vars.GCP_PROJECT_ID }}" \
+            --region="${{ vars.GCP_REGION }}" \
+            --format='value(status.url)')
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "Deployed: $url"
+
+  # PR preview deploy — tagged Cloud Run revision with NO traffic. The
+  # tagged URL is a stable per-PR address that lets reviewers click
+  # through, but production traffic stays on the live revision.
+  deploy-preview:
+    name: Deploy PR preview revision
+    needs: build
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: gcp-deploy
+      url: ${{ steps.deploy.outputs.url }}
+    steps:
+      - name: Skip if GCP not provisioned
+        id: skip-check
+        run: |
+          if [[ -z "${{ vars.GCP_PROJECT_ID }}" ]]; then
+            echo "GCP project not provisioned yet; preview skipped."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v6
+        if: steps.skip-check.outputs.skip != 'true'
+
+      - id: auth
+        if: steps.skip-check.outputs.skip != 'true'
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_WIF_SERVICE_ACCOUNT }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+        if: steps.skip-check.outputs.skip != 'true'
+
+      - name: Configure Docker for Artifact Registry
+        if: steps.skip-check.outputs.skip != 'true'
+        run: gcloud auth configure-docker ${{ vars.GCP_REGION }}-docker.pkg.dev --quiet
+
+      - name: Set up Docker Buildx
+        if: steps.skip-check.outputs.skip != 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build & push preview image
+        if: steps.skip-check.outputs.skip != 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          tags: ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.GCP_ARTIFACT_REPO }}/inkwell-demo:${{ needs.build.outputs.image-tag }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Deploy tagged revision (no traffic)
+        id: deploy
+        if: steps.skip-check.outputs.skip != 'true'
+        run: |
+          set -eu
+          revision_tag="${{ needs.build.outputs.image-tag }}"
+          gcloud run deploy "${{ vars.GCP_SERVICE_NAME }}" \
+            --project="${{ vars.GCP_PROJECT_ID }}" \
+            --region="${{ vars.GCP_REGION }}" \
+            --image="${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.GCP_ARTIFACT_REPO }}/inkwell-demo:${revision_tag}" \
+            --tag="${revision_tag}" \
+            --no-traffic \
+            --concurrency=1 \
+            --max-instances=2 \
+            --timeout=1800 \
+            --memory=2Gi \
+            --cpu=1 \
+            --quiet
+          # Cloud Run constructs the tagged URL deterministically as
+          # https://<tag>---<service>-<hash>-<region>.run.app — fetch it
+          # from the API to avoid hand-formatting.
+          url=$(gcloud run services describe "${{ vars.GCP_SERVICE_NAME }}" \
+            --project="${{ vars.GCP_PROJECT_ID }}" \
+            --region="${{ vars.GCP_REGION }}" \
+            --format="value(status.traffic[?tag='${revision_tag}'].url)" | head -1)
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "Preview: $url"
+
+      - name: Comment preview URL on PR
+        if: steps.skip-check.outputs.skip != 'true' && steps.deploy.outputs.url != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = '${{ steps.deploy.outputs.url }}';
+            const body = `🚀 **Demo preview deployed**\n\n` +
+                         `Revision tag: \`${{ needs.build.outputs.image-tag }}\`\n` +
+                         `URL: ${url}\n\n` +
+                         `Receives no production traffic; traffic shifts only after merge to \`main\`.`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,71 @@
+# syntax=docker/dockerfile:1.7
+#
+# Inkwell demo (OBRA-74) container image.
+#
+# Builds the FastAPI service that serves the public try-it surface. The
+# image bundles ffmpeg (yt-dlp + transcription dependency), the inkwell
+# package itself (CLI + demo modules), and the uvicorn entrypoint. It
+# does NOT carry GCP credentials — those mount in at runtime from
+# Secret Manager via Cloud Run env vars.
+#
+# Layer ordering favors cache hits: system packages first, then the
+# resolved dependency lock, then the source. A change to source code
+# rebuilds only the last two layers.
+
+# ---- builder: resolve and install Python deps with uv ----
+FROM python:3.12-slim AS builder
+
+# uv is the project's package manager (see ADR-008). Install the
+# released wheel via pip — pinning the major version keeps reproducible
+# builds without coupling to the ecosystem-wide GitHub release URL.
+RUN pip install --no-cache-dir uv==0.5.11
+
+WORKDIR /app
+
+# Pre-copy the lock + project metadata so we cache the dependency
+# install separately from the source tree.
+COPY pyproject.toml uv.lock README.md ./
+COPY src/ ./src/
+
+# Install the project + production dependencies into a venv at /app/.venv.
+# --no-dev skips test/lint deps that don't ship in production; --frozen
+# refuses to drift from uv.lock so Cloud Run can't accidentally pull a
+# different version than CI tested.
+RUN uv sync --frozen --no-dev
+
+
+# ---- runtime: thin layer with ffmpeg + the venv ----
+FROM python:3.12-slim AS runtime
+
+# ffmpeg is required by yt-dlp for audio extraction. tini gives us PID-1
+# behavior so Cloud Run's SIGTERM cleanly shuts down uvicorn instead of
+# hanging on an in-flight job.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ffmpeg tini \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy the resolved venv from the builder stage. We don't need uv at
+# runtime — the venv has everything pinned.
+COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder /app/src /app/src
+
+# Add the venv to PATH so `uvicorn` resolves without an explicit prefix.
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    # Cloud Run sends traffic to whatever port `$PORT` points at.
+    # Default to 8080 for local `docker run` parity.
+    PORT=8080
+
+# Cloud Run respects HEALTHCHECK; we expose the FastAPI /healthz route.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+    CMD python -c "import urllib.request,os,sys; sys.exit(0) if urllib.request.urlopen(f'http://127.0.0.1:{os.environ.get(\"PORT\",\"8080\")}/healthz', timeout=3).status == 200 else sys.exit(1)" || exit 1
+
+EXPOSE 8080
+
+# tini → uvicorn → create_app() factory. Concurrency=1 so the
+# class-attribute model pin in service.py stays single-threaded per
+# instance; Cloud Run scales by adding more instances, not threads.
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["sh", "-c", "uvicorn inkwell.demo.app:create_app --factory --host 0.0.0.0 --port ${PORT:-8080} --workers 1"]

--- a/docs/_internal/demo-runbook.md
+++ b/docs/_internal/demo-runbook.md
@@ -1,0 +1,112 @@
+# Inkwell demo runbook (OBRA-74)
+
+Operations reference for the public try-it demo. Companions: the
+[OBRA-73 plan](../../docs/building-in-public/devlog/) for design
+context, the m5 PR for deploy mechanics.
+
+## Service outline
+
+- **Service name**: `inkwell-demo` (Cloud Run).
+- **Image**: built from this repo's top-level `Dockerfile`. Pushed to
+  Artifact Registry per `.github/workflows/demo-deploy.yml`.
+- **Process**: `uvicorn inkwell.demo.app:create_app --factory`,
+  concurrency = 1 per Cloud Run instance, `max-instances=3` until we
+  have real cost data.
+- **Health probe**: `GET /healthz` returns `{"status":"ok"}`.
+
+## Required environment variables
+
+Set on the Cloud Run service via Secret Manager mounts (production)
+or `.env` (local):
+
+| Variable | Purpose |
+| --- | --- |
+| `GOOGLE_API_KEY` | Gemini API key for transcription + extraction. |
+| `INKWELL_DEMO_HASH_SALT` | Per-deploy salt for SHA-256 hashing of email/URL/IP. **Rotating this is the abuse-incident response.** |
+| `DEMO_PIPELINE_ENABLED` | Kill switch. `false` pauses processing; emails still record. |
+| `INKWELL_DEMO_TRUSTED_PROXY_COUNT` | Trusted proxy hops in front of Cloud Run. Default `1` for the standard GCLB chain. |
+| `INKWELL_DEMO_MONTHLY_SPEND_CAP_USD` | Override the default `$50` monthly cap (rarely needed). |
+
+Anthropic key (`ANTHROPIC_API_KEY`) is *not* required for the demo —
+extraction is pinned to Gemini Flash.
+
+## Operator actions
+
+### Pause processing without a redeploy
+
+```bash
+gcloud run services update inkwell-demo \
+    --project=$GCP_PROJECT_ID --region=$GCP_REGION \
+    --update-env-vars=DEMO_PIPELINE_ENABLED=false
+```
+
+The service still accepts emails (`/jobs` returns 503 maintenance with
+the email recorded for acquisition signal) but refuses to enqueue
+pipeline runs. Reverse with `=true`.
+
+### Rotate the hash salt (abuse incident response)
+
+The SHA-256 hashes of email, URL, and IP all derive from
+`INKWELL_DEMO_HASH_SALT`. Rotating the salt invalidates every
+rate-limit counter (no operator can tie pre-rotation hashes to
+post-rotation), without touching code:
+
+```bash
+new_salt=$(openssl rand -hex 32)
+gcloud secrets versions add inkwell-demo-hash-salt \
+    --project=$GCP_PROJECT_ID --data-file=<(printf '%s' "$new_salt")
+gcloud run services update inkwell-demo \
+    --project=$GCP_PROJECT_ID --region=$GCP_REGION \
+    --set-secrets=INKWELL_DEMO_HASH_SALT=inkwell-demo-hash-salt:latest
+```
+
+Existing in-flight jobs keep their old hash and run to completion;
+new submissions hash with the new salt.
+
+### Check monthly spend
+
+The spend cap pauses the service automatically when the per-month
+cumulative cost reaches `INKWELL_DEMO_MONTHLY_SPEND_CAP_USD`. To check
+the current month's total without waiting for a refusal:
+
+- The Firestore implementation (OBRA-90) writes per-month totals to
+  `rate_limits/{YYYY-MM}/spend`. Until that lands, totals only live in
+  memory on the running Cloud Run instance and are visible via the
+  per-job log line: `demo job <id> complete cost=$<usd>`.
+
+To force a temporary cap raise (rare):
+
+```bash
+gcloud run services update inkwell-demo \
+    --project=$GCP_PROJECT_ID --region=$GCP_REGION \
+    --update-env-vars=INKWELL_DEMO_MONTHLY_SPEND_CAP_USD=100.0
+```
+
+### Manual rollback to a prior revision
+
+```bash
+gcloud run revisions list \
+    --project=$GCP_PROJECT_ID --region=$GCP_REGION \
+    --service=inkwell-demo
+gcloud run services update-traffic inkwell-demo \
+    --project=$GCP_PROJECT_ID --region=$GCP_REGION \
+    --to-revisions=<prior-revision>=100
+```
+
+### PR preview deploys
+
+The `demo-deploy` workflow deploys a tagged Cloud Run revision with
+**no production traffic** for every PR (gated on `vars.GCP_PROJECT_ID`
+being set). The preview URL is posted as a PR comment by the workflow.
+Production traffic only shifts after merge to `main`.
+
+## What the demo does NOT do
+
+These are intentional non-features per the OBRA-73 plan:
+
+- Private / authenticated RSS feeds.
+- Episodes longer than 30 minutes.
+- In-browser interview mode.
+- Accounts, saved history, or persisted vault output.
+- Mailing list provider integration. Emails sit in Firestore until
+  Clara wires the ESP after we have conversion data.


### PR DESCRIPTION
## Summary

First slice of m5 ([OBRA-79](https://github.com/chekos/inkwell-cli/issues)). Lands the build + deploy plumbing for the demo. **Stacked on [PR #77](https://github.com/chekos/inkwell-cli/pull/77) (m4)** — please review/merge that first.

The Cloud Tasks dispatcher (the only remaining m5 deliverable) is cut as a separate child issue (m5b) so this PR stays small and the deploy chain is reviewable on its own.

### What lands

- **`Dockerfile`** — multi-stage on `python:3.12-slim`. Builder installs project deps via `uv sync --frozen --no-dev` from the lock; runtime stage adds `ffmpeg` (yt-dlp dep) + `tini` (clean PID-1 SIGTERM handling on Cloud Run revision rotation). `HEALTHCHECK` probes `/healthz`; ENTRYPOINT runs `uvicorn` with the `create_app` factory at concurrency=1 (matches the GeminiExtractor.MODEL pin invariant in service.py).
- **`.dockerignore`** — keeps the build context lean.
- **`.github/workflows/demo-deploy.yml`** — three-job pipeline:
  - `build` runs on every PR matching the demo paths. Builds the image, smoke-tests it by hitting `/healthz` from a transient container, caches Buildx layers in GHA. Catches Dockerfile breakage before deploy needs GCP.
  - `deploy-prod` runs on push to main. Pushes to Artifact Registry, deploys the Cloud Run service via WIF (`google-github-actions/auth@v2`) so no service-account JSON in repo secrets.
  - `deploy-preview` runs on PR open/sync. Deploys a tagged Cloud Run revision with **NO production traffic** and posts the preview URL as a PR comment. Skipped for fork PRs (no secrets exposure).
  - Both deploy jobs gate on `vars.GCP_PROJECT_ID` being set, so the workflow doesn't fail on this repo today — the moment Lucas adds the project / WIF / Artifact Registry vars, deploys start working with **zero code change**.
- **`docs/_internal/demo-runbook.md`** — operator reference: kill switch toggle, hash-salt rotation (abuse-incident response), spend-cap override, manual rollback, PR-preview deploy semantics.

### Lucas — GCP provisioning

Ready when you are. The workflow expects:

- `vars.GCP_PROJECT_ID` (e.g. `inkwell-demo-prod`)
- `vars.GCP_REGION` (e.g. `us-central1`)
- `vars.GCP_SERVICE_NAME` (e.g. `inkwell-demo`)
- `vars.GCP_ARTIFACT_REPO` (Artifact Registry Docker repo name)
- `secrets.GCP_WIF_PROVIDER` (full WIF resource name)
- `secrets.GCP_WIF_SERVICE_ACCOUNT` (SA the workflow impersonates)

Plus on the Cloud Run service itself: `GOOGLE_API_KEY`, `INKWELL_DEMO_HASH_SALT`, `DEMO_PIPELINE_ENABLED`, `INKWELL_DEMO_TRUSTED_PROXY_COUNT=1`. Runbook has the gcloud commands.

### What's deliberately not in this PR

- **Cloud Tasks dispatcher** (m5b, child issue follows). `inkwell.demo.cloud_tasks` will implement the m3 `Dispatcher` protocol and lazy-import `google-cloud-tasks`; adds it as an optional `[gcp]` extra. The in-process dispatcher remains the default for local dev.
- **Production smoke test** is m6 ([OBRA-80](/OBRA/issues/OBRA-80)).

### Test plan

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy src/`
- [x] `uv run pytest tests/unit/ -q`
- [ ] CI `build` job verifies the Docker image starts and serves `/healthz` (will run against this PR).
- [ ] PR preview deploy will be exercised once Lucas provisions GCP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)