### PR TITLE
Add Codex PR review defaults

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,8 @@
 
 -
 
+/cc @codex
+
 ## Validation
 
 - [ ] `uv run ruff check .`
@@ -17,6 +19,8 @@
 
 ## Agent Review
 
+- [ ] @codex review clean (no unresolved comments)
+- [ ] Ready for Sergio's merge approval
 - [ ] Code quality review requested when behavior changed
 - [ ] Security/data-integrity review requested when credentials, files, paths, or external input changed
 - [ ] Docs/release review requested when packaging, CI, or public docs changed

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,0 +1,43 @@
+name: Request Codex Review
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  tag-codex:
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment with Codex review request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = "/cc @codex";
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const alreadyTagged = comments.some((comment) =>
+              comment.user?.type === "Bot" && comment.body?.includes(marker)
+            );
+
+            if (!alreadyTagged) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body: marker,
+              });
+            }


### PR DESCRIPTION
## Summary

Adds the Obra-wide PR defaults for Codex review:

- Adds `/cc @codex` to the PR template
- Adds `@codex review clean` and Sergio merge approval checklist items
- Adds a `pull_request_target` workflow that comments `/cc @codex` on opened, reopened, and ready-for-review PRs

/cc @codex

## Validation

- [x] `git diff --check`
- [x] Workflow YAML parsed with Ruby `YAML.load_file`
- [ ] @codex review clean (no unresolved comments)
- [ ] Ready for Sergio's merge approval\n\n## Notes\n\nThe workflow does not checkout or run pull request code. It only reads existing PR comments and creates the Codex trigger comment when missing.