### PR TITLE
[codex] Fix import submit pending state

### DIFF
--- a/apps/web/src/components/ImportCommand.test.tsx
+++ b/apps/web/src/components/ImportCommand.test.tsx
@@ -1,0 +1,86 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ImportCommand } from "@/components/ImportCommand";
+
+const { push } = vi.hoisted(() => ({
+  push: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+describe("ImportCommand", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("disables the form immediately and prevents duplicate import requests", async () => {
+    let resolveFetch: (response: Response) => void = () => undefined;
+    const fetchMock = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ImportCommand />);
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Source URL" }), {
+      target: { value: "https://example.com/episode.mp3" },
+    });
+
+    const input = screen.getByRole("textbox", { name: "Source URL" });
+    const button = screen.getByRole("button", { name: "Start import" });
+    const form = button.closest("form");
+    expect(form).not.toBeNull();
+
+    fireEvent.submit(form!);
+    fireEvent.submit(form!);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(input).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Creating import..." })).toBeDisabled();
+    expect(screen.getByRole("status")).toHaveTextContent("Creating import job");
+    expect(form).toHaveAttribute("aria-busy", "true");
+
+    await act(async () => {
+      resolveFetch(
+        new Response(JSON.stringify({ statusUrl: "/app/jobs/job-1" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(push).toHaveBeenCalledWith("/app/jobs/job-1");
+    });
+  });
+
+  it("re-enables the form when the import API fails", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: "Could not create the import job." }), {
+        status: 500,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ImportCommand />);
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Source URL" }), {
+      target: { value: "https://example.com/episode.mp3" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Start import" }));
+
+    expect(screen.getByRole("button", { name: "Creating import..." })).toBeDisabled();
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Could not create the import job.");
+    expect(screen.getByRole("button", { name: "Start import" })).toBeEnabled();
+    expect(screen.getByRole("textbox", { name: "Source URL" })).toBeEnabled();
+  });
+});

--- a/apps/web/src/components/ImportCommand.tsx
+++ b/apps/web/src/components/ImportCommand.tsx
@@ -2,7 +2,7 @@
 
 import { ArrowRight, Link2, Loader2, Radio, Sparkles } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useMemo, useState, useTransition } from "react";
+import { useMemo, useRef, useState, useTransition } from "react";
 
 import { detectSourceKind, sourceKindLabel } from "@/lib/source";
 
@@ -25,13 +25,21 @@ export function ImportCommand({
   const [url, setUrl] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const submittingRef = useRef(false);
   const [isPending, startTransition] = useTransition();
 
   const sourceKind = useMemo(() => detectSourceKind(url), [url]);
   const sourceLabel = sourceKindLabel(sourceKind);
+  const isBusy = isSubmitting || isPending;
 
   async function submit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
+
+    if (submittingRef.current) {
+      return;
+    }
+
     setError(null);
     setNotice(null);
 
@@ -43,22 +51,34 @@ export function ImportCommand({
       return;
     }
 
-    const response = await fetch("/api/imports", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ url: normalizedUrl }),
-    });
+    submittingRef.current = true;
+    setIsSubmitting(true);
 
-    const payload = (await response.json()) as ImportPayload;
+    let response: Response;
+    let payload: ImportPayload;
+
+    try {
+      response = await fetch("/api/imports", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ url: normalizedUrl }),
+      });
+      payload = (await response.json()) as ImportPayload;
+    } catch {
+      submittingRef.current = false;
+      setIsSubmitting(false);
+      setError("Could not reach Inkwell. Check your connection and try again.");
+      return;
+    }
 
     if (!response.ok || !payload.statusUrl) {
+      submittingRef.current = false;
+      setIsSubmitting(false);
       setError(payload.error ?? "Could not create the import job.");
       return;
     }
 
-    if (payload.dispatchReason) {
-      setNotice(payload.dispatchReason);
-    }
+    setNotice(payload.dispatchReason ?? "Import job created. Opening the status page.");
 
     startTransition(() => {
       router.push(payload.statusUrl!);
@@ -66,7 +86,7 @@ export function ImportCommand({
   }
 
   return (
-    <form onSubmit={submit} className={variant === "full" ? "space-y-5" : "space-y-4"}>
+    <form aria-busy={isBusy} onSubmit={submit} className={variant === "full" ? "space-y-5" : "space-y-4"}>
       <div className="flex items-start gap-3">
         <span className="grid size-10 shrink-0 place-items-center rounded-sm bg-accent/10 text-accent">
           <Sparkles aria-hidden="true" className="size-5" />
@@ -84,11 +104,13 @@ export function ImportCommand({
           <input
             id="source-url"
             type="url"
+            aria-label="Source URL"
             required
             value={url}
+            disabled={isBusy}
             onChange={(event) => setUrl(event.target.value)}
             placeholder="https://www.youtube.com/watch?v=..."
-            className="min-w-0 flex-1 bg-transparent text-base outline-none placeholder:text-muted/70"
+            className="min-w-0 flex-1 bg-transparent text-base outline-none placeholder:text-muted/70 disabled:cursor-not-allowed disabled:text-muted"
           />
           {sourceKind !== "unknown" ? (
             <span className="hidden shrink-0 rounded-sm border border-border bg-surface px-2 py-1 text-xs font-semibold text-muted sm:inline-flex">
@@ -114,6 +136,11 @@ export function ImportCommand({
           {error}
         </p>
       ) : null}
+      {isSubmitting ? (
+        <p role="status" className="border border-accent/30 bg-accent/10 px-3 py-2 text-sm font-medium text-accent">
+          Creating import job. The worker will open on the status page when it is ready.
+        </p>
+      ) : null}
       {notice ? (
         <p role="status" className="border border-warning/30 bg-warning/10 px-3 py-2 text-sm font-medium text-warning">
           {notice}
@@ -122,11 +149,11 @@ export function ImportCommand({
 
       <button
         type="submit"
-        disabled={isPending}
+        disabled={isBusy}
         className="inline-flex h-11 items-center justify-center gap-2 rounded-sm bg-accent px-4 text-sm font-semibold text-accent-foreground transition hover:bg-accent-strong disabled:cursor-not-allowed disabled:opacity-60"
       >
-        {isPending ? <Loader2 aria-hidden="true" className="size-4 animate-spin" /> : <ArrowRight aria-hidden="true" className="size-4" />}
-        {isPending ? "Creating job..." : "Start import"}
+        {isBusy ? <Loader2 aria-hidden="true" className="size-4 animate-spin" /> : <ArrowRight aria-hidden="true" className="size-4" />}
+        {isBusy ? "Creating import..." : "Start import"}
       </button>
     </form>
   );


### PR DESCRIPTION
## Summary
- Disable the import form immediately while /api/imports is in flight
- Add visible pending feedback so users know the job is being created
- Add a regression test that submits twice during a pending request and asserts only one backend call is made

## Verification
- pnpm --filter web test -- ImportCommand
- pnpm web:test
- pnpm web:lint
- pnpm web:build
- git diff --check
- pre-push pytest hook
- Browser QA on /qa-import temporary local route, removed before commit: pending state showed disabled URL field, disabled Creating import button, aria-busy=true, and no console warnings/errors