### PR TITLE
feat: add extract-only fetch mode

### DIFF
--- a/docs/building-in-public/devlog/2026-05-21-extract-only-mode.md
+++ b/docs/building-in-public/devlog/2026-05-21-extract-only-mode.md
@@ -1,0 +1,38 @@
+# Extract-Only Mode
+
+**Date:** 2026-05-21
+**Author:** Codex
+
+## Focus
+
+Implement Phase 5 of the summarize-inspired CLI evolution: add a narrow extract-only media flow that emits transcript text without structured extraction, interview capture, or default note-directory output.
+
+## Plan
+
+- Choose the smallest CLI surface that fits existing fetch/transcribe behavior.
+- Reuse existing transcription, feed resolution, and progress/error patterns.
+- For media URLs and saved feed episodes, emit transcript text only.
+- Add optional file output without creating an episode note directory.
+- Keep local files, stdin, text cleanup, PDF/web article extraction, cache-key changes, and provider attempt policy out of scope.
+- Add focused tests for transcript-only behavior and compatibility.
+
+## Notes
+
+This is not a generic summarizer mode. It is a utility escape hatch for Inkwell media-learning workflows: get the transcript/clean source text, then decide what structured knowledge-note flow to run later.
+
+## Progress
+
+- Started implementation on `codex/extract-only-mode`.
+- Added `inkwell fetch --extract` for transcript-only media extraction.
+- Routed extract-only progress to stderr and transcript text to stdout by default.
+- Added explicit `--output-dir` handling for `.transcript.md` files without creating episode note directories.
+- Preserved saved-feed episode selection for extract-only mode.
+- Rejected structured extraction/interview options when `--extract` is active.
+- Documented the new flag and verified focused CLI tests, formatting, linting, and the full test suite locally.
+
+## Links
+
+- Related devlog: `./2026-05-21-media-cache-controls.md`
+- Related roadmap: `../../../2026-roadmap/03-universal-content-ingestion.md`
+- PR: TBD
+- Issue: TBD

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -256,6 +256,7 @@ inkwell fetch <SOURCE> [OPTIONS]
 | `--provider` | `-p` | string | Auto | LLM provider (gemini, claude, auto) |
 | `--skip-cache` | | flag | false | Skip extraction cache |
 | `--dry-run` | | flag | false | Show cost estimate only |
+| `--extract` | | flag | false | Emit transcript text only; skip structured extraction, interview, and note output |
 | `--overwrite` | | flag | false | Overwrite existing directory |
 | `--interview` | | flag | false | Enable interview mode |
 | `--interview-template` | | string | Config | Interview template (reflective, analytical, creative) |
@@ -306,6 +307,12 @@ inkwell fetch URL --interview --max-questions 3
 # Cost check
 inkwell fetch URL --dry-run
 
+# Transcript text only
+inkwell fetch URL --extract
+
+# Transcript file only, without an episode note directory
+inkwell fetch URL --extract --output-dir transcripts --plain
+
 # Force provider
 inkwell fetch URL --provider gemini
 
@@ -329,6 +336,8 @@ INKWELL_EXTRACTOR=gemini inkwell fetch URL
 ```
 
 `--json` and `--plain` are mutually exclusive. In both modes, stdout is reserved for the primary result and interactive progress output is sent to stderr.
+
+`--extract` is transcript-only for media workflows. It does not run templates, structured extraction, interview mode, or the episode note writer. Without `--output-dir`, transcript text is printed to stdout and progress goes to stderr. With `--output-dir`, Inkwell writes `.transcript.md` file(s) directly into that directory; combine with `--plain` to print the file path(s) to stdout.
 
 ---
 

--- a/docs/user-guide/processing.md
+++ b/docs/user-guide/processing.md
@@ -90,6 +90,7 @@ Step 4/4: Writing markdown files...
 | `--provider` | `-p` | LLM provider (claude, gemini) | Smart selection |
 | `--skip-cache` | | Skip extraction cache | `false` |
 | `--dry-run` | | Cost estimate only | `false` |
+| `--extract` | | Emit transcript text only and skip note generation | `false` |
 | `--overwrite` | | Overwrite existing directory | `false` |
 | `--interview` | | Enable interview mode | `false` |
 
@@ -183,6 +184,18 @@ inkwell fetch URL --dry-run
 # If acceptable, process
 inkwell fetch URL
 ```
+
+### Transcript Only
+
+```bash
+# Print transcript text to stdout; progress goes to stderr
+inkwell fetch URL --extract
+
+# Write transcript-only files without creating episode note directories
+inkwell fetch my-podcast --latest --extract --output-dir ~/transcripts --plain
+```
+
+Use this when you want the clean media transcript first and want to decide later whether to run Inkwell's structured note templates or reflection flow.
 
 ### Re-extract with Different Templates
 

--- a/src/inkwell/cli.py
+++ b/src/inkwell/cli.py
@@ -40,6 +40,7 @@ from inkwell.utils.errors import (
     ValidationError,
 )
 from inkwell.utils.progress import PipelineProgress
+from inkwell.utils.url_metadata import derive_readable_title_from_url
 
 app = typer.Typer(
     name="inkwell",
@@ -344,6 +345,97 @@ def _fetch_json_payload(
         "errors": [],
         "warnings": [],
     }
+
+
+def _validate_extract_only_options(
+    *,
+    json_output: bool,
+    dry_run: bool,
+    interview: bool,
+    interview_template: str | None,
+    interview_format: str | None,
+    max_questions: int | None,
+    no_resume: bool,
+    resume_session: str | None,
+    podcast_name: str | None,
+    templates: str | None,
+    category: str | None,
+    provider: str | None,
+    extractor: str | None,
+    skip_cache: bool,
+    save_feed: bool,
+) -> None:
+    """Reject fetch options that do not apply to transcript-only extraction."""
+    conflicts = []
+    if json_output:
+        conflicts.append("--json")
+    if dry_run:
+        conflicts.append("--dry-run")
+    if interview:
+        conflicts.append("--interview")
+    if interview_template:
+        conflicts.append("--interview-template")
+    if interview_format:
+        conflicts.append("--interview-format")
+    if max_questions is not None:
+        conflicts.append("--max-questions")
+    if no_resume:
+        conflicts.append("--no-resume")
+    if resume_session:
+        conflicts.append("--resume-session")
+    if podcast_name:
+        conflicts.append("--podcast-name")
+    if templates:
+        conflicts.append("--templates")
+    if category:
+        conflicts.append("--category")
+    if provider:
+        conflicts.append("--provider")
+    if extractor:
+        conflicts.append("--extractor")
+    if skip_cache:
+        conflicts.append("--skip-cache")
+    if save_feed:
+        conflicts.append("--save-feed")
+
+    if conflicts:
+        raise ValidationError(
+            f"--extract cannot be combined with {', '.join(conflicts)}",
+            suggestion=(
+                "Use regular 'inkwell fetch' for structured extraction, or run "
+                "'inkwell fetch SOURCE --extract' for transcript-only output."
+            ),
+        )
+
+
+def _extract_transcript_output_path(
+    *,
+    output_dir: Path,
+    title: str | None,
+    url: str,
+    used_filenames: set[str],
+    overwrite: bool,
+) -> Path:
+    """Choose an output path for a transcript-only extraction file."""
+    readable_title = title or derive_readable_title_from_url(url) or "transcript"
+    base_name = _slugify(readable_title) or "transcript"
+    filename = f"{base_name}.transcript.md"
+    path = output_dir / filename
+
+    if filename not in used_filenames and path.exists() and not overwrite:
+        raise FileExistsError(f"Transcript already exists: {path} (use --overwrite to replace it)")
+
+    suffix = 2
+    while filename in used_filenames:
+        filename = f"{base_name}-{suffix}.transcript.md"
+        path = output_dir / filename
+        suffix += 1
+
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"Transcript already exists: {path} (use --overwrite to replace it)")
+
+    used_filenames.add(filename)
+    return path
 
 
 def _derive_feed_name(resolved: ResolvedFeed, existing: set[str]) -> str:
@@ -1130,6 +1222,11 @@ def fetch_command(
     ),
     skip_cache: bool = typer.Option(False, "--skip-cache", help="Skip extraction cache"),
     dry_run: bool = typer.Option(False, "--dry-run", help="Show cost estimate without extracting"),
+    extract_only: bool = typer.Option(
+        False,
+        "--extract",
+        help="Emit transcript text only; skip structured extraction, interview, and note output.",
+    ),
     overwrite: bool = typer.Option(
         False, "--overwrite", help="Overwrite existing episode directory"
     ),
@@ -1219,11 +1316,32 @@ def fetch_command(
 
     async def run_fetch() -> None:
         nonlocal url_or_feed
-        machine_output = json_output or plain
+        machine_output = json_output or plain or extract_only
         status_console = err_console if machine_output else console
         processed_results = []
+        extract_transcripts: list[str] = []
+        extract_output_paths: list[Path] = []
+        extract_used_filenames: set[str] = set()
         try:
             _validate_machine_output_options(json_output=json_output, plain=plain)
+            if extract_only:
+                _validate_extract_only_options(
+                    json_output=json_output,
+                    dry_run=dry_run,
+                    interview=interview,
+                    interview_template=interview_template,
+                    interview_format=interview_format,
+                    max_questions=max_questions,
+                    no_resume=no_resume,
+                    resume_session=resume_session,
+                    podcast_name=podcast_name,
+                    templates=templates,
+                    category=category,
+                    provider=provider,
+                    extractor=extractor,
+                    skip_cache=skip_cache,
+                    save_feed=save_feed,
+                )
 
             manager = ConfigManager()
             config = manager.load_config()
@@ -1437,6 +1555,66 @@ def fetch_command(
                     # Direct YouTube URL: when yt-dlp provides a video title,
                     # use it so direct-URL capture folders are readable.
                     episode_title = pre_resolved.episode_title
+
+                if extract_only:
+                    transcription_manager = TranscriptionManager(
+                        config=config.transcription,
+                        media_cache=config.cache.media,
+                    )
+
+                    extract_substeps = {
+                        "checking_cache": "Checking transcript cache...",
+                        "trying_youtube": "Trying YouTube transcript...",
+                        "downloading_audio": "Downloading audio...",
+                        "transcribing_gemini": "Transcribing with Gemini...",
+                        "transcribing_gemini_youtube": "Transcribing YouTube URL with Gemini...",
+                        "caching_result": "Caching transcript...",
+                    }
+
+                    with Progress(
+                        SpinnerColumn(),
+                        TextColumn("[progress.description]{task.description}"),
+                        console=status_console,
+                    ) as progress:
+                        task = progress.add_task("Extracting transcript...", total=None)
+
+                        def handle_extract_progress(step: str, _data: dict) -> None:
+                            progress.update(task, description=extract_substeps.get(step, step))
+
+                        transcript_result = await transcription_manager.transcribe(
+                            url,
+                            use_cache=True,
+                            auth_username=auth_username,
+                            auth_password=auth_password,
+                            progress_callback=handle_extract_progress,
+                            transcriber_override=transcriber,
+                        )
+                        progress.update(task, completed=True)
+
+                    if not transcript_result.success or transcript_result.transcript is None:
+                        raise InkwellError(
+                            "Transcript extraction failed",
+                            suggestion=transcript_result.error,
+                        )
+
+                    transcript_text = transcript_result.transcript.full_text
+
+                    if output_dir is not None:
+                        output_dir.mkdir(parents=True, exist_ok=True)
+                        transcript_path = _extract_transcript_output_path(
+                            output_dir=output_dir,
+                            title=episode_title,
+                            url=url,
+                            used_filenames=extract_used_filenames,
+                            overwrite=overwrite,
+                        )
+                        transcript_path.write_text(transcript_text, encoding="utf-8")
+                        extract_output_paths.append(transcript_path)
+                        status_console.print(f"[green]✓[/green] Wrote {transcript_path}")
+                    else:
+                        extract_transcripts.append(transcript_text)
+
+                    continue
 
                 # Compute effective output directory
                 effective_output_dir = base_output_dir
@@ -1677,6 +1855,13 @@ def fetch_command(
                         "\n[dim]Want to track this channel? Re-run with "
                         "[cyan]--save-feed[/cyan] to save it as a feed.[/dim]"
                     )
+
+            if extract_only:
+                if output_dir is None:
+                    print("\n\n".join(extract_transcripts))
+                elif plain:
+                    print("\n".join(str(path) for path in extract_output_paths))
+                return
 
             if json_output:
                 _print_json_payload(

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -472,6 +472,134 @@ class TestCLIFetchMachineOutput:
         assert result.stdout == ""
 
 
+class TestCLIFetchExtractOnly:
+    """Tests for `inkwell fetch --extract` transcript-only mode."""
+
+    def test_fetch_extract_outputs_transcript_to_stdout_and_skips_pipeline(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Transcript-only mode does not run structured extraction or write notes."""
+        monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
+        seen: dict[str, object] = {}
+
+        async def fake_transcribe(_manager, episode_url: str, **kwargs):
+            seen["url"] = episode_url
+            seen["kwargs"] = kwargs
+            return _sample_transcription_result()
+
+        async def fail_process(*_args, **_kwargs):
+            raise AssertionError("Pipeline should not run in --extract mode")
+
+        monkeypatch.setattr("inkwell.cli.TranscriptionManager.transcribe", fake_transcribe)
+        monkeypatch.setattr("inkwell.pipeline.PipelineOrchestrator.process_episode", fail_process)
+
+        result = runner.invoke(
+            app,
+            ["fetch", "https://example.com/great-talk.mp3", "--extract"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert result.stdout == "Hello world\n"
+        assert "Inkwell Extraction Pipeline" not in result.stdout
+        assert "Inkwell Extraction Pipeline" not in result.stderr
+        assert seen["url"] == "https://example.com/great-talk.mp3"
+
+    def test_fetch_extract_writes_transcript_file_when_output_dir_requested(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """An explicit output directory writes transcript-only files, not note folders."""
+        monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
+        output_dir = tmp_path / "transcripts"
+
+        async def fake_transcribe(*_args, **_kwargs):
+            return _sample_transcription_result()
+
+        monkeypatch.setattr("inkwell.cli.TranscriptionManager.transcribe", fake_transcribe)
+
+        result = runner.invoke(
+            app,
+            [
+                "fetch",
+                "https://example.com/great-talk.mp3",
+                "--extract",
+                "--output-dir",
+                str(output_dir),
+                "--plain",
+            ],
+        )
+
+        expected_path = output_dir / "great-talk.transcript.md"
+        assert result.exit_code == 0, result.output
+        assert result.stdout == f"{expected_path}\n"
+        assert expected_path.read_text(encoding="utf-8") == "Hello world"
+        assert not (output_dir / "summary.md").exists()
+
+    def test_fetch_extract_preserves_saved_feed_latest_selection(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Extract-only mode still uses saved feed episode selection."""
+        from types import SimpleNamespace
+
+        monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
+
+        manager = ConfigManager(config_dir=tmp_path)
+        from inkwell.config.schema import FeedConfig as _FeedConfig
+
+        manager.add_feed(
+            "saved-show",
+            _FeedConfig(url="https://example.com/feed.rss"),  # type: ignore[arg-type]
+        )
+
+        async def fake_fetch_feed(*_args, **_kwargs):
+            return SimpleNamespace(entries=[object()])
+
+        def fake_get_latest_episode(*_args, **_kwargs):
+            return SimpleNamespace(
+                title="Latest Talk",
+                url="https://example.com/latest-talk.mp3",
+                podcast_name="Saved Show",
+            )
+
+        seen_urls: list[str] = []
+
+        async def fake_transcribe(_manager, episode_url: str, **_kwargs):
+            seen_urls.append(episode_url)
+            return _sample_transcription_result()
+
+        monkeypatch.setattr("inkwell.feeds.parser.RSSParser.fetch_feed", fake_fetch_feed)
+        monkeypatch.setattr(
+            "inkwell.feeds.parser.RSSParser.get_latest_episode",
+            fake_get_latest_episode,
+        )
+        monkeypatch.setattr("inkwell.cli.TranscriptionManager.transcribe", fake_transcribe)
+
+        result = runner.invoke(app, ["fetch", "saved-show", "--latest", "--extract"])
+
+        assert result.exit_code == 0, result.output
+        assert result.stdout == "Hello world\n"
+        assert seen_urls == ["https://example.com/latest-talk.mp3"]
+
+    def test_fetch_extract_rejects_structured_extraction_options(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Options that imply structured notes are rejected instead of ignored."""
+        monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
+
+        result = runner.invoke(
+            app,
+            [
+                "fetch",
+                "https://example.com/great-talk.mp3",
+                "--extract",
+                "--interview",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "--extract cannot be combined with --interview" in result.stderr
+        assert result.stdout == ""
+
+
 class TestCLIFetchSaveFeed:
     """Pre-fetch validation for `inkwell fetch --save-feed`.
 


### PR DESCRIPTION
## Summary
- Added inkwell fetch --extract for transcript-only media extraction without structured notes, interview mode, or default episode output directories.
- Preserved direct URL and saved-feed episode selection behavior while routing progress to stderr and transcript text to stdout.
- Added optional --output-dir transcript file output plus docs and focused CLI tests.

## Tests
- uv run pytest tests/integration/test_cli.py::TestCLIFetchExtractOnly
- uv run ruff format .
- uv run ruff check .
- uv run pytest tests/integration/test_cli.py::TestCLIFetchExtractOnly tests/integration/test_cli.py::TestCLIFetchMachineOutput tests/integration/test_cli.py::TestCLIHelp
- uv run pytest
- git push -u origin codex/extract-only-mode (pre-push: ruff, ruff format, pytest)

## Follow-up
- Phase 6: local file and stdin ingestion.
- Phase 7: provider attempt policy for transcription fallback ordering.
