### PR TITLE
feat: add media cache controls

### DIFF
--- a/docs/building-in-public/devlog/2026-05-21-media-cache-controls.md
+++ b/docs/building-in-public/devlog/2026-05-21-media-cache-controls.md
@@ -1,0 +1,36 @@
+# Media Cache Controls
+
+**Date:** 2026-05-21
+**Author:** Codex
+
+## Focus
+
+Implement Phase 4 of the summarize-inspired CLI evolution: add bounded media/audio cache controls without changing transcript or extraction cache semantics.
+
+## Plan
+
+- Add `cache.media.enabled`, `cache.media.max_mb`, and `cache.media.ttl_days` to the config schema and generated default config.
+- Apply TTL and size policy to the downloaded media/audio cache used by `AudioDownloader`.
+- Wire the media cache config through CLI and pipeline transcription paths.
+- Document the new configuration fields.
+- Add focused tests for config defaults, cache eviction, disabled cache behavior, and transcription wiring.
+
+## Notes
+
+This phase should only govern downloaded media/audio files. Transcript cache keys, extraction cache keys, JSON/plain output, provider attempt policy, local file ingestion, and extract-only mode stay out of scope.
+
+## Progress
+
+- Started implementation on `codex/media-cache-controls`.
+- Added media cache config schema/defaults and docs.
+- Applied TTL/size/enabled policy to `AudioDownloader` while preserving existing cache behavior by default.
+- Wired media cache config through CLI and pipeline transcription manager creation.
+- Added focused tests for config defaults, media cache eviction, disabled cache behavior, and transcription wiring.
+- Verified focused tests, formatting, linting, and the full test suite locally.
+
+## Links
+
+- Related devlog: `./2026-05-21-cache-key-observability.md`
+- Related roadmap: `../../../2026-roadmap/03-universal-content-ingestion.md`
+- PR: TBD
+- Issue: TBD

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -224,7 +224,7 @@ inkwell cache clear-expired
 inkwell cache clear
 ```
 
-`stats` is observational only. Media cache retention controls are planned separately.
+`stats` is observational only. Downloaded media/audio retention is configured with `cache.media.enabled`, `cache.media.max_mb`, and `cache.media.ttl_days`.
 
 ---
 
@@ -475,6 +475,7 @@ inkwell config set <KEY> <VALUE>
 inkwell config set log_level DEBUG
 inkwell config set default_output_dir ~/Documents/podcasts
 inkwell config set transcription.api_key "your-key"
+inkwell config set cache.media.max_mb 4096
 ```
 
 ### inkwell config feed

--- a/docs/reference/config-options.md
+++ b/docs/reference/config-options.md
@@ -99,6 +99,36 @@ transcription:
 
 ---
 
+## Cache Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `cache.media.enabled` | boolean | `true` | Cache downloaded media/audio files |
+| `cache.media.max_mb` | int | `2048` | Maximum media/audio cache size in MB |
+| `cache.media.ttl_days` | int | `30` | Maximum media/audio cache entry age in days |
+
+### cache.media
+
+Inkwell keeps downloaded media/audio files in the local cache so retries and fallback transcription do not need to download the same episode again. Retention is enforced when media downloads run.
+
+```yaml
+cache:
+  media:
+    enabled: true
+    max_mb: 2048
+    ttl_days: 30
+```
+
+To disable downloaded media caching:
+
+```yaml
+cache:
+  media:
+    enabled: false
+```
+
+---
+
 ## Extraction Settings
 
 | Key | Type | Default | Description |
@@ -229,6 +259,13 @@ transcription:
   api_key: "your-google-ai-key"
   model_name: gemini-2.5-flash
   youtube_check: true
+
+# Cache
+cache:
+  media:
+    enabled: true
+    max_mb: 2048
+    ttl_days: 30
 
 # Extraction
 max_episodes_per_run: 10

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -40,6 +40,7 @@ Output directory: ~/podcasts
 Log level: INFO
 YouTube check: ✓
 Transcription model: gemini-2.5-flash
+Media cache: enabled, 2048 MB, 30 days
 ```
 
 ---
@@ -58,6 +59,7 @@ inkwell config set <key> <value>
 inkwell config set log_level DEBUG
 inkwell config set default_output_dir ~/Documents/podcasts
 inkwell config set transcription.api_key "your-key"
+inkwell config set cache.media.max_mb 4096
 ```
 
 ### Via Editor
@@ -98,6 +100,14 @@ Opens `config.yaml` in your `$EDITOR` (defaults to `vi`).
 | `extraction.claude_api_key` | string | `""` | Optional Anthropic key for extraction |
 | `extraction.cache_days` | integer | `30` | Extraction cache duration |
 
+### Cache
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `cache.media.enabled` | boolean | `true` | Cache downloaded media/audio files |
+| `cache.media.max_mb` | integer | `2048` | Maximum media/audio cache size in MB |
+| `cache.media.ttl_days` | integer | `30` | Maximum media/audio cache entry age in days |
+
 ### Interview
 
 | Option | Type | Default | Description |
@@ -135,6 +145,13 @@ transcription:
   api_key: your-google-ai-key-here
   model_name: gemini-2.5-flash   # omit to use the generated config default
   youtube_check: true
+
+# Cache
+cache:
+  media:
+    enabled: true
+    max_mb: 2048
+    ttl_days: 30
 
 # Extraction
 extraction:
@@ -202,7 +219,8 @@ tail -f ~/.local/state/inkwell/inkwell.log
 ```
 ~/.cache/inkwell/
 ├── transcripts/    # Cached transcripts
-└── extractions/    # Cached extractions
+├── extractions/    # Cached extractions
+└── audio/          # Downloaded media/audio cache
 ```
 
 Clear cache:

--- a/src/inkwell/audio/downloader.py
+++ b/src/inkwell/audio/downloader.py
@@ -3,6 +3,7 @@
 import asyncio
 import hashlib
 import logging
+import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -51,6 +52,9 @@ class AudioDownloader:
         output_dir: Path | None = None,
         cache_dir: Path | None = None,
         progress_callback: Callable[[DownloadProgress], None] | None = None,
+        cache_enabled: bool = True,
+        cache_max_mb: int | None = None,
+        cache_ttl_days: int | None = None,
     ):
         """Initialize audio downloader.
 
@@ -58,12 +62,21 @@ class AudioDownloader:
             output_dir: Directory to save downloaded audio (default: temp dir)
             cache_dir: Directory to cache audio files (default: platform cache dir)
             progress_callback: Optional callback for progress updates
+            cache_enabled: Whether to cache downloaded media/audio
+            cache_max_mb: Maximum media/audio cache size in megabytes
+            cache_ttl_days: Maximum media/audio cache entry age in days
         """
         self.output_dir = output_dir or Path.cwd() / "downloads"
         self.output_dir.mkdir(parents=True, exist_ok=True)
 
         self.cache_dir = cache_dir or self.default_cache_dir()
-        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.cache_enabled = cache_enabled
+        self.cache_max_mb = cache_max_mb
+        self.cache_ttl_days = cache_ttl_days
+        self.cache_max_bytes = cache_max_mb * 1024 * 1024 if cache_max_mb else None
+
+        if self.cache_enabled:
+            self.cache_dir.mkdir(parents=True, exist_ok=True)
 
         self.progress_callback = progress_callback
 
@@ -119,6 +132,101 @@ class AudioDownloader:
         url_hash = hashlib.sha256(url.encode()).hexdigest()[:16]
         return self.cache_dir / f"{url_hash}.m4a"
 
+    def _get_output_path(self, url: str, output_filename: str | None = None) -> Path:
+        """Get non-cache download output path for a URL."""
+        url_hash = hashlib.sha256(url.encode()).hexdigest()[:16]
+        stem = Path(output_filename).stem if output_filename else url_hash
+        return self.output_dir / f"{stem or url_hash}.m4a"
+
+    def _iter_cache_files(self) -> list[Path]:
+        """Return current files in the media cache directory."""
+        if not self.cache_dir.exists():
+            return []
+        return [path for path in self.cache_dir.iterdir() if path.is_file()]
+
+    def _is_cache_file_expired(self, path: Path) -> bool:
+        """Return whether a media cache file exceeds the configured TTL."""
+        if not self.cache_ttl_days or self.cache_ttl_days <= 0:
+            return False
+
+        try:
+            age_seconds = time.time() - path.stat().st_mtime
+        except OSError:
+            return False
+
+        return age_seconds > self.cache_ttl_days * 24 * 60 * 60
+
+    def _delete_cache_file(self, path: Path) -> int | None:
+        """Delete a cache file and return deleted bytes when successful."""
+        try:
+            size = path.stat().st_size
+            path.unlink()
+            return size
+        except OSError as e:
+            logger.debug(f"Failed to delete media cache file {path}: {e}")
+            return None
+
+    def enforce_cache_policy(self, protected_path: Path | None = None) -> dict[str, int]:
+        """Apply media cache TTL and size limits.
+
+        Args:
+            protected_path: Cache file that must not be evicted, usually the file
+                just downloaded and about to be returned to the caller.
+
+        Returns:
+            Counts of deleted expired/size-limit files and deleted bytes.
+        """
+        result = {"expired_files": 0, "size_files": 0, "bytes_deleted": 0}
+
+        if not self.cache_enabled:
+            return result
+
+        protected_path = protected_path.resolve() if protected_path else None
+
+        for cache_file in self._iter_cache_files():
+            if protected_path and cache_file.resolve() == protected_path:
+                continue
+            if not self._is_cache_file_expired(cache_file):
+                continue
+
+            deleted_bytes = self._delete_cache_file(cache_file)
+            if deleted_bytes is None:
+                continue
+            result["expired_files"] += 1
+            result["bytes_deleted"] += deleted_bytes
+
+        if self.cache_max_bytes is None:
+            return result
+
+        cache_files: list[tuple[float, int, Path]] = []
+        total_size = 0
+
+        for cache_file in self._iter_cache_files():
+            try:
+                stat_result = cache_file.stat()
+            except OSError:
+                continue
+            total_size += stat_result.st_size
+            cache_files.append((stat_result.st_mtime, stat_result.st_size, cache_file))
+
+        if total_size <= self.cache_max_bytes:
+            return result
+
+        for _, size, cache_file in sorted(cache_files, key=lambda item: item[0]):
+            if total_size <= self.cache_max_bytes:
+                break
+            if protected_path and cache_file.resolve() == protected_path:
+                continue
+
+            deleted_bytes = self._delete_cache_file(cache_file)
+            if deleted_bytes is None:
+                continue
+            total_size -= size
+            result["size_files"] += 1
+            result["bytes_deleted"] += deleted_bytes
+
+        return result
+
     def _check_cache(self, url: str) -> Path | None:
         """Check if audio for this URL is already cached.
 
@@ -128,8 +236,16 @@ class AudioDownloader:
         Returns:
             Path to cached file if it exists, None otherwise
         """
+        if not self.cache_enabled:
+            return None
+
         cache_path = self._get_cache_path(url)
         if cache_path.exists():
+            if self._is_cache_file_expired(cache_path):
+                self._delete_cache_file(cache_path)
+                logger.info(f"Expired cached audio: {cache_path}")
+                return None
+
             logger.info(f"Found cached audio: {cache_path}")
             return cache_path
         return None
@@ -175,13 +291,20 @@ class AudioDownloader:
         Raises:
             AudioDownloadError: If download fails
         """
-        if use_cache:
+        if self.cache_enabled:
+            self.enforce_cache_policy()
+
+        if use_cache and self.cache_enabled:
             cached_path = self._check_cache(url)
             if cached_path:
                 return cached_path
 
-        cache_path = self._get_cache_path(url)
-        output_template = str(cache_path.with_suffix(".%(ext)s"))
+        output_path = (
+            self._get_cache_path(url)
+            if self.cache_enabled
+            else self._get_output_path(url, output_filename)
+        )
+        output_template = str(output_path.with_suffix(".%(ext)s"))
 
         # Configure yt-dlp options per ADR-011 (M4A/AAC 128kbps)
         ydl_opts = {
@@ -210,6 +333,9 @@ class AudioDownloader:
             output_path = await loop.run_in_executor(
                 None, self._download_sync, url, ydl_opts, output_template
             )
+
+            if self.cache_enabled:
+                self.enforce_cache_policy(protected_path=output_path)
 
             return output_path
 
@@ -254,7 +380,7 @@ class AudioDownloader:
                     f"Download completed but file not found at expected location: {output_path}"
                 )
 
-            logger.info(f"Cached audio to: {output_path}")
+            logger.info(f"Downloaded audio to: {output_path}")
             return output_path
 
     async def get_info(self, url: str) -> dict[str, Any]:

--- a/src/inkwell/cli.py
+++ b/src/inkwell/cli.py
@@ -613,6 +613,14 @@ def config_command(
             table.add_row("YouTube check", "✓" if config.transcription.youtube_check else "✗")
             table.add_row("Transcription model", config.transcription.model_name)
             table.add_row("Interview model", config.interview.model)
+            table.add_row(
+                "Media cache",
+                (
+                    f"enabled, {config.cache.media.max_mb} MB, {config.cache.media.ttl_days} days"
+                    if config.cache.media.enabled
+                    else "disabled"
+                ),
+            )
             table.add_row("", "")
 
             # API key status - simplified to show the two keys that matter
@@ -729,18 +737,30 @@ def config_command(
                     console.print("  • transcription.api_key")
                     console.print("  • extraction.gemini_api_key")
                     console.print("  • extraction.claude_api_key")
+                    console.print("  • cache.media.enabled")
                     sys.exit(1)
-            elif len(key_parts) == 2:
-                # Nested key (e.g., transcription.api_key)
-                parent_key, child_key = key_parts
+            elif len(key_parts) in {2, 3}:
+                # Nested key (e.g., transcription.api_key or cache.media.enabled)
+                parent_key, *child_path = key_parts
 
                 if not hasattr(config, parent_key):
                     console.print(f"[red]✗[/red] Unknown config section: {parent_key}")
-                    console.print("\nAvailable sections: transcription, extraction, interview")
+                    console.print(
+                        "\nAvailable sections: transcription, extraction, interview, cache"
+                    )
                     sys.exit(1)
 
                 parent_obj = getattr(config, parent_key)
 
+                for nested_key in child_path[:-1]:
+                    if not hasattr(parent_obj, nested_key):
+                        console.print(
+                            f"[red]✗[/red] Unknown key '{nested_key}' in section '{parent_key}'"
+                        )
+                        sys.exit(1)
+                    parent_obj = getattr(parent_obj, nested_key)
+
+                child_key = child_path[-1]
                 if not hasattr(parent_obj, child_key):
                     console.print(
                         f"[red]✗[/red] Unknown key '{child_key}' in section '{parent_key}'"
@@ -782,8 +802,8 @@ def config_command(
             else:
                 console.print(f"[red]✗[/red] Invalid key format: {key}")
                 console.print(
-                    "Use 'key' for top-level or 'section.key' for nested "
-                    "(e.g., transcription.api_key)"
+                    "Use 'key' for top-level or dot notation for nested values "
+                    "(e.g., transcription.api_key or cache.media.enabled)"
                 )
                 sys.exit(1)
 
@@ -879,7 +899,9 @@ def transcribe_command(
             transcribe_url = input_source.url or input_source.value
 
             manager = TranscriptionManager(
-                model_name=config.transcription_model, cost_confirmation_callback=confirm_cost
+                config=config.transcription,
+                media_cache=config.cache.media,
+                cost_confirmation_callback=confirm_cost,
             )
 
             with Progress(

--- a/src/inkwell/config/defaults.py
+++ b/src/inkwell/config/defaults.py
@@ -22,6 +22,13 @@ interview_model: claude-sonnet-4-5
 
 youtube_check: true
 
+# Downloaded media/audio cache controls
+cache:
+  media:
+    enabled: true
+    max_mb: 2048
+    ttl_days: 30
+
 # Logging level (DEBUG, INFO, WARNING, ERROR)
 log_level: INFO
 

--- a/src/inkwell/config/schema.py
+++ b/src/inkwell/config/schema.py
@@ -78,6 +78,33 @@ class ExtractionConfig(BaseModel):
     )
 
 
+class MediaCacheConfig(BaseModel):
+    """Downloaded media/audio cache configuration."""
+
+    enabled: bool = Field(
+        default=True,
+        description="Whether downloaded media/audio files should be cached",
+    )
+    max_mb: int = Field(
+        default=2048,
+        ge=1,
+        le=102400,
+        description="Maximum media/audio cache size in megabytes",
+    )
+    ttl_days: int = Field(
+        default=30,
+        ge=1,
+        le=3650,
+        description="Maximum media/audio cache entry age in days",
+    )
+
+
+class CacheConfig(BaseModel):
+    """Local cache configuration."""
+
+    media: MediaCacheConfig = Field(default_factory=MediaCacheConfig)
+
+
 class PluginConfig(BaseModel):
     """Configuration for a single plugin.
 
@@ -196,6 +223,7 @@ class GlobalConfig(BaseModel):
     transcription: TranscriptionConfig = Field(default_factory=TranscriptionConfig)
     extraction: ExtractionConfig = Field(default_factory=ExtractionConfig)
     interview: InterviewConfig = Field(default_factory=InterviewConfig)
+    cache: CacheConfig = Field(default_factory=CacheConfig)
 
     # Plugin configurations (keyed by plugin name)
     plugins: dict[str, PluginConfig] = Field(

--- a/src/inkwell/pipeline/orchestrator.py
+++ b/src/inkwell/pipeline/orchestrator.py
@@ -430,7 +430,9 @@ class PipelineOrchestrator:
             InkwellError: If transcription fails
         """
         manager = TranscriptionManager(
-            config=self.config.transcription, cost_tracker=self.cost_tracker
+            config=self.config.transcription,
+            media_cache=self.config.cache.media,
+            cost_tracker=self.cost_tracker,
         )
         result = await manager.transcribe(
             url,

--- a/src/inkwell/transcription/manager.py
+++ b/src/inkwell/transcription/manager.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse
 
 from inkwell.audio import AudioDownloader
 from inkwell.config.precedence import resolve_config_value
-from inkwell.config.schema import TranscriptionConfig
+from inkwell.config.schema import MediaCacheConfig, TranscriptionConfig
 
 # Import from specific submodules to avoid potential circular imports
 from inkwell.plugins.discovery import discover_plugins
@@ -48,6 +48,7 @@ class TranscriptionManager:
         cache: TranscriptCache | None = None,
         youtube_transcriber: YouTubeTranscriber | None = None,
         audio_downloader: AudioDownloader | None = None,
+        media_cache: MediaCacheConfig | None = None,
         gemini_transcriber: GeminiTranscriber | None = None,
         gemini_api_key: str | None = None,
         model_name: str | None = None,
@@ -62,6 +63,7 @@ class TranscriptionManager:
             cache: Transcript cache (default: new instance)
             youtube_transcriber: YouTube transcriber (default: new instance)
             audio_downloader: Audio downloader (default: new instance)
+            media_cache: Downloaded media/audio cache configuration
             gemini_transcriber: Gemini transcriber (default: new instance)
             gemini_api_key: Google AI API key (default: from env) [deprecated]
             model_name: Gemini model (default: gemini-2.5-flash) [deprecated]
@@ -87,7 +89,12 @@ class TranscriptionManager:
             )
 
         self.cache = cache or TranscriptCache()
-        self.audio_downloader = audio_downloader or AudioDownloader()
+        self.media_cache = media_cache or MediaCacheConfig()
+        self.audio_downloader = audio_downloader or AudioDownloader(
+            cache_enabled=self.media_cache.enabled,
+            cache_max_mb=self.media_cache.max_mb,
+            cache_ttl_days=self.media_cache.ttl_days,
+        )
         self.cost_tracker = cost_tracker
         self._use_plugin_registry = use_plugin_registry
 

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1539,6 +1539,16 @@ class TestCLIConfig:
         config_reloaded = manager.load_config()
         assert config_reloaded.log_level == "DEBUG"
 
+    def test_config_set_media_cache_nested_value(self, tmp_path: Path, monkeypatch) -> None:
+        """Config set supports three-level media cache values."""
+        monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
+        monkeypatch.setattr("inkwell.config.manager.get_config_dir", lambda: tmp_path)
+
+        result = runner.invoke(app, ["config", "set", "cache.media.max_mb", "4096"])
+
+        assert result.exit_code == 0, result.output
+        assert ConfigManager(config_dir=tmp_path).load_config().cache.media.max_mb == 4096
+
     def test_config_roundtrip(self, tmp_path: Path) -> None:
         """Test that config can be saved and loaded."""
         manager = ConfigManager(config_dir=tmp_path)

--- a/tests/unit/audio/test_downloader.py
+++ b/tests/unit/audio/test_downloader.py
@@ -1,5 +1,6 @@
 """Tests for audio downloader."""
 
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
@@ -155,6 +156,79 @@ class TestAudioDownloader:
         assert stats["size_bytes"] == 7
         assert stats["cache_format_version"] == AUDIO_CACHE_FORMAT_VERSION
         assert stats["extensions"] == {".m4a": 1, ".webm": 1}
+
+    def test_cache_disabled_does_not_create_cache_directory(
+        self, temp_dir: Path, tmp_path: Path
+    ) -> None:
+        """Disabled media cache avoids creating the cache directory."""
+        cache_dir = tmp_path / "disabled-cache"
+
+        downloader = AudioDownloader(
+            output_dir=temp_dir,
+            cache_dir=cache_dir,
+            cache_enabled=False,
+        )
+
+        assert downloader.cache_enabled is False
+        assert not cache_dir.exists()
+
+    def test_check_cache_expires_stale_file(self, downloader: AudioDownloader) -> None:
+        """Stale media cache files are treated as misses and removed."""
+        downloader.cache_ttl_days = 1
+        url = "https://youtube.com/watch?v=stale123"
+        cache_path = downloader._get_cache_path(url)
+        cache_path.write_bytes(b"stale")
+        os.utime(cache_path, (1, 1))
+
+        result = downloader._check_cache(url)
+
+        assert result is None
+        assert not cache_path.exists()
+
+    def test_enforce_cache_policy_removes_oldest_files(
+        self, temp_dir: Path, cache_dir: Path
+    ) -> None:
+        """Size policy removes oldest media files until the cache is under limit."""
+        downloader = AudioDownloader(
+            output_dir=temp_dir,
+            cache_dir=cache_dir,
+            cache_max_mb=1,
+        )
+        old_file = cache_dir / "old.m4a"
+        new_file = cache_dir / "new.m4a"
+        old_file.write_bytes(b"a" * 700_000)
+        new_file.write_bytes(b"b" * 700_000)
+        os.utime(old_file, (1, 1))
+        os.utime(new_file, (2, 2))
+
+        result = downloader.enforce_cache_policy()
+
+        assert result["size_files"] == 1
+        assert result["bytes_deleted"] == 700_000
+        assert not old_file.exists()
+        assert new_file.exists()
+
+    def test_enforce_cache_policy_keeps_protected_file(
+        self, temp_dir: Path, cache_dir: Path
+    ) -> None:
+        """Size policy does not evict the file about to be returned."""
+        downloader = AudioDownloader(
+            output_dir=temp_dir,
+            cache_dir=cache_dir,
+            cache_max_mb=1,
+        )
+        old_file = cache_dir / "old.m4a"
+        protected_file = cache_dir / "protected.m4a"
+        old_file.write_bytes(b"a" * 700_000)
+        protected_file.write_bytes(b"b" * 700_000)
+        os.utime(old_file, (1, 1))
+        os.utime(protected_file, (2, 2))
+
+        result = downloader.enforce_cache_policy(protected_path=protected_file)
+
+        assert result["size_files"] == 1
+        assert not old_file.exists()
+        assert protected_file.exists()
 
     @pytest.mark.asyncio
     async def test_download_success(
@@ -490,4 +564,35 @@ class TestAudioDownloader:
 
         # Should have downloaded fresh (even though cache existed)
         # yt-dlp SHOULD have been called
+        mock_ydl_class.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_download_cache_disabled_uses_output_directory(
+        self,
+        temp_dir: Path,
+        cache_dir: Path,
+        mock_ydl_class: Mock,
+        mock_ydl_instance: Mock,
+    ) -> None:
+        """Disabled media cache downloads to output_dir and ignores cached files."""
+        downloader = AudioDownloader(
+            output_dir=temp_dir,
+            cache_dir=cache_dir,
+            cache_enabled=False,
+        )
+        url = "https://youtube.com/watch?v=nocache123"
+        downloader._get_cache_path(url).write_bytes(b"existing-cache")
+        output_file = downloader._get_output_path(url)
+
+        def mock_download(download_url: str, download: bool) -> dict:
+            output_file.touch()
+            return {"title": "Test Video", "id": "test123", "duration": 300}
+
+        mock_ydl_instance.extract_info.side_effect = mock_download
+
+        with patch("inkwell.audio.downloader.YoutubeDL", mock_ydl_class):
+            result = await downloader.download(url)
+
+        assert result == output_file
+        assert result.parent == temp_dir
         mock_ydl_class.assert_called_once()

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -7,11 +7,13 @@ from pydantic import HttpUrl, ValidationError
 
 from inkwell.config.schema import (
     AuthConfig,
+    CacheConfig,
     ExtractionConfig,
     FeedConfig,
     Feeds,
     GlobalConfig,
     InterviewConfig,
+    MediaCacheConfig,
     TranscriptionConfig,
 )
 
@@ -111,6 +113,9 @@ class TestGlobalConfig:
         assert config.transcription.cost_threshold_usd == 1.0
         assert config.interview.model == "claude-sonnet-4-5"
         assert config.extraction.default_provider == "gemini"
+        assert config.cache.media.enabled is True
+        assert config.cache.media.max_mb == 2048
+        assert config.cache.media.ttl_days == 30
 
     def test_global_config_from_dict(self, sample_config_dict: dict) -> None:
         """Test GlobalConfig created from dictionary."""
@@ -414,6 +419,38 @@ class TestExtractionConfigValidation:
         with pytest.raises(ValidationError) as exc_info:
             ExtractionConfig(gemini_api_key="x" * 600)
         assert "at most 500 characters" in str(exc_info.value)
+
+
+class TestCacheConfigValidation:
+    """Tests for cache configuration validation."""
+
+    def test_media_cache_defaults(self) -> None:
+        """Media cache defaults are enabled and bounded."""
+        config = CacheConfig()
+
+        assert config.media.enabled is True
+        assert config.media.max_mb == 2048
+        assert config.media.ttl_days == 30
+
+    def test_media_cache_custom_values(self) -> None:
+        """Media cache accepts explicit bounded values."""
+        config = MediaCacheConfig(enabled=False, max_mb=4096, ttl_days=90)
+
+        assert config.enabled is False
+        assert config.max_mb == 4096
+        assert config.ttl_days == 90
+
+    def test_media_cache_rejects_invalid_size(self) -> None:
+        """Media cache size must be positive."""
+        with pytest.raises(ValidationError) as exc_info:
+            MediaCacheConfig(max_mb=0)
+        assert "greater than or equal to 1" in str(exc_info.value)
+
+    def test_media_cache_rejects_invalid_ttl(self) -> None:
+        """Media cache TTL must be positive."""
+        with pytest.raises(ValidationError) as exc_info:
+            MediaCacheConfig(ttl_days=0)
+        assert "greater than or equal to 1" in str(exc_info.value)
 
 
 class TestInterviewConfigValidation:

--- a/tests/unit/test_transcription_manager.py
+++ b/tests/unit/test_transcription_manager.py
@@ -5,10 +5,11 @@ dependency injection, ensuring config objects take precedence over individual pa
 """
 
 import warnings
+from unittest.mock import Mock, patch
 
 import pytest
 
-from inkwell.config.schema import TranscriptionConfig
+from inkwell.config.schema import MediaCacheConfig, TranscriptionConfig
 from inkwell.transcription.gemini import GeminiTranscriber
 from inkwell.transcription.manager import TranscriptionManager
 from inkwell.utils.costs import CostTracker
@@ -180,6 +181,28 @@ class TestTranscriptionManagerCostTracker:
 
         assert manager.cost_tracker is tracker
         assert manager.gemini_transcriber is not None
+
+
+class TestTranscriptionManagerMediaCache:
+    """Test media cache configuration wiring."""
+
+    def test_media_cache_configures_default_audio_downloader(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Media cache config is passed to the default AudioDownloader."""
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        media_cache = MediaCacheConfig(enabled=False, max_mb=4096, ttl_days=90)
+
+        with patch("inkwell.transcription.manager.AudioDownloader") as downloader_class:
+            downloader_class.return_value = Mock()
+            manager = TranscriptionManager(media_cache=media_cache)
+
+        assert manager.media_cache is media_cache
+        downloader_class.assert_called_once_with(
+            cache_enabled=False,
+            cache_max_mb=4096,
+            cache_ttl_days=90,
+        )
 
 
 class TestTranscriptionManagerEdgeCases:


### PR DESCRIPTION
## Summary
- Added bounded media/audio cache config fields for cache.media.enabled, cache.media.max_mb, and cache.media.ttl_days.
- Applied TTL and size retention policy to downloaded media/audio cache while preserving existing cache behavior by default.
- Documented the new config fields and added focused tests for config, eviction, disabled cache behavior, and transcription wiring.

## Tests
- uv run pytest tests/unit/test_schema.py tests/unit/audio/test_downloader.py tests/unit/test_transcription_manager.py tests/integration/test_cli.py::TestCLIConfig::test_config_set_media_cache_nested_value
- uv run ruff format .
- uv run ruff check .
- uv run pytest
- git push -u origin codex/media-cache-controls (pre-push: ruff, ruff format, pytest)

## Follow-up
- Phase 5: extract-only mode for transcript/media extraction without structured notes.
- Phase 6: local file and stdin ingestion.
