### PR TITLE
feat: add input resolver foundation

### DIFF
--- a/docs/building-in-public/devlog/2026-05-21-summarize-inspired-cli-foundation.md
+++ b/docs/building-in-public/devlog/2026-05-21-summarize-inspired-cli-foundation.md
@@ -1,0 +1,33 @@
+# Summarize-Inspired CLI Foundation
+
+**Date:** 2026-05-21
+**Author:** Codex
+
+## Focus
+
+Start the first phase of the summarize-inspired CLI evolution by adding a conservative input-resolution foundation without changing Inkwell's core identity or feed behavior.
+
+## Progress
+
+- Read the summarize architecture research, universal ingestion roadmap, multi-export roadmap, CLI, pipeline, transcription, extraction, cache, and audio downloader code.
+- Scoped this pass to Phase 1: `InputResolver` / `ContentSource` models, CLI classification cleanup, and focused unit tests.
+- Added `src/inkwell/ingestion/` with conservative source kinds for saved feeds, URLs, local files, stdin, direct media, YouTube, and unknown URLs.
+- Wired `inkwell fetch` to use the resolver for URL normalization/classification while keeping `ConfigManager.get_feed()` as the authority for saved-feed lookup.
+- Added tests for resolver behavior and fetch handling of recognized-but-not-yet-routed local file/stdin inputs.
+- Preserved later phases as follow-up work: machine-readable output, cache key migration, media cache policy, extract-only mode, local/stdin ingestion routing, and provider attempt policy.
+
+## Observations
+
+The current `fetch` command already has several careful direct-URL behaviors, especially YouTube pre-resolution and `--save-feed` validation. The safest foundation is a small classification layer that makes those decisions explicit while leaving RSS episode selection and pipeline processing untouched.
+
+## Next
+
+Move to Phase 2: add machine-readable output modes for `fetch` and `transcribe`, with primary JSON/plain output on stdout and progress/warnings on stderr.
+
+## Links
+
+- Related research: summarize CLI architecture analysis from task context
+- Related roadmap: `../../../2026-roadmap/03-universal-content-ingestion.md`
+- Related roadmap: `../../../2026-roadmap/09-multi-export-system.md`
+- PR: TBD
+- Issue: TBD

--- a/src/inkwell/cli.py
+++ b/src/inkwell/cli.py
@@ -27,6 +27,7 @@ from inkwell.feeds.youtube_resolver import (
     is_youtube_url,
     resolve_youtube_url,
 )
+from inkwell.ingestion import ContentSourceKind, InputResolver
 from inkwell.pipeline import PipelineOptions, PipelineOrchestrator
 from inkwell.transcription import CostEstimate, TranscriptionManager
 from inkwell.utils.datetime import now_utc
@@ -910,18 +911,15 @@ def fetch_command(
                     ),
                 )
 
-            # Normalize scheme-less URL-shaped inputs up-front so the
-            # --save-feed guard and the feed-name lookup both see the same
-            # URL. Feed names never contain both `.` and `/`, so this is
-            # unambiguous. Without this, `www.youtube.com/watch?v=X
-            # --save-feed` would be rejected as "not YouTube" even though
-            # the same input works in plain fetch mode.
-            if (
-                not url_or_feed.startswith(("http://", "https://"))
-                and "." in url_or_feed
-                and "/" in url_or_feed
-            ):
-                url_or_feed = f"https://{url_or_feed}"
+            input_source = InputResolver().resolve(url_or_feed)
+            if input_source.is_url and input_source.url:
+                # Normalize scheme-less URL-shaped inputs up-front so the
+                # --save-feed guard and the feed-name lookup both see the same
+                # URL. Feed names never contain both `.` and `/`, so this is
+                # unambiguous. Without this, `www.youtube.com/watch?v=X
+                # --save-feed` would be rejected as "not YouTube" even though
+                # the same input works in plain fetch mode.
+                url_or_feed = input_source.url
 
             # Resolve feed name to episode URL if needed
             url = url_or_feed
@@ -936,7 +934,7 @@ def fetch_command(
             # out into its episodes); stays None for direct-URL mode.
             selected_episodes: list[Episode] | None = None
 
-            is_url = url_or_feed.startswith(("http://", "https://"))
+            is_url = input_source.is_url
 
             if is_url and count is not None:
                 raise ValidationError(
@@ -987,7 +985,29 @@ def fetch_command(
                 # Treat as feed name - look up in configured feeds
                 try:
                     feed_config = manager.get_feed(url_or_feed)
-                except NotFoundError:
+                except NotFoundError as e:
+                    if input_source.kind == ContentSourceKind.STDIN:
+                        raise ValidationError(
+                            "Stdin ingestion is recognized but not supported by fetch yet",
+                            suggestion=(
+                                "Use a saved feed or media URL for now. Stdin routing is planned "
+                                "for the local/stdin ingestion phase."
+                            ),
+                        ) from e
+                    if input_source.kind == ContentSourceKind.LOCAL_FILE:
+                        raise ValidationError(
+                            "Local file ingestion is recognized but not supported by fetch yet",
+                            suggestion=(
+                                "Use a saved feed or media URL for now. Local audio/video routing "
+                                "is planned for the local/stdin ingestion phase."
+                            ),
+                        ) from e
+                    if input_source.kind == ContentSourceKind.UNKNOWN_URL:
+                        raise ValidationError(
+                            f"Unsupported URL input: {input_source.value}",
+                            suggestion="Use an http(s) media URL or a saved feed name.",
+                        ) from e
+
                     console.print(f"[red]✗[/red] Feed '{url_or_feed}' not found.")
                     console.print("  Use [cyan]inkwell list[/cyan] to see configured feeds.")
                     console.print("  Or provide a direct episode URL.")

--- a/src/inkwell/ingestion/__init__.py
+++ b/src/inkwell/ingestion/__init__.py
@@ -1,0 +1,5 @@
+"""Input classification primitives for Inkwell ingestion."""
+
+from .resolver import ContentSource, ContentSourceKind, InputResolver
+
+__all__ = ["ContentSource", "ContentSourceKind", "InputResolver"]

--- a/src/inkwell/ingestion/resolver.py
+++ b/src/inkwell/ingestion/resolver.py
@@ -1,0 +1,195 @@
+"""Conservative input classification for CLI ingestion.
+
+This module intentionally stops at classification. It does not fetch RSS feeds,
+open local files, read stdin, or route content through extraction. Those are
+separate phases once the source model is stable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from inkwell.config.manager import slugify_feed_name
+
+
+class ContentSourceKind(str, Enum):
+    """Kinds of raw input Inkwell can recognize before processing."""
+
+    SAVED_FEED = "saved_feed"
+    URL = "url"
+    LOCAL_FILE = "local_file"
+    STDIN = "stdin"
+    DIRECT_MEDIA = "direct_media"
+    YOUTUBE = "youtube"
+    UNKNOWN_URL = "unknown_url"
+
+
+@dataclass(frozen=True)
+class ContentSource:
+    """Classified user input.
+
+    `value` is the normalized input to pass downstream when the source kind is
+    already processable by the existing pipeline. For saved feeds, it remains
+    the feed reference supplied by the user so `ConfigManager.get_feed()` can
+    preserve its display-name and fuzzy matching behavior.
+    """
+
+    raw_input: str
+    kind: ContentSourceKind
+    value: str
+    url: str | None = None
+    path: Path | None = None
+    feed_name: str | None = None
+    is_existing_feed: bool = False
+
+    @property
+    def is_url(self) -> bool:
+        """Return True for URL inputs currently accepted by the fetch pipeline."""
+        return self.kind in {
+            ContentSourceKind.URL,
+            ContentSourceKind.DIRECT_MEDIA,
+            ContentSourceKind.YOUTUBE,
+        }
+
+
+class InputResolver:
+    """Classify raw CLI input into a conservative `ContentSource`.
+
+    The resolver may receive known saved feeds to identify a feed reference, but
+    callers can omit them to avoid reading feed config before direct URL work.
+    """
+
+    _MEDIA_EXTENSIONS = {
+        ".aac",
+        ".aif",
+        ".aiff",
+        ".avi",
+        ".flac",
+        ".m4a",
+        ".m4v",
+        ".mkv",
+        ".mov",
+        ".mp3",
+        ".mp4",
+        ".mpeg",
+        ".mpg",
+        ".oga",
+        ".ogg",
+        ".opus",
+        ".wav",
+        ".webm",
+    }
+    _YOUTUBE_HOSTS = {"youtu.be", "youtube.com", "www.youtube.com", "m.youtube.com"}
+    _SUPPORTED_URL_SCHEMES = {"http", "https"}
+
+    def __init__(self, saved_feeds: dict[str, Any] | None = None) -> None:
+        """Initialize the resolver.
+
+        Args:
+            saved_feeds: Optional mapping of canonical feed names to feed configs.
+                Values may expose a `display_name` attribute.
+        """
+        self._saved_feeds = saved_feeds or {}
+
+    def resolve(self, raw_input: str) -> ContentSource:
+        """Classify raw user input without performing I/O beyond path checks."""
+        value = raw_input.strip()
+
+        if value == "-":
+            return ContentSource(
+                raw_input=raw_input,
+                kind=ContentSourceKind.STDIN,
+                value=value,
+            )
+
+        feed_name = self._resolve_saved_feed_name(value)
+        if feed_name is not None:
+            return ContentSource(
+                raw_input=raw_input,
+                kind=ContentSourceKind.SAVED_FEED,
+                value=value,
+                feed_name=feed_name,
+                is_existing_feed=True,
+            )
+
+        local_path = Path(value).expanduser()
+        if local_path.is_file():
+            return ContentSource(
+                raw_input=raw_input,
+                kind=ContentSourceKind.LOCAL_FILE,
+                value=str(local_path),
+                path=local_path,
+            )
+
+        normalized_url = self._normalize_scheme_less_url(value)
+        parsed = urlparse(normalized_url)
+
+        if parsed.scheme:
+            if parsed.scheme not in self._SUPPORTED_URL_SCHEMES or not parsed.netloc:
+                return ContentSource(
+                    raw_input=raw_input,
+                    kind=ContentSourceKind.UNKNOWN_URL,
+                    value=normalized_url,
+                    url=normalized_url,
+                )
+
+            kind = self._classify_supported_url(parsed.netloc, parsed.path)
+            return ContentSource(
+                raw_input=raw_input,
+                kind=kind,
+                value=normalized_url,
+                url=normalized_url,
+            )
+
+        # Preserve existing fetch behavior: non-URL tokens are feed references.
+        return ContentSource(
+            raw_input=raw_input,
+            kind=ContentSourceKind.SAVED_FEED,
+            value=value,
+            feed_name=value,
+            is_existing_feed=False,
+        )
+
+    def _resolve_saved_feed_name(self, value: str) -> str | None:
+        """Return canonical feed name when the input matches known feeds."""
+        if value in self._saved_feeds:
+            return value
+
+        normalized = slugify_feed_name(value)
+        if normalized in self._saved_feeds:
+            return normalized
+
+        for feed_name, feed_config in self._saved_feeds.items():
+            display_name = getattr(feed_config, "display_name", None)
+            if not display_name:
+                continue
+            if value.casefold() == display_name.casefold():
+                return feed_name
+            if normalized and normalized == slugify_feed_name(display_name):
+                return feed_name
+
+        return None
+
+    def _normalize_scheme_less_url(self, value: str) -> str:
+        """Mirror fetch's historic `example.com/path` URL normalization."""
+        if urlparse(value).scheme:
+            return value
+        if "." in value and "/" in value:
+            return f"https://{value}"
+        return value
+
+    def _classify_supported_url(self, host: str, path: str) -> ContentSourceKind:
+        """Classify a normalized HTTP(S) URL."""
+        normalized_host = host.lower()
+        if normalized_host in self._YOUTUBE_HOSTS:
+            return ContentSourceKind.YOUTUBE
+
+        suffix = Path(path.lower()).suffix
+        if suffix in self._MEDIA_EXTENSIONS:
+            return ContentSourceKind.DIRECT_MEDIA
+
+        return ContentSourceKind.URL

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1095,6 +1095,47 @@ class TestCLIFetchSaveFeed:
         assert result.exit_code != 0
         assert "Playlist" in result.stdout or "playlist" in result.stdout
 
+    def test_fetch_local_file_is_recognized_but_not_processed_yet(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Phase 1 recognizes local files without routing them through fetch yet."""
+        monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
+
+        local_media = tmp_path / "episode.mp3"
+        local_media.write_bytes(b"fake audio")
+
+        result = runner.invoke(
+            app,
+            [
+                "fetch",
+                str(local_media),
+                "--dry-run",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "Local file ingestion is recognized" in result.output
+        assert "saved feed or media URL" in result.output
+
+    def test_fetch_stdin_is_recognized_but_not_processed_yet(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Phase 1 recognizes stdin without introducing text ingestion yet."""
+        monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
+
+        result = runner.invoke(
+            app,
+            [
+                "fetch",
+                "-",
+                "--dry-run",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "Stdin ingestion is recognized" in result.output
+        assert "saved feed or media URL" in result.output
+
 
 class TestCLIFetchHintSuppression:
     """The --save-feed hint must not fire when the fetch itself failed."""

--- a/tests/unit/test_input_resolver.py
+++ b/tests/unit/test_input_resolver.py
@@ -1,0 +1,89 @@
+"""Tests for input classification primitives."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from inkwell.ingestion import ContentSourceKind, InputResolver
+
+
+def test_resolves_stdin_marker() -> None:
+    source = InputResolver().resolve("-")
+
+    assert source.kind == ContentSourceKind.STDIN
+    assert source.value == "-"
+    assert source.url is None
+
+
+def test_resolves_existing_local_file(tmp_path: Path) -> None:
+    media_file = tmp_path / "episode.mp3"
+    media_file.write_bytes(b"fake audio")
+
+    source = InputResolver().resolve(str(media_file))
+
+    assert source.kind == ContentSourceKind.LOCAL_FILE
+    assert source.path == media_file
+    assert source.value == str(media_file)
+
+
+def test_resolves_youtube_url() -> None:
+    source = InputResolver().resolve("https://www.youtube.com/watch?v=abc123")
+
+    assert source.kind == ContentSourceKind.YOUTUBE
+    assert source.is_url is True
+    assert source.url == "https://www.youtube.com/watch?v=abc123"
+
+
+def test_resolves_scheme_less_youtube_url() -> None:
+    source = InputResolver().resolve("www.youtube.com/watch?v=abc123")
+
+    assert source.kind == ContentSourceKind.YOUTUBE
+    assert source.url == "https://www.youtube.com/watch?v=abc123"
+    assert source.value == "https://www.youtube.com/watch?v=abc123"
+
+
+def test_resolves_direct_media_url() -> None:
+    source = InputResolver().resolve("https://example.com/podcast/episode.m4a?download=1")
+
+    assert source.kind == ContentSourceKind.DIRECT_MEDIA
+    assert source.is_url is True
+
+
+def test_resolves_generic_http_url() -> None:
+    source = InputResolver().resolve("https://example.com/articles/how-to-learn")
+
+    assert source.kind == ContentSourceKind.URL
+    assert source.is_url is True
+
+
+def test_resolves_unknown_url_scheme() -> None:
+    source = InputResolver().resolve("ftp://example.com/episode.mp3")
+
+    assert source.kind == ContentSourceKind.UNKNOWN_URL
+    assert source.is_url is False
+    assert source.url == "ftp://example.com/episode.mp3"
+
+
+def test_resolves_known_saved_feed_by_key() -> None:
+    source = InputResolver(saved_feeds={"my-feed": object()}).resolve("my-feed")
+
+    assert source.kind == ContentSourceKind.SAVED_FEED
+    assert source.feed_name == "my-feed"
+    assert source.is_existing_feed is True
+
+
+def test_resolves_known_saved_feed_by_display_name() -> None:
+    source = InputResolver(
+        saved_feeds={"omw": SimpleNamespace(display_name="Oren Meets World")}
+    ).resolve("oren meets world")
+
+    assert source.kind == ContentSourceKind.SAVED_FEED
+    assert source.feed_name == "omw"
+    assert source.is_existing_feed is True
+
+
+def test_unrecognized_token_stays_feed_reference() -> None:
+    source = InputResolver().resolve("maybe-a-feed")
+
+    assert source.kind == ContentSourceKind.SAVED_FEED
+    assert source.feed_name == "maybe-a-feed"
+    assert source.is_existing_feed is False


### PR DESCRIPTION
## Summary
- Added the InputResolver / ContentSource foundation for future universal ingestion work.
- Preserved existing feed/direct URL behavior.
- Added focused tests for input classification and compatibility.

## Tests
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run pytest tests/unit/test_input_resolver.py tests/integration/test_cli.py`
- `uv run pytest`

## Follow-up
- Phase 2: JSON/plain output envelope for fetch/transcribe.
- Phase 3: cache key/version cleanup and bounded media cache.