### PR TITLE
feat: add local file and stdin ingestion

### DIFF
--- a/docs/building-in-public/devlog/2026-05-21-local-file-stdin-ingestion.md
+++ b/docs/building-in-public/devlog/2026-05-21-local-file-stdin-ingestion.md
@@ -1,0 +1,37 @@
+# Local File And Stdin Ingestion
+
+**Date:** 2026-05-21
+**Author:** Codex
+
+## Focus
+
+Implement Phase 6 of the summarize-inspired CLI evolution: let Inkwell ingest local audio/video files, local text/markdown files, and stdin without turning the CLI into a generic article/PDF/OCR summarizer.
+
+## Plan
+
+- Route local audio/video files through the existing transcription path.
+- Route local `.txt` and `.md` files directly into extraction templates as source text.
+- Route stdin text directly into extraction templates as source text.
+- Preserve existing saved-feed and URL behavior.
+- Keep PDF, web article extraction, OCR, and slide ingestion out of scope.
+- Add focused tests and user-facing docs for the new input surfaces.
+
+## Notes
+
+This phase should continue to produce Inkwell-style structured knowledge notes. Local text/stdin are treated as already-clean source text for the same template extraction pipeline, not as generic summarizer inputs.
+
+## Progress
+
+- Started implementation on `codex/local-file-stdin-ingestion`.
+- Routed local audio/video files through transcription without downloading through `yt-dlp`.
+- Routed local `.txt`/`.md` files and stdin text into the existing template extraction pipeline as source text.
+- Added explicit unsupported-local-file errors for PDF/article/OCR-style inputs.
+- Documented local file/stdin usage and out-of-scope formats.
+- Verified focused tests, formatting, linting, mypy, and the full test suite locally.
+
+## Links
+
+- Related devlog: `./2026-05-21-extract-only-mode.md`
+- Related roadmap: `../../../2026-roadmap/03-universal-content-ingestion.md`
+- PR: TBD
+- Issue: TBD

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -240,7 +240,7 @@ inkwell fetch <SOURCE> [OPTIONS]
 
 | Argument | Required | Description |
 |----------|----------|-------------|
-| `SOURCE` | Yes | Feed name or episode URL |
+| `SOURCE` | Yes | Feed name, episode/media URL, local audio/video file, local `.txt`/`.md` file, or `-` for stdin text |
 
 ### Options
 
@@ -276,6 +276,15 @@ inkwell fetch <SOURCE> [OPTIONS]
 ```bash
 # From URL
 inkwell fetch https://youtube.com/watch?v=xyz
+
+# From local audio/video
+inkwell fetch ~/Downloads/interview.mp3
+
+# From local text or markdown
+inkwell fetch ./notes.md
+
+# From stdin text
+pbpaste | inkwell fetch -
 
 # From URL with custom podcast name
 inkwell fetch https://youtube.com/watch?v=xyz --podcast-name "Python Tutorials"

--- a/docs/user-guide/processing.md
+++ b/docs/user-guide/processing.md
@@ -14,6 +14,21 @@ Process any YouTube video or podcast episode directly:
 inkwell fetch https://youtube.com/watch?v=xyz
 ```
 
+### Process from Local Files or Stdin
+
+Local audio/video routes through transcription. Local text/markdown and stdin are treated as already-clean source text for the extraction templates.
+
+```bash
+# Local audio/video
+inkwell fetch ~/Downloads/interview.mp3
+
+# Local text or markdown
+inkwell fetch ./notes.md
+
+# Pasted/stdin text
+pbpaste | inkwell fetch -
+```
+
 ### Process from Feed
 
 If you've added a feed, process by feed name:
@@ -196,6 +211,8 @@ inkwell fetch my-podcast --latest --extract --output-dir ~/transcripts --plain
 ```
 
 Use this when you want the clean media transcript first and want to decide later whether to run Inkwell's structured note templates or reflection flow.
+
+PDFs, web article extraction, slide decks, and OCR inputs are not part of local/stdin ingestion yet.
 
 ### Re-extract with Different Templates
 

--- a/src/inkwell/cli.py
+++ b/src/inkwell/cli.py
@@ -53,6 +53,28 @@ console = Console()
 # post-fetch save notices).
 err_console = Console(stderr=True)
 
+_LOCAL_TEXT_EXTENSIONS = {".txt", ".md", ".markdown"}
+_LOCAL_MEDIA_EXTENSIONS = {
+    ".aac",
+    ".aif",
+    ".aiff",
+    ".avi",
+    ".flac",
+    ".m4a",
+    ".m4v",
+    ".mkv",
+    ".mov",
+    ".mp3",
+    ".mp4",
+    ".mpeg",
+    ".mpg",
+    ".oga",
+    ".ogg",
+    ".opus",
+    ".wav",
+    ".webm",
+}
+
 
 def _register_subcommands() -> None:
     """Register subcommand apps (lazy import to avoid circular deps)."""
@@ -142,6 +164,33 @@ def _parse_and_validate_extra_templates(value: str | None) -> list[str]:
     templates = _dedupe_template_names(_parse_extra_templates(value))
     _validate_template_names(templates)
     return templates
+
+
+def _is_local_text_path(path: Path) -> bool:
+    """Return True for local text inputs supported in Phase 6."""
+    return path.suffix.lower() in _LOCAL_TEXT_EXTENSIONS
+
+
+def _is_local_media_path(path: Path) -> bool:
+    """Return True for local media inputs supported in Phase 6."""
+    return path.suffix.lower() in _LOCAL_MEDIA_EXTENSIONS
+
+
+def _read_text_source_file(path: Path) -> str:
+    """Read a local text/markdown source file with user-facing errors."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as e:
+        raise ValidationError(
+            f"Local text file is not valid UTF-8: {path}",
+            suggestion="Save the file as UTF-8 text or markdown and try again.",
+        ) from e
+    except OSError as e:
+        raise ValidationError(f"Could not read local file: {path}") from e
+
+    if not text.strip():
+        raise ValidationError("Local text file is empty")
+    return text
 
 
 def _print_json_payload(payload: dict[str, Any]) -> None:
@@ -1378,6 +1427,10 @@ def fetch_command(
             feed_extra_templates: list[str] = []
             # Episode from RSS feed (if applicable)
             ep: Episode | None = None
+            source_text: str | None = None
+            source_kind: str | None = None
+            source_episode_title: str | None = None
+            source_podcast_name: str | None = None
             # Set when the argument resolves to a configured feed (and we fan
             # out into its episodes); stays None for direct-URL mode.
             selected_episodes: list[Episode] | None = None
@@ -1429,27 +1482,42 @@ def fetch_command(
                     # pre-empt it here — just fall back to "Unknown Podcast".
                     pre_resolved = None
 
-            if not is_url:
+            if input_source.kind == ContentSourceKind.LOCAL_FILE:
+                local_path = input_source.path or Path(input_source.value)
+                local_path = local_path.expanduser()
+                if _is_local_text_path(local_path):
+                    source_text = _read_text_source_file(local_path)
+                    source_kind = "local_text"
+                    source_episode_title = local_path.stem
+                    source_podcast_name = "Local Files"
+                    url = str(local_path)
+                elif _is_local_media_path(local_path):
+                    source_episode_title = local_path.stem
+                    source_podcast_name = "Local Files"
+                    url = str(local_path)
+                else:
+                    raise ValidationError(
+                        f"Unsupported local file type: {local_path.suffix or '<none>'}",
+                        suggestion=(
+                            "Use local audio/video, .txt, or .md files for now. "
+                            "PDF, article, slide, and OCR ingestion are planned later."
+                        ),
+                    )
+
+            elif input_source.kind == ContentSourceKind.STDIN:
+                source_text = sys.stdin.read()
+                if not source_text.strip():
+                    raise ValidationError("Stdin input is empty")
+                source_kind = "stdin"
+                source_episode_title = "stdin"
+                source_podcast_name = "Stdin"
+                url = "stdin://input"
+
+            elif not is_url:
                 # Treat as feed name - look up in configured feeds
                 try:
                     feed_config = manager.get_feed(url_or_feed)
                 except NotFoundError as e:
-                    if input_source.kind == ContentSourceKind.STDIN:
-                        raise ValidationError(
-                            "Stdin ingestion is recognized but not supported by fetch yet",
-                            suggestion=(
-                                "Use a saved feed or media URL for now. Stdin routing is planned "
-                                "for the local/stdin ingestion phase."
-                            ),
-                        ) from e
-                    if input_source.kind == ContentSourceKind.LOCAL_FILE:
-                        raise ValidationError(
-                            "Local file ingestion is recognized but not supported by fetch yet",
-                            suggestion=(
-                                "Use a saved feed or media URL for now. Local audio/video routing "
-                                "is planned for the local/stdin ingestion phase."
-                            ),
-                        ) from e
                     if input_source.kind == ContentSourceKind.UNKNOWN_URL:
                         raise ValidationError(
                             f"Unsupported URL input: {input_source.value}",
@@ -1551,53 +1619,61 @@ def fetch_command(
                 if ep is not None:
                     episode_title = ep.title
                     detected_podcast_name = ep.podcast_name or url_or_feed
+                elif source_episode_title is not None:
+                    episode_title = source_episode_title
+                    detected_podcast_name = source_podcast_name
                 elif pre_resolved is not None and pre_resolved.episode_title:
                     # Direct YouTube URL: when yt-dlp provides a video title,
                     # use it so direct-URL capture folders are readable.
                     episode_title = pre_resolved.episode_title
 
                 if extract_only:
-                    transcription_manager = TranscriptionManager(
-                        config=config.transcription,
-                        media_cache=config.cache.media,
-                    )
-
-                    extract_substeps = {
-                        "checking_cache": "Checking transcript cache...",
-                        "trying_youtube": "Trying YouTube transcript...",
-                        "downloading_audio": "Downloading audio...",
-                        "transcribing_gemini": "Transcribing with Gemini...",
-                        "transcribing_gemini_youtube": "Transcribing YouTube URL with Gemini...",
-                        "caching_result": "Caching transcript...",
-                    }
-
-                    with Progress(
-                        SpinnerColumn(),
-                        TextColumn("[progress.description]{task.description}"),
-                        console=status_console,
-                    ) as progress:
-                        task = progress.add_task("Extracting transcript...", total=None)
-
-                        def handle_extract_progress(step: str, _data: dict) -> None:
-                            progress.update(task, description=extract_substeps.get(step, step))
-
-                        transcript_result = await transcription_manager.transcribe(
-                            url,
-                            use_cache=True,
-                            auth_username=auth_username,
-                            auth_password=auth_password,
-                            progress_callback=handle_extract_progress,
-                            transcriber_override=transcriber,
-                        )
-                        progress.update(task, completed=True)
-
-                    if not transcript_result.success or transcript_result.transcript is None:
-                        raise InkwellError(
-                            "Transcript extraction failed",
-                            suggestion=transcript_result.error,
+                    if source_text is not None:
+                        transcript_text = source_text
+                    else:
+                        transcription_manager = TranscriptionManager(
+                            config=config.transcription,
+                            media_cache=config.cache.media,
                         )
 
-                    transcript_text = transcript_result.transcript.full_text
+                        extract_substeps = {
+                            "checking_cache": "Checking transcript cache...",
+                            "trying_youtube": "Trying YouTube transcript...",
+                            "downloading_audio": "Downloading audio...",
+                            "transcribing_gemini": "Transcribing with Gemini...",
+                            "transcribing_gemini_youtube": (
+                                "Transcribing YouTube URL with Gemini..."
+                            ),
+                            "caching_result": "Caching transcript...",
+                        }
+
+                        with Progress(
+                            SpinnerColumn(),
+                            TextColumn("[progress.description]{task.description}"),
+                            console=status_console,
+                        ) as progress:
+                            task = progress.add_task("Extracting transcript...", total=None)
+
+                            def handle_extract_progress(step: str, _data: dict) -> None:
+                                progress.update(task, description=extract_substeps.get(step, step))
+
+                            transcript_result = await transcription_manager.transcribe(
+                                url,
+                                use_cache=True,
+                                auth_username=auth_username,
+                                auth_password=auth_password,
+                                progress_callback=handle_extract_progress,
+                                transcriber_override=transcriber,
+                            )
+                            progress.update(task, completed=True)
+
+                        if not transcript_result.success or transcript_result.transcript is None:
+                            raise InkwellError(
+                                "Transcript extraction failed",
+                                suggestion=transcript_result.error,
+                            )
+
+                        transcript_text = transcript_result.transcript.full_text
 
                     if output_dir is not None:
                         output_dir.mkdir(parents=True, exist_ok=True)
@@ -1654,6 +1730,8 @@ def fetch_command(
                     auth_password=auth_password,
                     episode_title=episode_title,
                     podcast_name=podcast_name or detected_podcast_name,
+                    source_text=source_text,
+                    source_kind=source_kind,
                     extractor=extractor,
                     transcriber=transcriber,
                 )

--- a/src/inkwell/pipeline/models.py
+++ b/src/inkwell/pipeline/models.py
@@ -33,6 +33,9 @@ class PipelineOptions:
     # Episode metadata (from RSS feed)
     episode_title: str | None = None
     podcast_name: str | None = None
+    # Already-clean source text (local .txt/.md files or stdin)
+    source_text: str | None = None
+    source_kind: str | None = None
     # Plugin overrides (from CLI flags or env vars)
     extractor: str | None = None
     transcriber: str | None = None

--- a/src/inkwell/pipeline/orchestrator.py
+++ b/src/inkwell/pipeline/orchestrator.py
@@ -19,6 +19,7 @@ from inkwell.feeds.models import Episode
 from inkwell.interview import conduct_interview_from_output
 from inkwell.output import EpisodeMetadata, EpisodeOutput, OutputManager
 from inkwell.transcription import TranscriptionManager
+from inkwell.transcription.models import Transcript, TranscriptionResult, TranscriptSegment
 from inkwell.utils.api_keys import APIKeyError, get_validated_api_key
 from inkwell.utils.costs import CostTracker
 from inkwell.utils.datetime import now_utc
@@ -183,6 +184,8 @@ class PipelineOrchestrator:
 
         transcript_result = await self._transcribe(
             options.url,
+            source_text=options.source_text,
+            source_kind=options.source_kind,
             auth_username=options.auth_username,
             auth_password=options.auth_password,
             progress_callback=transcription_progress,
@@ -409,6 +412,8 @@ class PipelineOrchestrator:
     async def _transcribe(
         self,
         url: str,
+        source_text: str | None = None,
+        source_kind: str | None = None,
         auth_username: str | None = None,
         auth_password: str | None = None,
         progress_callback: Callable[[str, dict], None] | None = None,
@@ -418,6 +423,8 @@ class PipelineOrchestrator:
 
         Args:
             url: Episode URL
+            source_text: Already-clean text to extract from without media transcription
+            source_kind: Source label for already-clean text
             auth_username: Username for authenticated audio downloads (private feeds)
             auth_password: Password for authenticated audio downloads (private feeds)
             progress_callback: Optional callback for transcription sub-step progress
@@ -429,6 +436,27 @@ class PipelineOrchestrator:
         Raises:
             InkwellError: If transcription fails
         """
+        if source_text is not None:
+            text = source_text.strip()
+            if not text:
+                raise InkwellError("Source text is empty")
+
+            transcript = Transcript(
+                segments=[TranscriptSegment(text=text, start=0.0, duration=0.0)],
+                source="text",
+                language="und",
+                episode_url=url,
+                word_count=len(text.split()),
+            )
+            return TranscriptionResult(
+                success=True,
+                transcript=transcript,
+                attempts=[source_kind or "text"],
+                duration_seconds=0.0,
+                cost_usd=0.0,
+                from_cache=False,
+            )
+
         manager = TranscriptionManager(
             config=self.config.transcription,
             media_cache=self.config.cache.media,
@@ -479,7 +507,7 @@ class PipelineOrchestrator:
         # url is HttpUrl but Pydantic validates str at runtime
         episode = Episode(
             title=episode_title,
-            url=episode_url,  # type: ignore[arg-type]
+            url=self._template_safe_episode_url(episode_url),  # type: ignore[arg-type]
             published=now_utc(),
             description="",
             podcast_name=podcast_name,
@@ -493,6 +521,12 @@ class PipelineOrchestrator:
         )
 
         return selected_templates
+
+    def _template_safe_episode_url(self, episode_url: str) -> str:
+        """Return an HTTP URL placeholder for local/stdin template selection."""
+        if episode_url.startswith(("http://", "https://")):
+            return episode_url
+        return "https://local.inkwell/source"
 
     async def _extract_content(
         self,

--- a/src/inkwell/transcription/manager.py
+++ b/src/inkwell/transcription/manager.py
@@ -6,6 +6,7 @@ import os
 import warnings
 from collections.abc import Callable
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
@@ -280,6 +281,7 @@ class TranscriptionManager:
                 progress_callback(step, kwargs)
 
         override = transcriber_override or os.environ.get("INKWELL_TRANSCRIBER")
+        local_media_path = self._local_media_path(episode_url)
         if override:
             return await self._transcribe_with_override(
                 override,
@@ -287,6 +289,14 @@ class TranscriptionManager:
                 use_cache,
                 auth_username,
                 auth_password,
+                progress_callback,
+                local_media_path=local_media_path,
+            )
+
+        if local_media_path is not None:
+            return await self._transcribe_local_media(
+                local_media_path,
+                episode_url,
                 progress_callback,
             )
 
@@ -491,6 +501,82 @@ class TranscriptionManager:
         host = parsed.netloc.lower()
         return host in {"youtu.be", "youtube.com", "www.youtube.com", "m.youtube.com"}
 
+    def _local_media_path(self, value: str) -> Path | None:
+        """Return a local media path when transcription input is a file."""
+        path = Path(value).expanduser()
+        if path.is_file():
+            return path
+        return None
+
+    async def _transcribe_local_media(
+        self,
+        audio_path: Path,
+        episode_url: str,
+        progress_callback: Callable[[str, dict], None] | None,
+    ) -> TranscriptionResult:
+        """Transcribe an already-local audio/video file without downloading it."""
+        start_time = datetime.now(timezone.utc)
+        attempts = ["gemini"]
+
+        def _progress(step: str, **kwargs: object) -> None:
+            if progress_callback:
+                progress_callback(step, kwargs)
+
+        if self.gemini_transcriber is None:
+            duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+            return TranscriptionResult(
+                success=False,
+                error=(
+                    "Transcription failed: Local media files require Gemini transcription, "
+                    "but the API key is not configured.\n\n"
+                    "Configure your Google AI API key:\n"
+                    "  inkwell config set transcription.api_key YOUR_API_KEY"
+                ),
+                attempts=attempts,
+                duration_seconds=duration,
+                cost_usd=0.0,
+                from_cache=False,
+            )
+
+        try:
+            _progress("transcribing_gemini", audio_path=str(audio_path))
+            transcript = await self.gemini_transcriber.transcribe(audio_path, episode_url)
+            total_cost = transcript.cost_usd or 0.0
+
+            try:
+                if total_cost and self.cost_tracker:
+                    transcript_tokens = len(transcript.full_text) // 4
+                    self.cost_tracker.add_cost(
+                        provider="gemini",
+                        model="gemini-2.5-flash",
+                        operation="transcription",
+                        input_tokens=transcript_tokens,
+                        output_tokens=transcript_tokens,
+                        episode_title=None,
+                    )
+            except Exception as e:
+                logger.warning(f"Failed to track transcription cost: {e}")
+
+            duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+            return TranscriptionResult(
+                success=True,
+                transcript=transcript,
+                attempts=attempts,
+                duration_seconds=duration,
+                cost_usd=total_cost,
+                from_cache=False,
+            )
+        except Exception as e:
+            duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+            return TranscriptionResult(
+                success=False,
+                error=f"Local media transcription failed: {e}",
+                attempts=attempts,
+                duration_seconds=duration,
+                cost_usd=0.0,
+                from_cache=False,
+            )
+
     async def _transcribe_with_override(
         self,
         transcriber_name: str,
@@ -499,6 +585,7 @@ class TranscriptionManager:
         auth_username: str | None,
         auth_password: str | None,
         progress_callback: Callable[[str, dict], None] | None,
+        local_media_path: Path | None = None,
     ) -> TranscriptionResult:
         """Transcribe using a specific plugin (environment variable override).
 
@@ -561,12 +648,15 @@ class TranscriptionManager:
                 transcript = await plugin.transcribe(request)
             # Gemini and other file-based plugins need audio download first
             else:
-                _progress("downloading_audio", url=episode_url)
-                audio_path = await self.audio_downloader.download(
-                    episode_url,
-                    username=auth_username,
-                    password=auth_password,
-                )
+                if local_media_path is not None:
+                    audio_path = local_media_path
+                else:
+                    _progress("downloading_audio", url=episode_url)
+                    audio_path = await self.audio_downloader.download(
+                        episode_url,
+                        username=auth_username,
+                        password=auth_password,
+                    )
                 _progress(f"transcribing_{transcriber_name}", audio_path=str(audio_path))
                 request = TranscriptionRequest(file_path=audio_path)
                 transcript = await plugin.transcribe(request)

--- a/src/inkwell/transcription/models.py
+++ b/src/inkwell/transcription/models.py
@@ -63,7 +63,7 @@ class Transcript(BaseModel):
     segments: list[TranscriptSegment] = Field(
         default_factory=list, description="List of transcript segments with timing"
     )
-    source: Literal["youtube", "gemini", "cached"] = Field(
+    source: Literal["youtube", "gemini", "cached", "text"] = Field(
         ..., description="Source of the transcript"
     )
     language: str = Field(default="en", description="Language code (ISO 639-1)")
@@ -126,7 +126,7 @@ class Transcript(BaseModel):
     @property
     def is_free(self) -> bool:
         """Check if this transcript was free (YouTube) or cost money (Gemini)."""
-        return self.source in ("youtube", "cached")
+        return self.source in ("youtube", "cached", "text")
 
     def get_segment_at_time(self, time_seconds: float) -> TranscriptSegment | None:
         """Get segment containing a specific timestamp.

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1415,14 +1415,23 @@ class TestCLIFetchSaveFeed:
         assert result.exit_code != 0
         assert "Playlist" in result.stdout or "playlist" in result.stdout
 
-    def test_fetch_local_file_is_recognized_but_not_processed_yet(
-        self, tmp_path: Path, monkeypatch
-    ) -> None:
-        """Phase 1 recognizes local files without routing them through fetch yet."""
+    def test_fetch_local_media_file_routes_to_pipeline(self, tmp_path: Path, monkeypatch) -> None:
+        """Local audio/video files are accepted as media transcription inputs."""
         monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
 
         local_media = tmp_path / "episode.mp3"
         local_media.write_bytes(b"fake audio")
+        output_dir = tmp_path / "episode-dir"
+        output_dir.mkdir()
+        seen: dict[str, object] = {}
+
+        async def fake_process(_orchestrator, options, *_args, **_kwargs):
+            seen["url"] = options.url
+            seen["source_text"] = options.source_text
+            seen["episode_title"] = options.episode_title
+            return _sample_pipeline_result(output_dir)
+
+        monkeypatch.setattr("inkwell.pipeline.PipelineOrchestrator.process_episode", fake_process)
 
         result = runner.invoke(
             app,
@@ -1430,31 +1439,95 @@ class TestCLIFetchSaveFeed:
                 "fetch",
                 str(local_media),
                 "--dry-run",
+                "--output-dir",
+                str(tmp_path),
             ],
         )
 
-        assert result.exit_code != 0
-        assert "Local file ingestion is recognized" in result.output
-        assert "saved feed or media URL" in result.output
+        assert result.exit_code == 0, result.output
+        assert seen["url"] == str(local_media)
+        assert seen["source_text"] is None
+        assert seen["episode_title"] == "episode"
 
-    def test_fetch_stdin_is_recognized_but_not_processed_yet(
+    def test_fetch_local_text_file_routes_source_text_to_pipeline(
         self, tmp_path: Path, monkeypatch
     ) -> None:
-        """Phase 1 recognizes stdin without introducing text ingestion yet."""
+        """Local text/markdown files bypass transcription and feed extraction templates."""
         monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
+
+        local_text = tmp_path / "notes.md"
+        local_text.write_text("# Notes\n\nImportant source text.", encoding="utf-8")
+        output_dir = tmp_path / "episode-dir"
+        output_dir.mkdir()
+        seen: dict[str, object] = {}
+
+        async def fake_process(_orchestrator, options, *_args, **_kwargs):
+            seen["url"] = options.url
+            seen["source_text"] = options.source_text
+            seen["source_kind"] = options.source_kind
+            seen["episode_title"] = options.episode_title
+            return _sample_pipeline_result(output_dir)
+
+        monkeypatch.setattr("inkwell.pipeline.PipelineOrchestrator.process_episode", fake_process)
 
         result = runner.invoke(
             app,
             [
                 "fetch",
-                "-",
+                str(local_text),
                 "--dry-run",
+                "--output-dir",
+                str(tmp_path),
             ],
         )
 
+        assert result.exit_code == 0, result.output
+        assert seen["url"] == str(local_text)
+        assert seen["source_text"] == "# Notes\n\nImportant source text."
+        assert seen["source_kind"] == "local_text"
+        assert seen["episode_title"] == "notes"
+
+    def test_fetch_stdin_routes_source_text_to_pipeline(self, tmp_path: Path, monkeypatch) -> None:
+        """Stdin text bypasses transcription and feeds extraction templates."""
+        monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
+
+        output_dir = tmp_path / "episode-dir"
+        output_dir.mkdir()
+        seen: dict[str, object] = {}
+
+        async def fake_process(_orchestrator, options, *_args, **_kwargs):
+            seen["url"] = options.url
+            seen["source_text"] = options.source_text
+            seen["source_kind"] = options.source_kind
+            seen["episode_title"] = options.episode_title
+            return _sample_pipeline_result(output_dir)
+
+        monkeypatch.setattr("inkwell.pipeline.PipelineOrchestrator.process_episode", fake_process)
+
+        result = runner.invoke(
+            app,
+            ["fetch", "-", "--dry-run", "--output-dir", str(tmp_path)],
+            input="Pasted source text",
+        )
+
+        assert result.exit_code == 0, result.output
+        assert seen["url"] == "stdin://input"
+        assert seen["source_text"] == "Pasted source text"
+        assert seen["source_kind"] == "stdin"
+        assert seen["episode_title"] == "stdin"
+
+    def test_fetch_unsupported_local_file_type_errors(self, tmp_path: Path, monkeypatch) -> None:
+        """PDF/article/OCR-style inputs remain out of scope for Phase 6."""
+        monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
+
+        local_pdf = tmp_path / "paper.pdf"
+        local_pdf.write_bytes(b"%PDF")
+
+        result = runner.invoke(app, ["fetch", str(local_pdf), "--dry-run"])
+
         assert result.exit_code != 0
-        assert "Stdin ingestion is recognized" in result.output
-        assert "saved feed or media URL" in result.output
+        assert "Unsupported local file type" in result.output
+        assert "PDF" in result.output
 
 
 class TestCLIFetchHintSuppression:

--- a/tests/unit/test_pipeline_orchestrator.py
+++ b/tests/unit/test_pipeline_orchestrator.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from inkwell.config.schema import GlobalConfig
 from inkwell.pipeline.models import PipelineOptions
 from inkwell.pipeline.orchestrator import PipelineOrchestrator
@@ -58,3 +60,35 @@ def test_podcast_name_override_wins_over_inbox_default(tmp_path: Path) -> None:
 
     assert podcast_name == "My Override"
     assert episode_title == "episode 12"
+
+
+@pytest.mark.asyncio
+async def test_transcribe_source_text_bypasses_media_transcription(tmp_path: Path) -> None:
+    orchestrator = _orchestrator(tmp_path)
+
+    result = await orchestrator._transcribe(
+        "stdin://input",
+        source_text="Already clean source text",
+        source_kind="stdin",
+    )
+
+    assert result.success is True
+    assert result.transcript is not None
+    assert result.transcript.source == "text"
+    assert result.transcript.full_text == "Already clean source text"
+    assert result.attempts == ["stdin"]
+    assert result.cost_usd == 0.0
+
+
+def test_template_safe_episode_url_uses_placeholder_for_local_sources(tmp_path: Path) -> None:
+    orchestrator = _orchestrator(tmp_path)
+
+    assert orchestrator._template_safe_episode_url("/tmp/source.md") == (
+        "https://local.inkwell/source"
+    )
+    assert orchestrator._template_safe_episode_url("stdin://input") == (
+        "https://local.inkwell/source"
+    )
+    assert orchestrator._template_safe_episode_url("https://example.com/episode.mp3") == (
+        "https://example.com/episode.mp3"
+    )

--- a/tests/unit/transcription/test_manager.py
+++ b/tests/unit/transcription/test_manager.py
@@ -391,6 +391,34 @@ class TestTranscriptionManager:
         mock_gemini.transcribe.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_transcribe_local_media_uses_gemini_without_download(
+        self,
+        tmp_path: Path,
+        manager: TranscriptionManager,
+        mock_cache: Mock,
+        mock_youtube: Mock,
+        mock_downloader: Mock,
+        mock_gemini: Mock,
+        sample_transcript: Transcript,
+    ) -> None:
+        """Local media files are passed directly to Gemini without yt-dlp."""
+        local_media = tmp_path / "episode.mp3"
+        local_media.write_bytes(b"fake audio")
+        gemini_transcript = sample_transcript.model_copy(update={"source": "gemini"})
+        mock_gemini.transcribe.return_value = gemini_transcript
+
+        result = await manager.transcribe(str(local_media))
+
+        assert result.success is True
+        assert result.transcript is not None
+        assert result.transcript.source == "gemini"
+        assert result.attempts == ["gemini"]
+        mock_cache.get.assert_not_called()
+        mock_youtube.can_transcribe.assert_not_called()
+        mock_downloader.download.assert_not_called()
+        mock_gemini.transcribe.assert_called_once_with(local_media, str(local_media))
+
+    @pytest.mark.asyncio
     async def test_download_403_is_not_reported_as_api_auth_failure(
         self,
         manager: TranscriptionManager,

--- a/tests/unit/transcription/test_models.py
+++ b/tests/unit/transcription/test_models.py
@@ -292,6 +292,13 @@ class TestTranscript:
         )
         assert cached.is_free is True
 
+        text = Transcript(
+            segments=[],
+            source="text",
+            episode_url="stdin://input",
+        )
+        assert text.is_free is True
+
         gemini = Transcript(
             segments=[],
             source="gemini",


### PR DESCRIPTION
## Summary
- Added local audio/video file ingestion through the existing transcription flow without routing local files through yt-dlp.
- Added local text/markdown and stdin ingestion as source text for the existing structured extraction pipeline.
- Kept PDF, web article extraction, slide, and OCR inputs out of scope with explicit unsupported-file errors.
- Updated docs and tests for local media, text files, stdin, and transcription model behavior.

## Tests
- uv run pytest tests/integration/test_cli.py::TestCLIFetchSaveFeed::test_fetch_local_media_file_routes_to_pipeline tests/integration/test_cli.py::TestCLIFetchSaveFeed::test_fetch_local_text_file_routes_source_text_to_pipeline tests/integration/test_cli.py::TestCLIFetchSaveFeed::test_fetch_stdin_routes_source_text_to_pipeline tests/integration/test_cli.py::TestCLIFetchSaveFeed::test_fetch_unsupported_local_file_type_errors tests/unit/transcription/test_manager.py::TestTranscriptionManager::test_transcribe_local_media_uses_gemini_without_download tests/unit/test_pipeline_orchestrator.py
- uv run ruff format .
- uv run ruff check .
- uv run mypy src/
- uv run pytest tests/unit/transcription/test_models.py tests/unit/transcription/test_manager.py::TestTranscriptionManager::test_transcribe_local_media_uses_gemini_without_download tests/unit/test_pipeline_orchestrator.py tests/integration/test_cli.py::TestCLIFetchSaveFeed::test_fetch_local_media_file_routes_to_pipeline tests/integration/test_cli.py::TestCLIFetchSaveFeed::test_fetch_local_text_file_routes_source_text_to_pipeline tests/integration/test_cli.py::TestCLIFetchSaveFeed::test_fetch_stdin_routes_source_text_to_pipeline tests/integration/test_cli.py::TestCLIFetchSaveFeed::test_fetch_unsupported_local_file_type_errors
- uv run pytest
- git push -u origin codex/local-file-stdin-ingestion (pre-push: ruff, ruff format, pytest)

## Follow-up
- Phase 7: provider attempt policy for transcription fallback ordering.
- Later: PDF/web article extraction, token-aware routing, slides/OCR.
