### PR TITLE
feat: improve cache keys and observability

### DIFF
--- a/docs/building-in-public/devlog/2026-05-21-cache-key-observability.md
+++ b/docs/building-in-public/devlog/2026-05-21-cache-key-observability.md
@@ -1,0 +1,35 @@
+# Cache Key And Observability Cleanup
+
+**Date:** 2026-05-21
+**Author:** Codex
+
+## Focus
+
+Implement Phase 3 of the summarize-inspired CLI evolution: make cache formats explicit, improve extraction cache key inputs, and expose broader cache observability without changing media retention policy yet.
+
+## Plan
+
+- Add explicit cache format version constants for transcript and extraction caches.
+- Extend extraction cache keys with transcript hash, template identity, provider/model, prompt/template hash, and output schema version.
+- Preserve existing cache files as safe misses when new key metadata is used.
+- Expand cache stats so `inkwell cache stats` can report transcript, extraction, and audio/media cache sections.
+- Keep TTL/size enforcement for media cache out of scope for the next phase.
+
+## Notes
+
+This phase should be a compatibility cleanup, not a cache eviction feature. Existing transcript and extraction entries must not be rewritten or corrupted just because key inputs changed.
+
+## Progress
+
+- Added explicit cache format version constants for transcript, extraction, and audio/media caches.
+- Extended extraction cache keys with versioned metadata for transcript hash, template identity, provider/model, prompt hash, and output schema identity.
+- Added cache stats for extraction and media caches alongside existing transcript cache stats.
+- Documented the expanded `inkwell cache stats` output in the CLI reference.
+- Verified focused cache/CLI tests and the full test suite locally.
+
+## Links
+
+- Related devlog: `./2026-05-21-machine-readable-output.md`
+- Related roadmap: `../../../2026-roadmap/03-universal-content-ingestion.md`
+- PR: TBD
+- Issue: TBD

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -200,6 +200,34 @@ inkwell transcribe https://youtube.com/watch?v=xyz --plain
 
 ---
 
+## inkwell cache
+
+Inspect and manage local caches.
+
+```bash
+inkwell cache <ACTION>
+```
+
+### Actions
+
+| Action | Description |
+|--------|-------------|
+| `stats` | Show transcript, extraction, and media cache statistics |
+| `clear` | Clear cached transcripts |
+| `clear-expired` | Remove expired cached transcripts |
+
+### Examples
+
+```bash
+inkwell cache stats
+inkwell cache clear-expired
+inkwell cache clear
+```
+
+`stats` is observational only. Media cache retention controls are planned separately.
+
+---
+
 ## inkwell fetch
 
 Process podcast episodes.

--- a/src/inkwell/audio/__init__.py
+++ b/src/inkwell/audio/__init__.py
@@ -1,8 +1,9 @@
 """Audio download module for Inkwell."""
 
-from inkwell.audio.downloader import AudioDownloader, DownloadProgress
+from inkwell.audio.downloader import AUDIO_CACHE_FORMAT_VERSION, AudioDownloader, DownloadProgress
 
 __all__ = [
+    "AUDIO_CACHE_FORMAT_VERSION",
     "AudioDownloader",
     "DownloadProgress",
 ]

--- a/src/inkwell/audio/downloader.py
+++ b/src/inkwell/audio/downloader.py
@@ -16,6 +16,8 @@ from inkwell.utils.errors import APIError
 
 logger = logging.getLogger(__name__)
 
+AUDIO_CACHE_FORMAT_VERSION = 1
+
 
 class DownloadProgress(BaseModel):
     """Progress information for audio download."""
@@ -60,10 +62,50 @@ class AudioDownloader:
         self.output_dir = output_dir or Path.cwd() / "downloads"
         self.output_dir.mkdir(parents=True, exist_ok=True)
 
-        self.cache_dir = cache_dir or Path(platformdirs.user_cache_dir("inkwell")) / "audio"
+        self.cache_dir = cache_dir or self.default_cache_dir()
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
         self.progress_callback = progress_callback
+
+    @staticmethod
+    def default_cache_dir() -> Path:
+        """Return the default audio/media cache directory."""
+        return Path(platformdirs.user_cache_dir("inkwell")) / "audio"
+
+    @classmethod
+    def cache_stats(cls, cache_dir: Path | None = None) -> dict[str, Any]:
+        """Get audio/media cache statistics without enforcing retention policy."""
+        resolved_cache_dir = cache_dir or cls.default_cache_dir()
+
+        if not resolved_cache_dir.exists():
+            return {
+                "total": 0,
+                "size_bytes": 0,
+                "cache_dir": str(resolved_cache_dir),
+                "cache_format_version": AUDIO_CACHE_FORMAT_VERSION,
+                "extensions": {},
+            }
+
+        cache_files = [path for path in resolved_cache_dir.iterdir() if path.is_file()]
+        total_size = 0
+        extensions: dict[str, int] = {}
+
+        for cache_file in cache_files:
+            try:
+                stat_result = cache_file.stat()
+            except OSError:
+                continue
+            total_size += stat_result.st_size
+            extension = cache_file.suffix.lower() or "<none>"
+            extensions[extension] = extensions.get(extension, 0) + 1
+
+        return {
+            "total": len(cache_files),
+            "size_bytes": total_size,
+            "cache_dir": str(resolved_cache_dir),
+            "cache_format_version": AUDIO_CACHE_FORMAT_VERSION,
+            "extensions": extensions,
+        }
 
     def _get_cache_path(self, url: str) -> Path:
         """Get cached audio file path for a URL.

--- a/src/inkwell/cli.py
+++ b/src/inkwell/cli.py
@@ -969,7 +969,12 @@ def cache_command(
         manager = TranscriptionManager()
 
         if action == "stats":
+            from inkwell.audio.downloader import AudioDownloader
+            from inkwell.extraction.cache import ExtractionCache
+
             stats = manager.cache_stats()
+            extraction_stats = asyncio.run(ExtractionCache().get_stats())
+            audio_stats = AudioDownloader.cache_stats()
 
             console.print("\n[bold]Transcript Cache Statistics[/bold]\n")
 
@@ -981,6 +986,7 @@ def cache_command(
             table.add_row("Valid", str(stats["valid"]))
             table.add_row("Expired", str(stats["expired"]))
             table.add_row("Size", f"{stats['size_bytes'] / 1024 / 1024:.2f} MB")
+            table.add_row("Format version", str(stats.get("cache_format_version", "unknown")))
             table.add_row("Cache directory", stats["cache_dir"])
 
             console.print(table)
@@ -989,6 +995,57 @@ def cache_command(
                 console.print("\n[bold]By Source:[/bold]")
                 for source, count in stats["sources"].items():
                     console.print(f"  • {source}: {count}")
+
+            console.print("\n[bold]Extraction Cache Statistics[/bold]\n")
+
+            extraction_table = Table(show_header=False, box=None)
+            extraction_table.add_column("Key", style="cyan")
+            extraction_table.add_column("Value", style="white")
+
+            extraction_table.add_row("Total entries", str(extraction_stats["total_entries"]))
+            extraction_table.add_row("Size", f"{extraction_stats['total_size_mb']:.2f} MB")
+            extraction_table.add_row(
+                "Oldest entry age",
+                f"{extraction_stats['oldest_entry_age_days']:.1f} days",
+            )
+            extraction_table.add_row(
+                "Format version",
+                str(extraction_stats.get("cache_format_version", "unknown")),
+            )
+            extraction_table.add_row("Cache directory", extraction_stats["cache_dir"])
+
+            console.print(extraction_table)
+
+            if extraction_stats["templates"]:
+                console.print("\n[bold]By Template:[/bold]")
+                for template_name, count in extraction_stats["templates"].items():
+                    console.print(f"  • {template_name}: {count}")
+
+            if extraction_stats["providers"]:
+                console.print("\n[bold]By Provider:[/bold]")
+                for provider_name, count in extraction_stats["providers"].items():
+                    console.print(f"  • {provider_name}: {count}")
+
+            console.print("\n[bold]Media Cache Statistics[/bold]\n")
+
+            media_table = Table(show_header=False, box=None)
+            media_table.add_column("Key", style="cyan")
+            media_table.add_column("Value", style="white")
+
+            media_table.add_row("Total files", str(audio_stats["total"]))
+            media_table.add_row("Size", f"{audio_stats['size_bytes'] / 1024 / 1024:.2f} MB")
+            media_table.add_row(
+                "Format version",
+                str(audio_stats.get("cache_format_version", "unknown")),
+            )
+            media_table.add_row("Cache directory", audio_stats["cache_dir"])
+
+            console.print(media_table)
+
+            if audio_stats["extensions"]:
+                console.print("\n[bold]By Extension:[/bold]")
+                for extension, count in audio_stats["extensions"].items():
+                    console.print(f"  • {extension}: {count}")
 
         elif action == "clear":
             confirm: bool = typer.confirm(

--- a/src/inkwell/extraction/__init__.py
+++ b/src/inkwell/extraction/__init__.py
@@ -7,7 +7,11 @@ Note: ExtractionEngine uses lazy import to avoid circular dependency with
 inkwell.plugins.types.extraction (which imports BaseExtractor from this package).
 """
 
-from .cache import ExtractionCache
+from .cache import (
+    EXTRACTION_CACHE_FORMAT_VERSION,
+    EXTRACTION_OUTPUT_SCHEMA_VERSION,
+    ExtractionCache,
+)
 from .models import (
     ExtractedContent,
     ExtractionResult,
@@ -21,6 +25,8 @@ __all__ = [
     "ExtractedContent",
     "ExtractionResult",
     "ExtractionCache",
+    "EXTRACTION_CACHE_FORMAT_VERSION",
+    "EXTRACTION_OUTPUT_SCHEMA_VERSION",
     "ExtractionEngine",
 ]
 

--- a/src/inkwell/extraction/cache.py
+++ b/src/inkwell/extraction/cache.py
@@ -4,6 +4,7 @@ Provides file-based caching with TTL to avoid redundant LLM API calls.
 """
 
 import hashlib
+import json
 import logging
 import time
 from pathlib import Path
@@ -16,7 +17,15 @@ from inkwell.utils.cache import FileCache
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["ExtractionCache"]
+EXTRACTION_CACHE_FORMAT_VERSION = 2
+EXTRACTION_OUTPUT_SCHEMA_VERSION = "extraction-result:v1"
+UNKNOWN_CACHE_KEY_PART = "unknown"
+
+__all__ = [
+    "EXTRACTION_CACHE_FORMAT_VERSION",
+    "EXTRACTION_OUTPUT_SCHEMA_VERSION",
+    "ExtractionCache",
+]
 
 
 class ExtractionCache:
@@ -60,23 +69,76 @@ class ExtractionCache:
 
         self.ttl_seconds = ttl_days * 24 * 60 * 60
 
-    def _make_key(self, template_name: str, template_version: str, transcript: str) -> str:
+    @staticmethod
+    def _hash_text(value: str) -> str:
+        """Hash text content for cache-key metadata."""
+        return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _canonical_json(data: dict[str, Any]) -> str:
+        """Serialize cache-key metadata deterministically."""
+        return json.dumps(data, sort_keys=True, separators=(",", ":"))
+
+    def _key_components(
+        self,
+        template_name: str,
+        template_version: str,
+        transcript: str,
+        provider: str | None = None,
+        model: str | None = None,
+        prompt_hash: str | None = None,
+        output_schema_version: str | None = None,
+    ) -> dict[str, Any]:
+        """Build explicit extraction cache-key inputs."""
+        return {
+            "cache_format_version": EXTRACTION_CACHE_FORMAT_VERSION,
+            "transcript_hash": self._hash_text(transcript),
+            "template_name": template_name,
+            "template_version": template_version,
+            "provider": provider or UNKNOWN_CACHE_KEY_PART,
+            "model": model or UNKNOWN_CACHE_KEY_PART,
+            "prompt_hash": prompt_hash or UNKNOWN_CACHE_KEY_PART,
+            "output_schema_version": output_schema_version or EXTRACTION_OUTPUT_SCHEMA_VERSION,
+        }
+
+    def _make_key(
+        self,
+        template_name: str,
+        template_version: str,
+        transcript: str,
+        provider: str | None = None,
+        model: str | None = None,
+        prompt_hash: str | None = None,
+        output_schema_version: str | None = None,
+    ) -> str:
         """Generate cache key from template and transcript.
 
-        Includes template version so cache is invalidated when template changes.
+        Includes explicit versioned key inputs so cache entries are invalidated
+        when template prompts, provider/model routing, transcript content, or
+        output schema expectations change.
 
         Args:
             template_name: Template name
             template_version: Template version
             transcript: Transcript text
+            provider: LLM provider used or selected
+            model: Provider model used or selected
+            prompt_hash: Hash of prompt/template content
+            output_schema_version: Output schema identifier
 
         Returns:
             Cache key (hex string)
         """
-        # Include template name, version, and transcript hash
-        # This ensures cache invalidation when template changes
-        content = f"{template_name}:{template_version}:{transcript}"
-        return hashlib.sha256(content.encode()).hexdigest()
+        payload = self._key_components(
+            template_name,
+            template_version,
+            transcript,
+            provider,
+            model,
+            prompt_hash,
+            output_schema_version,
+        )
+        return self._hash_text(self._canonical_json(payload))
 
     def _serialize_result(self, result: str) -> dict[str, Any]:
         """Serialize extraction result to dict for JSON storage.
@@ -88,6 +150,7 @@ class ExtractionCache:
             Dictionary with result and timestamp
         """
         return {
+            "cache_format_version": EXTRACTION_CACHE_FORMAT_VERSION,
             "result": result,
             "timestamp": time.time(),
         }
@@ -103,18 +166,40 @@ class ExtractionCache:
         """
         return str(data["result"])
 
-    async def get(self, template_name: str, template_version: str, transcript: str) -> str | None:
+    async def get(
+        self,
+        template_name: str,
+        template_version: str,
+        transcript: str,
+        *,
+        provider: str | None = None,
+        model: str | None = None,
+        prompt_hash: str | None = None,
+        output_schema_version: str | None = None,
+    ) -> str | None:
         """Get cached extraction result.
 
         Args:
             template_name: Template name
             template_version: Template version (for invalidation)
             transcript: Transcript text
+            provider: LLM provider used or selected
+            model: Provider model used or selected
+            prompt_hash: Hash of prompt/template content
+            output_schema_version: Output schema identifier
 
         Returns:
             Cached result or None if not found/expired
         """
-        cache_key = self._make_key(template_name, template_version, transcript)
+        cache_key = self._make_key(
+            template_name,
+            template_version,
+            transcript,
+            provider,
+            model,
+            prompt_hash,
+            output_schema_version,
+        )
         cache_file = self.cache_dir / f"{cache_key}.json"
 
         temp_file = cache_file.with_suffix(".tmp")
@@ -142,10 +227,27 @@ class ExtractionCache:
                 # File system error
                 return None
 
-        return await self._cache.get(template_name, template_version, transcript)
+        return await self._cache.get(
+            template_name,
+            template_version,
+            transcript,
+            provider,
+            model,
+            prompt_hash,
+            output_schema_version,
+        )
 
     async def set(
-        self, template_name: str, template_version: str, transcript: str, result: str
+        self,
+        template_name: str,
+        template_version: str,
+        transcript: str,
+        result: str,
+        *,
+        provider: str | None = None,
+        model: str | None = None,
+        prompt_hash: str | None = None,
+        output_schema_version: str | None = None,
     ) -> None:
         """Store extraction result in cache.
 
@@ -154,7 +256,21 @@ class ExtractionCache:
             template_version: Template version
             transcript: Transcript text
             result: Extraction result to cache
+            provider: LLM provider used or selected
+            model: Provider model used or selected
+            prompt_hash: Hash of prompt/template content
+            output_schema_version: Output schema identifier
         """
+        key_components = self._key_components(
+            template_name,
+            template_version,
+            transcript,
+            provider,
+            model,
+            prompt_hash,
+            output_schema_version,
+        )
+
         # Override serializer temporarily to include template metadata
         original_serializer = self._cache.serializer
 
@@ -164,6 +280,14 @@ class ExtractionCache:
                 {
                     "template_name": template_name,
                     "template_version": template_version,
+                    "provider": provider or UNKNOWN_CACHE_KEY_PART,
+                    "model": model or UNKNOWN_CACHE_KEY_PART,
+                    "prompt_hash": prompt_hash or UNKNOWN_CACHE_KEY_PART,
+                    "output_schema_version": (
+                        output_schema_version or EXTRACTION_OUTPUT_SCHEMA_VERSION
+                    ),
+                    "transcript_hash": key_components["transcript_hash"],
+                    "key_components": key_components,
                 }
             )
             return base_data
@@ -171,22 +295,53 @@ class ExtractionCache:
         self._cache.serializer = extended_serializer
 
         try:
-            await self._cache.set(template_name, template_version, transcript, value=result)
+            await self._cache.set(
+                template_name,
+                template_version,
+                transcript,
+                provider,
+                model,
+                prompt_hash,
+                output_schema_version,
+                value=result,
+            )
         finally:
             self._cache.serializer = original_serializer
 
-    async def delete(self, template_name: str, template_version: str, transcript: str) -> bool:
+    async def delete(
+        self,
+        template_name: str,
+        template_version: str,
+        transcript: str,
+        *,
+        provider: str | None = None,
+        model: str | None = None,
+        prompt_hash: str | None = None,
+        output_schema_version: str | None = None,
+    ) -> bool:
         """Delete cached extraction result.
 
         Args:
             template_name: Template name
             template_version: Template version
             transcript: Transcript text
+            provider: LLM provider used or selected
+            model: Provider model used or selected
+            prompt_hash: Hash of prompt/template content
+            output_schema_version: Output schema identifier
 
         Returns:
             True if deleted, False if not found
         """
-        return await self._cache.delete(template_name, template_version, transcript)
+        return await self._cache.delete(
+            template_name,
+            template_version,
+            transcript,
+            provider,
+            model,
+            prompt_hash,
+            output_schema_version,
+        )
 
     async def clear(self) -> int:
         """Clear all cached values.
@@ -208,7 +363,7 @@ class ExtractionCache:
         """Get cache statistics.
 
         Returns:
-            Dict with cache stats (total_entries, total_size_mb, oldest_entry_age_days)
+            Dict with cache stats and extraction-specific metadata summaries.
         """
         cache_files = list(self.cache_dir.glob("*.json"))
         total_entries = len(cache_files)
@@ -216,41 +371,75 @@ class ExtractionCache:
         if total_entries == 0:
             return {
                 "total_entries": 0,
+                "total": 0,
                 "total_size_mb": 0.0,
+                "size_bytes": 0,
                 "oldest_entry_age_days": 0,
+                "cache_dir": str(self.cache_dir),
+                "cache_format_version": EXTRACTION_CACHE_FORMAT_VERSION,
+                "format_versions": {},
+                "templates": {},
+                "providers": {},
+                "models": {},
             }
 
         import asyncio
 
-        async def get_size(path: Path) -> int:
-            stat_result = await asyncio.to_thread(path.stat)
-            return stat_result.st_size
-
-        sizes = await asyncio.gather(*[get_size(f) for f in cache_files])
-        total_size = sum(sizes)
-        total_size_mb = total_size / (1024 * 1024)
-
-        import json
-
-        async def get_timestamp(cache_file: Path) -> float:
-            """Get timestamp from cache file, returns current time if error."""
+        async def analyze_file(cache_file: Path) -> dict[str, Any] | None:
+            """Analyze one cache file, returning metadata or None if unreadable."""
             try:
+                stat_result = await asyncio.to_thread(cache_file.stat)
                 async with aiofiles.open(cache_file) as f:
                     content = await f.read()
                     data = json.loads(content)
-                    return float(data["timestamp"])
-            except (json.JSONDecodeError, KeyError, OSError):
-                return time.time()
 
-        timestamps = await asyncio.gather(*[get_timestamp(f) for f in cache_files])
+                value = data.get("value", data)
+                timestamp = float(value.get("timestamp", time.time()))
+                format_version = value.get("cache_format_version", "legacy")
+                template_name = value.get("template_name", "unknown")
+                provider = value.get("provider", "unknown")
+                model = value.get("model", "unknown")
+
+                return {
+                    "size_bytes": stat_result.st_size,
+                    "timestamp": timestamp,
+                    "format_version": str(format_version),
+                    "template_name": template_name,
+                    "provider": provider,
+                    "model": model,
+                }
+            except (json.JSONDecodeError, KeyError, OSError, ValueError):
+                return None
+
+        file_stats = await asyncio.gather(*[analyze_file(f) for f in cache_files])
+        readable_stats = [stat for stat in file_stats if stat is not None]
+
+        total_size = sum(stat["size_bytes"] for stat in readable_stats)
+        total_size_mb = total_size / (1024 * 1024)
+        timestamps = [stat["timestamp"] for stat in readable_stats]
         oldest_timestamp = min(timestamps) if timestamps else time.time()
 
         oldest_age_days = (time.time() - oldest_timestamp) / (24 * 60 * 60)
 
+        def count_by(field: str) -> dict[str, int]:
+            counts: dict[str, int] = {}
+            for stat in readable_stats:
+                value = str(stat[field])
+                counts[value] = counts.get(value, 0) + 1
+            return counts
+
         return {
             "total_entries": total_entries,
+            "total": total_entries,
             "total_size_mb": round(total_size_mb, 2),
+            "size_bytes": total_size,
             "oldest_entry_age_days": round(oldest_age_days, 1),
+            "cache_dir": str(self.cache_dir),
+            "cache_format_version": EXTRACTION_CACHE_FORMAT_VERSION,
+            "format_versions": count_by("format_version"),
+            "templates": count_by("template_name"),
+            "providers": count_by("provider"),
+            "models": count_by("model"),
         }
 
     async def stats(self) -> dict[str, Any]:

--- a/src/inkwell/extraction/engine.py
+++ b/src/inkwell/extraction/engine.py
@@ -3,6 +3,8 @@
 Coordinates template selection, provider selection, caching, and result parsing.
 """
 
+import hashlib
+import json
 import logging
 import os
 import re
@@ -273,6 +275,103 @@ class ExtractionEngine:
             self._load_extraction_plugins()
         return self._registry
 
+    def _cache_key_options(
+        self,
+        template: ExtractionTemplate,
+        extractor: BaseExtractor | None = None,
+    ) -> dict[str, str]:
+        """Build stable extraction cache-key metadata for a template."""
+        provider = (
+            self._provider_name_for_extractor(extractor)
+            if extractor is not None
+            else self._cache_provider_for_template(template)
+        )
+        return {
+            "provider": provider,
+            "model": (
+                self._model_name_for_extractor(extractor)
+                if extractor is not None
+                else self._cache_model_for_provider(provider)
+            ),
+            "prompt_hash": self._template_prompt_hash(template),
+            "output_schema_version": self._output_schema_version(template),
+        }
+
+    def _provider_name_for_extractor(self, extractor: BaseExtractor) -> str:
+        """Return a provider identity for cache keys and result metadata."""
+        plugin_name = getattr(extractor, "NAME", None)
+        if isinstance(plugin_name, str) and plugin_name:
+            return plugin_name
+
+        class_name = extractor.__class__.__name__
+        if class_name == "ClaudeExtractor":
+            return "claude"
+        if class_name == "GeminiExtractor":
+            return "gemini"
+        return class_name.removesuffix("Extractor").lower() or "unknown"
+
+    def _model_name_for_extractor(self, extractor: BaseExtractor) -> str:
+        """Return a model identity for cache keys."""
+        model = getattr(extractor, "model", None) or getattr(extractor, "MODEL", None)
+        if isinstance(model, str) and model:
+            return model
+        return "unknown"
+
+    def _cache_provider_for_template(self, template: ExtractionTemplate) -> str:
+        """Mirror provider selection inputs without requiring plugin initialization."""
+        override = self._extractor_override or os.environ.get("INKWELL_EXTRACTOR")
+        if override:
+            return override
+
+        if template.model_preference:
+            return template.model_preference
+
+        if "quote" in template.name.lower():
+            return "claude"
+
+        if template.expected_format == "json" and template.output_schema:
+            required_fields = template.output_schema.get("required", [])
+            if len(required_fields) > 5:
+                return "claude"
+
+        return self.default_provider
+
+    def _cache_model_for_provider(self, provider: str) -> str:
+        """Return the default model identity used for cache-key metadata."""
+        default_models = {
+            "claude": "claude-3-5-sonnet-20241022",
+            "gemini": "gemini-3-pro-preview",
+        }
+        return default_models.get(provider, "unknown")
+
+    def _template_prompt_hash(self, template: ExtractionTemplate) -> str:
+        """Hash prompt/template inputs that affect extraction output."""
+        payload = {
+            "name": template.name,
+            "version": template.version,
+            "system_prompt": template.system_prompt,
+            "user_prompt_template": template.user_prompt_template,
+            "expected_format": template.expected_format,
+            "output_schema": template.output_schema,
+            "model_preference": template.model_preference,
+            "max_tokens": template.max_tokens,
+            "temperature": template.temperature,
+            "variables": [variable.model_dump(mode="json") for variable in template.variables],
+            "few_shot_examples": template.few_shot_examples,
+        }
+        content = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+        return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+    def _output_schema_version(self, template: ExtractionTemplate) -> str:
+        """Build an output schema identity for cache-key metadata."""
+        schema_payload = {
+            "expected_format": template.expected_format,
+            "output_schema": template.output_schema or {},
+        }
+        content = json.dumps(schema_payload, sort_keys=True, separators=(",", ":"), default=str)
+        schema_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        return f"{template.expected_format}:{schema_hash}"
+
     async def extract(
         self,
         template: ExtractionTemplate,
@@ -295,9 +394,15 @@ class ExtractionEngine:
             ExtractionError: If extraction fails
         """
         episode_url = metadata.get("episode_url", "")
+        policy_cache_key_options = self._cache_key_options(template)
 
         if use_cache:
-            cached = await self.cache.get(template.name, template.version, transcript)
+            cached = await self.cache.get(
+                template.name,
+                template.version,
+                transcript,
+                **policy_cache_key_options,
+            )
             if cached:
                 content = self._parse_output(cached, template)
                 return ExtractionResult(
@@ -312,7 +417,28 @@ class ExtractionEngine:
                 )
 
         extractor = self._select_extractor(template)
-        provider_name = "claude" if extractor.__class__.__name__ == "ClaudeExtractor" else "gemini"
+        provider_name = self._provider_name_for_extractor(extractor)
+        cache_key_options = self._cache_key_options(template, extractor)
+
+        if use_cache and cache_key_options != policy_cache_key_options:
+            cached = await self.cache.get(
+                template.name,
+                template.version,
+                transcript,
+                **cache_key_options,
+            )
+            if cached:
+                content = self._parse_output(cached, template)
+                return ExtractionResult(
+                    episode_url=episode_url,
+                    template_name=template.name,
+                    template_version=template.version,
+                    success=True,
+                    extracted_content=content,
+                    cost_usd=0.0,
+                    provider="cache",
+                    from_cache=True,
+                )
 
         # Estimate cost
         estimated_cost = extractor.estimate_cost(template, len(transcript))
@@ -324,7 +450,13 @@ class ExtractionEngine:
             content = self._parse_output(raw_output, template)
 
             if use_cache:
-                await self.cache.set(template.name, template.version, transcript, raw_output)
+                await self.cache.set(
+                    template.name,
+                    template.version,
+                    transcript,
+                    raw_output,
+                    **cache_key_options,
+                )
 
             if self.cost_tracker:
                 # Estimate token counts based on transcript length
@@ -492,11 +624,25 @@ class ExtractionEngine:
             template: ExtractionTemplate,
         ) -> tuple[ExtractionTemplate, str | None]:
             """Lookup single template in cache."""
+            policy_cache_key_options = self._cache_key_options(template)
             result = await self.cache.get(
                 template.name,
                 template.version,
                 transcript,
+                **policy_cache_key_options,
             )
+            if result is not None:
+                return (template, result)
+
+            extractor = self._select_extractor(template)
+            cache_key_options = self._cache_key_options(template, extractor)
+            if cache_key_options != policy_cache_key_options:
+                result = await self.cache.get(
+                    template.name,
+                    template.version,
+                    transcript,
+                    **cache_key_options,
+                )
             return (template, result)
 
         results = await asyncio.gather(*[lookup_one(t) for t in templates])
@@ -613,7 +759,14 @@ class ExtractionEngine:
                 result = batch_results.get(template.name)
                 if result and result.success and result.extracted_content:
                     raw_output = self._serialize_extracted_content(result.extracted_content)
-                    await self.cache.set(template.name, template.version, transcript, raw_output)
+                    extractor = self._select_extractor(template)
+                    await self.cache.set(
+                        template.name,
+                        template.version,
+                        transcript,
+                        raw_output,
+                        **self._cache_key_options(template, extractor),
+                    )
 
         # Combine cached and new results in original order and build summary
         all_results = []

--- a/src/inkwell/transcription/__init__.py
+++ b/src/inkwell/transcription/__init__.py
@@ -13,7 +13,11 @@ Key components:
 - manager: High-level orchestration
 """
 
-from inkwell.transcription.cache import CacheError, TranscriptCache
+from inkwell.transcription.cache import (
+    TRANSCRIPT_CACHE_FORMAT_VERSION,
+    CacheError,
+    TranscriptCache,
+)
 from inkwell.transcription.gemini import (
     CostEstimate,
     GeminiTranscriber,
@@ -34,6 +38,7 @@ __all__ = [
     "GeminiTranscriberWithSegments",
     "Transcript",
     "TranscriptCache",
+    "TRANSCRIPT_CACHE_FORMAT_VERSION",
     "TranscriptionManager",
     "TranscriptSegment",
     "TranscriptionResult",

--- a/src/inkwell/transcription/cache.py
+++ b/src/inkwell/transcription/cache.py
@@ -13,7 +13,9 @@ from platformdirs import user_cache_dir
 from inkwell.transcription.models import Transcript
 from inkwell.utils.cache import CacheError, FileCache
 
-__all__ = ["TranscriptCache", "CacheError"]
+TRANSCRIPT_CACHE_FORMAT_VERSION = 1
+
+__all__ = ["TRANSCRIPT_CACHE_FORMAT_VERSION", "TranscriptCache", "CacheError"]
 
 
 class TranscriptCache:
@@ -74,6 +76,7 @@ class TranscriptCache:
             Dictionary with transcript data and metadata
         """
         return {
+            "cache_format_version": TRANSCRIPT_CACHE_FORMAT_VERSION,
             "transcript": transcript.model_dump(mode="json"),
             "episode_url": transcript.episode_url,
         }
@@ -200,6 +203,8 @@ class TranscriptCache:
                 "valid": 0,
                 "size_bytes": 0,
                 "sources": {},
+                "cache_format_version": TRANSCRIPT_CACHE_FORMAT_VERSION,
+                "format_versions": {},
                 "cache_dir": str(self.cache_dir),
             }
 
@@ -220,11 +225,13 @@ class TranscriptCache:
                 # (data["value"]["transcript"])
                 value_data = data.get("value", data)  # Fallback for old format
                 source = value_data.get("transcript", {}).get("source", "unknown")
+                format_version = value_data.get("cache_format_version", "legacy")
 
                 return {
                     "size": file_size,
                     "expired": is_expired,
                     "source": source,
+                    "format_version": str(format_version),
                 }
 
             except (json.JSONDecodeError, KeyError, ValueError, OSError):
@@ -239,6 +246,7 @@ class TranscriptCache:
         expired = 0
         total_size = 0
         sources: dict[str, int] = {}
+        format_versions: dict[str, int] = {}
 
         for result in results:
             if result:
@@ -247,6 +255,8 @@ class TranscriptCache:
                     expired += 1
                 source = result["source"]
                 sources[source] = sources.get(source, 0) + 1
+                format_version = result["format_version"]
+                format_versions[format_version] = format_versions.get(format_version, 0) + 1
 
         return {
             "total": total,
@@ -254,5 +264,7 @@ class TranscriptCache:
             "valid": total - expired,
             "size_bytes": total_size,
             "sources": sources,
+            "cache_format_version": TRANSCRIPT_CACHE_FORMAT_VERSION,
+            "format_versions": format_versions,
             "cache_dir": str(self.cache_dir),
         }

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1825,6 +1825,28 @@ class TestCLICache:
         # Main goal is to ensure command is registered and parseable
         assert result.exit_code in (0, 1)
 
+    def test_cache_stats_shows_all_cache_sections(self, tmp_path: Path, monkeypatch) -> None:
+        """Cache stats reports transcript, extraction, and media sections."""
+        monkeypatch.setattr(
+            "inkwell.transcription.cache.user_cache_dir",
+            lambda *_args: str(tmp_path / "transcripts-root"),
+        )
+        monkeypatch.setattr(
+            "inkwell.extraction.cache.platformdirs.user_cache_dir",
+            lambda *_args: str(tmp_path / "extractions-root"),
+        )
+        monkeypatch.setattr(
+            "inkwell.audio.downloader.platformdirs.user_cache_dir",
+            lambda *_args: str(tmp_path / "media-root"),
+        )
+
+        result = runner.invoke(app, ["cache", "stats"])
+
+        assert result.exit_code == 0, result.output
+        assert "Transcript Cache Statistics" in result.stdout
+        assert "Extraction Cache Statistics" in result.stdout
+        assert "Media Cache Statistics" in result.stdout
+
     def test_cache_invalid_action(self) -> None:
         """Test cache command with invalid action."""
         result = runner.invoke(app, ["cache", "invalid-action"])

--- a/tests/unit/audio/test_downloader.py
+++ b/tests/unit/audio/test_downloader.py
@@ -7,6 +7,7 @@ import pytest
 from yt_dlp.utils import DownloadError, ExtractorError
 
 from inkwell.audio import AudioDownloader, DownloadProgress
+from inkwell.audio.downloader import AUDIO_CACHE_FORMAT_VERSION
 from inkwell.utils.errors import APIError
 
 
@@ -130,6 +131,30 @@ class TestAudioDownloader:
         downloader = AudioDownloader()
 
         assert downloader.output_dir == Path.cwd() / "downloads"
+
+    def test_cache_stats_empty_missing_directory(self, tmp_path: Path) -> None:
+        """Cache stats can inspect a missing media cache directory."""
+        cache_dir = tmp_path / "missing-cache"
+
+        stats = AudioDownloader.cache_stats(cache_dir)
+
+        assert stats["total"] == 0
+        assert stats["size_bytes"] == 0
+        assert stats["cache_dir"] == str(cache_dir)
+        assert stats["cache_format_version"] == AUDIO_CACHE_FORMAT_VERSION
+        assert stats["extensions"] == {}
+
+    def test_cache_stats_counts_media_files(self, cache_dir: Path) -> None:
+        """Cache stats reports media file count, bytes, and extensions."""
+        (cache_dir / "one.m4a").write_bytes(b"abc")
+        (cache_dir / "two.webm").write_bytes(b"abcd")
+
+        stats = AudioDownloader.cache_stats(cache_dir)
+
+        assert stats["total"] == 2
+        assert stats["size_bytes"] == 7
+        assert stats["cache_format_version"] == AUDIO_CACHE_FORMAT_VERSION
+        assert stats["extensions"] == {".m4a": 1, ".webm": 1}
 
     @pytest.mark.asyncio
     async def test_download_success(

--- a/tests/unit/test_batch_extraction.py
+++ b/tests/unit/test_batch_extraction.py
@@ -219,16 +219,28 @@ class TestBatchedExtraction:
             transcript = "Test transcript"
             metadata = {"episode_url": "https://example.com/ep1"}
 
-            # Pre-populate cache for all templates
-            await temp_cache.set("summary", "1.0", transcript, "Cached summary")
-            await temp_cache.set("quotes", "1.0", transcript, '{"quotes": ["Cached quote"]}')
-
             # Mock extractor (should NOT be called)
             mock_extract = AsyncMock()
             mock_extractor = Mock()
             mock_extractor.extract = mock_extract
             mock_extractor.estimate_cost = Mock(return_value=0.01)
             mock_extractor.__class__.__name__ = "GeminiExtractor"
+
+            # Pre-populate cache for all templates
+            await temp_cache.set(
+                "summary",
+                "1.0",
+                transcript,
+                "Cached summary",
+                **engine._cache_key_options(summary_template, mock_extractor),
+            )
+            await temp_cache.set(
+                "quotes",
+                "1.0",
+                transcript,
+                '{"quotes": ["Cached quote"]}',
+                **engine._cache_key_options(quotes_template, mock_extractor),
+            )
 
             with patch.object(engine, "_select_extractor", return_value=mock_extractor):
                 # Execute batch extraction

--- a/tests/unit/test_extraction_cache.py
+++ b/tests/unit/test_extraction_cache.py
@@ -1,12 +1,13 @@
 """Unit tests for extraction cache."""
 
+import hashlib
 import json
 import time
 from pathlib import Path
 
 import pytest
 
-from inkwell.extraction.cache import ExtractionCache
+from inkwell.extraction.cache import EXTRACTION_CACHE_FORMAT_VERSION, ExtractionCache
 
 
 @pytest.fixture
@@ -159,14 +160,36 @@ class TestExtractionCache:
         """Test stats with cached entries."""
         cache = ExtractionCache(cache_dir=temp_cache_dir)
 
-        await cache.set("summary", "1.0", "transcript1", "result1")
-        await cache.set("quotes", "1.0", "transcript2", "result2")
+        await cache.set(
+            "summary",
+            "1.0",
+            "transcript1",
+            "result1",
+            provider="gemini",
+            model="gemini-3-pro-preview",
+            prompt_hash="prompt-a",
+            output_schema_version="markdown:schema-a",
+        )
+        await cache.set(
+            "quotes",
+            "1.0",
+            "transcript2",
+            "result2",
+            provider="claude",
+            model="claude-3-5-sonnet-20241022",
+            prompt_hash="prompt-b",
+            output_schema_version="json:schema-b",
+        )
 
         stats = await cache.get_stats()
         assert stats["total_entries"] == 2
         # Size in MB may be very small, but should be non-negative
         assert stats["total_size_mb"] >= 0
         assert stats["oldest_entry_age_days"] >= 0
+        assert stats["cache_format_version"] == EXTRACTION_CACHE_FORMAT_VERSION
+        assert stats["format_versions"][str(EXTRACTION_CACHE_FORMAT_VERSION)] == 2
+        assert stats["templates"] == {"summary": 1, "quotes": 1}
+        assert stats["providers"] == {"gemini": 1, "claude": 1}
 
     @pytest.mark.asyncio
     async def test_corrupted_cache_file_ignored(self, temp_cache_dir: Path) -> None:
@@ -246,7 +269,16 @@ class TestExtractionCache:
         """Test that cache files have correct structure."""
         cache = ExtractionCache(cache_dir=temp_cache_dir)
 
-        await cache.set("summary", "1.0", "transcript", "result")
+        await cache.set(
+            "summary",
+            "1.0",
+            "transcript",
+            "result",
+            provider="gemini",
+            model="gemini-3-pro-preview",
+            prompt_hash="prompt-hash",
+            output_schema_version="markdown:schema-hash",
+        )
 
         cache_files = list(temp_cache_dir.glob("*.json"))
         assert len(cache_files) == 1
@@ -256,13 +288,97 @@ class TestExtractionCache:
 
         assert "cached_at" in data
         assert "value" in data
+        assert data["value"]["cache_format_version"] == EXTRACTION_CACHE_FORMAT_VERSION
         assert "timestamp" in data["value"]
         assert "template_name" in data["value"]
         assert "template_version" in data["value"]
         assert "result" in data["value"]
+        assert data["value"]["provider"] == "gemini"
+        assert data["value"]["model"] == "gemini-3-pro-preview"
+        assert data["value"]["prompt_hash"] == "prompt-hash"
+        assert data["value"]["output_schema_version"] == "markdown:schema-hash"
+        assert "transcript_hash" in data["value"]
+        assert "key_components" in data["value"]
         assert data["value"]["template_name"] == "summary"
         assert data["value"]["template_version"] == "1.0"
         assert data["value"]["result"] == "result"
+
+    @pytest.mark.asyncio
+    async def test_cache_key_includes_versioned_metadata(self, temp_cache_dir: Path) -> None:
+        """Provider/model/prompt/schema inputs participate in cache keys."""
+        cache = ExtractionCache(cache_dir=temp_cache_dir)
+
+        base_key = cache._make_key(
+            "summary",
+            "1.0",
+            "transcript",
+            provider="gemini",
+            model="gemini-3-pro-preview",
+            prompt_hash="prompt-a",
+            output_schema_version="markdown:schema-a",
+        )
+
+        assert base_key != cache._make_key(
+            "summary",
+            "1.0",
+            "transcript",
+            provider="claude",
+            model="claude-3-5-sonnet-20241022",
+            prompt_hash="prompt-a",
+            output_schema_version="markdown:schema-a",
+        )
+        assert base_key != cache._make_key(
+            "summary",
+            "1.0",
+            "transcript",
+            provider="gemini",
+            model="gemini-3-pro-preview",
+            prompt_hash="prompt-b",
+            output_schema_version="markdown:schema-a",
+        )
+        assert base_key != cache._make_key(
+            "summary",
+            "1.0",
+            "transcript",
+            provider="gemini",
+            model="gemini-3-pro-preview",
+            prompt_hash="prompt-a",
+            output_schema_version="json:schema-b",
+        )
+
+    @pytest.mark.asyncio
+    async def test_legacy_cache_key_is_safe_miss(self, temp_cache_dir: Path) -> None:
+        """Old key filenames are left alone and treated as misses."""
+        cache = ExtractionCache(cache_dir=temp_cache_dir)
+
+        legacy_key = hashlib.sha256(b"summary:1.0:transcript").hexdigest()
+        legacy_file = temp_cache_dir / f"{legacy_key}.json"
+        legacy_file.write_text(
+            json.dumps(
+                {
+                    "cached_at": "2026-05-21T00:00:00+00:00",
+                    "value": {
+                        "result": "legacy result",
+                        "timestamp": time.time(),
+                        "template_name": "summary",
+                        "template_version": "1.0",
+                    },
+                }
+            )
+        )
+
+        result = await cache.get(
+            "summary",
+            "1.0",
+            "transcript",
+            provider="gemini",
+            model="gemini-3-pro-preview",
+            prompt_hash="prompt-a",
+            output_schema_version="markdown:schema-a",
+        )
+
+        assert result is None
+        assert legacy_file.exists()
 
     @pytest.mark.asyncio
     async def test_concurrent_access(self, temp_cache_dir: Path) -> None:

--- a/tests/unit/transcription/test_cache.py
+++ b/tests/unit/transcription/test_cache.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from inkwell.transcription import Transcript, TranscriptCache, TranscriptSegment
+from inkwell.transcription.cache import TRANSCRIPT_CACHE_FORMAT_VERSION
 
 
 class TestTranscriptCache:
@@ -180,6 +181,7 @@ class TestTranscriptCache:
 
         assert "cached_at" in data
         assert "value" in data
+        assert data["value"]["cache_format_version"] == TRANSCRIPT_CACHE_FORMAT_VERSION
         assert "episode_url" in data["value"]
         assert "transcript" in data["value"]
         assert data["value"]["episode_url"] == url
@@ -329,6 +331,9 @@ class TestTranscriptCache:
         assert stats["size_bytes"] > 0
         assert stats["sources"]["youtube"] == 2  # Original source preserved
         assert stats["sources"]["gemini"] == 1
+        assert stats["cache_format_version"] == TRANSCRIPT_CACHE_FORMAT_VERSION
+        assert stats["format_versions"][str(TRANSCRIPT_CACHE_FORMAT_VERSION)] == 2
+        assert stats["format_versions"]["legacy"] == 1
 
     @pytest.mark.asyncio
     async def test_stats_with_corrupted(self, cache: TranscriptCache, temp_cache_dir: Path) -> None:


### PR DESCRIPTION
## Summary
- Added explicit cache format version constants for transcript, extraction, and media caches.
- Expanded extraction cache keys with transcript hash, template identity, provider/model, prompt hash, and output schema identity.
- Treated legacy extraction cache keys as safe misses without rewriting or deleting existing files.
- Extended `inkwell cache stats` to report transcript, extraction, and media cache sections.
- Documented the expanded cache stats behavior and added focused cache/CLI tests.

## Tests
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run pytest tests/unit/test_extraction_cache.py tests/unit/test_extraction_engine.py tests/unit/test_batch_extraction.py tests/unit/test_extraction_summary.py tests/unit/transcription/test_cache.py tests/unit/audio/test_downloader.py tests/integration/test_cli.py`
- `uv run pytest`
- Pre-push hook: `ruff`, `ruff format`, `pytest`

## Follow-up
- Phase 4: bounded media/audio cache controls with config-backed TTL and size policy.
- Phase 5: extract-only mode for media transcript output.