### PR TITLE
Allow Codex review workflow to write PR comments

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -7,7 +7,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   tag-codex:


### PR DESCRIPTION
## Summary

Updates the Codex review-request workflow token permissions so the action can create the `/cc @codex` PR comment.

/cc @codex

## Validation

- [x] `git diff --check`
- [x] Workflow YAML parsed with Ruby `YAML.load_file`
- [ ] @codex review clean (no unresolved comments)
- [ ] Ready for Sergio's merge approval