### PR TITLE
feat: add transcription attempt policy

### DIFF
--- a/docs/building-in-public/devlog/2026-05-21-transcription-attempt-policy.md
+++ b/docs/building-in-public/devlog/2026-05-21-transcription-attempt-policy.md
@@ -1,0 +1,36 @@
+# Transcription Attempt Policy
+
+**Date:** 2026-05-21
+**Author:** Codex
+
+## Focus
+
+Implement Phase 7 of the summarize-inspired CLI evolution: replace ad hoc transcription fallback ordering with a small policy object that can produce ordered attempts and remain ready for future providers.
+
+## Plan
+
+- Add a transcription attempt policy model with explicit attempt kinds and provider names.
+- Wire `TranscriptionManager` to consult the policy for cache, YouTube transcript, Gemini YouTube URL, Gemini audio, and local media attempts.
+- Preserve the current provider set and user-visible fallback behavior.
+- Keep token-aware routing, new providers, and plugin capability expansion out of scope.
+- Add focused unit tests for policy ordering and manager integration.
+
+## Notes
+
+This phase is about making fallback order intentional and observable, not adding more transcription backends.
+
+## Progress
+
+- Started implementation on `codex/transcription-attempt-policy`.
+- Added `TranscriptionAttemptPolicy` with explicit attempt kinds for cache, YouTube transcript, Gemini YouTube URL, Gemini audio, and Gemini local media.
+- Wired `TranscriptionManager` to consult the policy while preserving current fallback behavior and provider names in attempt records.
+- Added focused policy-ordering tests and a manager integration test for injected policy behavior.
+- Tightened the manager loop so omitted attempts are not run implicitly after earlier failures.
+- Verified focused tests, formatting, linting, mypy, and the full test suite locally.
+
+## Links
+
+- Related devlog: `./2026-05-21-local-file-stdin-ingestion.md`
+- Related roadmap: `../../../2026-roadmap/03-universal-content-ingestion.md`
+- PR: #94
+- Issue: TBD

--- a/src/inkwell/transcription/__init__.py
+++ b/src/inkwell/transcription/__init__.py
@@ -29,6 +29,11 @@ from inkwell.transcription.models import (
     TranscriptionResult,
     TranscriptSegment,
 )
+from inkwell.transcription.policy import (
+    TranscriptionAttempt,
+    TranscriptionAttemptKind,
+    TranscriptionAttemptPolicy,
+)
 from inkwell.transcription.youtube import YouTubeTranscriber
 
 __all__ = [
@@ -40,6 +45,9 @@ __all__ = [
     "TranscriptCache",
     "TRANSCRIPT_CACHE_FORMAT_VERSION",
     "TranscriptionManager",
+    "TranscriptionAttempt",
+    "TranscriptionAttemptKind",
+    "TranscriptionAttemptPolicy",
     "TranscriptSegment",
     "TranscriptionResult",
     "YouTubeTranscriber",

--- a/src/inkwell/transcription/manager.py
+++ b/src/inkwell/transcription/manager.py
@@ -21,6 +21,7 @@ from inkwell.plugins.types.transcription import TranscriptionPlugin, Transcripti
 from inkwell.transcription.cache import TranscriptCache
 from inkwell.transcription.gemini import CostEstimate, GeminiTranscriber
 from inkwell.transcription.models import Transcript, TranscriptionResult
+from inkwell.transcription.policy import TranscriptionAttemptKind, TranscriptionAttemptPolicy
 from inkwell.transcription.youtube import YouTubeTranscriber
 from inkwell.utils.errors import APIError
 
@@ -56,6 +57,7 @@ class TranscriptionManager:
         cost_confirmation_callback: Callable[[CostEstimate], bool] | None = None,
         cost_tracker: "CostTracker | None" = None,
         use_plugin_registry: bool = True,
+        attempt_policy: TranscriptionAttemptPolicy | None = None,
     ):
         """Initialize transcription manager.
 
@@ -71,6 +73,7 @@ class TranscriptionManager:
             cost_confirmation_callback: Callback for Gemini cost confirmation
             cost_tracker: Cost tracker for recording API usage (optional, for DI)
             use_plugin_registry: Whether to load transcribers from plugin registry (default: True)
+            attempt_policy: Ordered fallback policy (default: built-in policy)
 
         Note:
             Prefer passing `config` over individual parameters. Individual parameters
@@ -98,6 +101,7 @@ class TranscriptionManager:
         )
         self.cost_tracker = cost_tracker
         self._use_plugin_registry = use_plugin_registry
+        self.attempt_policy = attempt_policy or TranscriptionAttemptPolicy()
 
         self._config = config
         self._gemini_api_key = gemini_api_key
@@ -280,69 +284,11 @@ class TranscriptionManager:
             if progress_callback:
                 progress_callback(step, kwargs)
 
-        override = transcriber_override or os.environ.get("INKWELL_TRANSCRIBER")
-        local_media_path = self._local_media_path(episode_url)
-        if override:
-            return await self._transcribe_with_override(
-                override,
-                episode_url,
-                use_cache,
-                auth_username,
-                auth_password,
-                progress_callback,
-                local_media_path=local_media_path,
-            )
+        def _record_attempt(provider: str) -> None:
+            if provider not in attempts:
+                attempts.append(provider)
 
-        if local_media_path is not None:
-            return await self._transcribe_local_media(
-                local_media_path,
-                episode_url,
-                progress_callback,
-            )
-
-        is_youtube_url = self._is_youtube_url(episode_url)
-
-        if use_cache:
-            _progress("checking_cache")
-            attempts.append("cache")
-            cached = await self.cache.get(episode_url)
-            if cached:
-                duration = (datetime.now(timezone.utc) - start_time).total_seconds()
-                return TranscriptionResult(
-                    success=True,
-                    transcript=cached,
-                    attempts=attempts,
-                    duration_seconds=duration,
-                    cost_usd=0.0,  # Cache hit is free
-                    from_cache=True,
-                )
-
-        if not skip_youtube and await self.youtube_transcriber.can_transcribe(episode_url):
-            _progress("trying_youtube")
-            attempts.append("youtube")
-            try:
-                transcript = await self.youtube_transcriber.transcribe(episode_url)
-
-                if use_cache:
-                    _progress("caching_result")
-                    await self.cache.set(episode_url, transcript)
-
-                duration = (datetime.now(timezone.utc) - start_time).total_seconds()
-                return TranscriptionResult(
-                    success=True,
-                    transcript=transcript,
-                    attempts=attempts,
-                    duration_seconds=duration,
-                    cost_usd=0.0,  # YouTube tier is free
-                    from_cache=False,
-                )
-
-            except APIError:
-                # YouTube failed - continue to Gemini tier
-                pass
-
-        if self.gemini_transcriber is None:
-            # Gemini not available - provide helpful error message
+        def _gemini_unavailable_result() -> TranscriptionResult:
             duration = (datetime.now(timezone.utc) - start_time).total_seconds()
             error_msg = "Transcription failed: No transcript source available.\n\nAttempted:\n"
             if "youtube" in attempts:
@@ -362,94 +308,25 @@ class TranscriptionManager:
                 from_cache=False,
             )
 
-        gemini_attempt_recorded = False
-        direct_youtube_transcriber = getattr(
-            self.gemini_transcriber, "transcribe_youtube_url", None
-        )
-        if is_youtube_url and callable(direct_youtube_transcriber):
-            attempts.append("gemini")
-            gemini_attempt_recorded = True
-            try:
-                _progress("transcribing_gemini_youtube", url=episode_url)
-                transcript = await direct_youtube_transcriber(episode_url)
-
-                try:
-                    if transcript.cost_usd:
-                        total_cost += transcript.cost_usd
-                except Exception as e:
-                    logger.warning(f"Failed to track transcription cost: {e}")
-
-                if use_cache:
-                    _progress("caching_result")
-                    await self.cache.set(episode_url, transcript)
-
-                duration = (datetime.now(timezone.utc) - start_time).total_seconds()
-                return TranscriptionResult(
-                    success=True,
-                    transcript=transcript,
-                    attempts=attempts,
-                    duration_seconds=duration,
-                    cost_usd=total_cost,
-                    from_cache=False,
-                )
-            except Exception as e:
-                logger.warning(f"Gemini YouTube URL transcription failed: {e}")
-
-        if not gemini_attempt_recorded:
-            attempts.append("gemini")
-
-        try:
-            # Download audio (with auth credentials for private feeds)
-            _progress("downloading_audio", url=episode_url)
-            audio_path = await self.audio_downloader.download(
-                episode_url,
-                username=auth_username,
-                password=auth_password,
-            )
-
-            # Transcribe with Gemini
-            _progress("transcribing_gemini", audio_path=str(audio_path))
-            transcript = await self.gemini_transcriber.transcribe(audio_path, episode_url)
-
-            # Track cost (non-critical - don't fail transcription on cost tracking errors)
-            try:
-                if transcript.cost_usd:
-                    total_cost += transcript.cost_usd
-
-                    if self.cost_tracker:
-                        # Estimate token counts from transcript
-                        # Note: This is approximate; real counts would come from Gemini API
-                        transcript_tokens = len(transcript.full_text) // 4
-                        self.cost_tracker.add_cost(
-                            provider="gemini",
-                            model="gemini-2.5-flash",
-                            operation="transcription",
-                            input_tokens=transcript_tokens,
-                            output_tokens=transcript_tokens,
-                            episode_title=None,  # Not available here
-                        )
-            except Exception as e:
-                logger.warning(f"Failed to track transcription cost: {e}")
-
-            if use_cache:
-                _progress("caching_result")
-                await self.cache.set(episode_url, transcript)
-
+        def _no_source_result() -> TranscriptionResult:
             duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+            attempted = ", ".join(attempts) if attempts else "none"
             return TranscriptionResult(
-                success=True,
-                transcript=transcript,
+                success=False,
+                error=(
+                    "Transcription failed: no transcript source produced a transcript.\n\n"
+                    f"Attempted: {attempted}"
+                ),
                 attempts=attempts,
                 duration_seconds=duration,
                 cost_usd=total_cost,
                 from_cache=False,
             )
 
-        except Exception as e:
-            # All tiers failed - provide detailed error message
+        def _audio_failure_result(error: Exception) -> TranscriptionResult:
             duration = (datetime.now(timezone.utc) - start_time).total_seconds()
 
-            error_str = str(e)
+            error_str = str(error)
             error_msg = f"Transcription failed after {duration:.1f}s.\n\n"
 
             if "timeout" in error_str.lower() or "timed out" in error_str.lower():
@@ -474,7 +351,7 @@ class TranscriptionManager:
                     "  • Private feed requires authentication\n"
                     "  • Network connectivity issues\n"
                     "  • yt-dlp is outdated or blocked by the source site\n\n"
-                    f"Error details: {e}"
+                    f"Error details: {error}"
                 )
             elif "401" in error_str or "403" in error_str or "invalid" in error_str.lower():
                 error_msg += (
@@ -484,7 +361,7 @@ class TranscriptionManager:
                     "Get a new key at: https://aistudio.google.com/apikey"
                 )
             else:
-                error_msg += f"Error details: {e}"
+                error_msg += f"Error details: {error}"
 
             return TranscriptionResult(
                 success=False,
@@ -494,6 +371,177 @@ class TranscriptionManager:
                 cost_usd=total_cost,
                 from_cache=False,
             )
+
+        override = transcriber_override or os.environ.get("INKWELL_TRANSCRIBER")
+        local_media_path = self._local_media_path(episode_url)
+        if override:
+            return await self._transcribe_with_override(
+                override,
+                episode_url,
+                use_cache,
+                auth_username,
+                auth_password,
+                progress_callback,
+                local_media_path=local_media_path,
+            )
+
+        is_youtube_url = self._is_youtube_url(episode_url)
+        attempt_plan = self.attempt_policy.plan(
+            use_cache=use_cache,
+            skip_youtube=skip_youtube,
+            is_youtube_url=is_youtube_url,
+            is_local_media=local_media_path is not None,
+        )
+
+        for attempt in attempt_plan:
+            if attempt.kind is TranscriptionAttemptKind.GEMINI_LOCAL_MEDIA:
+                assert local_media_path is not None
+                return await self._transcribe_local_media(
+                    local_media_path,
+                    episode_url,
+                    progress_callback,
+                )
+
+            if attempt.kind is TranscriptionAttemptKind.CACHE:
+                _progress("checking_cache")
+                _record_attempt(attempt.record_as)
+                cached = await self.cache.get(episode_url)
+                if cached:
+                    duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+                    return TranscriptionResult(
+                        success=True,
+                        transcript=cached,
+                        attempts=attempts,
+                        duration_seconds=duration,
+                        cost_usd=0.0,  # Cache hit is free
+                        from_cache=True,
+                    )
+                continue
+
+            if attempt.kind is TranscriptionAttemptKind.YOUTUBE_TRANSCRIPT:
+                if not await self.youtube_transcriber.can_transcribe(episode_url):
+                    continue
+
+                _progress("trying_youtube")
+                _record_attempt(attempt.record_as)
+                try:
+                    transcript = await self.youtube_transcriber.transcribe(episode_url)
+
+                    if use_cache:
+                        _progress("caching_result")
+                        await self.cache.set(episode_url, transcript)
+
+                    duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+                    return TranscriptionResult(
+                        success=True,
+                        transcript=transcript,
+                        attempts=attempts,
+                        duration_seconds=duration,
+                        cost_usd=0.0,  # YouTube tier is free
+                        from_cache=False,
+                    )
+
+                except APIError:
+                    # YouTube failed - continue to the next policy attempt.
+                    continue
+
+            if attempt.kind is TranscriptionAttemptKind.GEMINI_YOUTUBE_URL:
+                gemini_transcriber = self.gemini_transcriber
+                if gemini_transcriber is None:
+                    return _gemini_unavailable_result()
+
+                direct_youtube_transcriber = getattr(
+                    gemini_transcriber, "transcribe_youtube_url", None
+                )
+                if not callable(direct_youtube_transcriber):
+                    continue
+
+                _record_attempt(attempt.record_as)
+                try:
+                    _progress("transcribing_gemini_youtube", url=episode_url)
+                    transcript = await direct_youtube_transcriber(episode_url)
+
+                    try:
+                        if transcript.cost_usd:
+                            total_cost += transcript.cost_usd
+                    except Exception as e:
+                        logger.warning(f"Failed to track transcription cost: {e}")
+
+                    if use_cache:
+                        _progress("caching_result")
+                        await self.cache.set(episode_url, transcript)
+
+                    duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+                    return TranscriptionResult(
+                        success=True,
+                        transcript=transcript,
+                        attempts=attempts,
+                        duration_seconds=duration,
+                        cost_usd=total_cost,
+                        from_cache=False,
+                    )
+                except Exception as e:
+                    logger.warning(f"Gemini YouTube URL transcription failed: {e}")
+                    continue
+
+            if attempt.kind is TranscriptionAttemptKind.GEMINI_AUDIO:
+                gemini_transcriber = self.gemini_transcriber
+                if gemini_transcriber is None:
+                    return _gemini_unavailable_result()
+
+                _record_attempt(attempt.record_as)
+                try:
+                    # Download audio (with auth credentials for private feeds)
+                    _progress("downloading_audio", url=episode_url)
+                    audio_path = await self.audio_downloader.download(
+                        episode_url,
+                        username=auth_username,
+                        password=auth_password,
+                    )
+
+                    # Transcribe with Gemini
+                    _progress("transcribing_gemini", audio_path=str(audio_path))
+                    transcript = await gemini_transcriber.transcribe(audio_path, episode_url)
+
+                    # Track cost (non-critical - don't fail transcription on cost tracking errors)
+                    try:
+                        if transcript.cost_usd:
+                            total_cost += transcript.cost_usd
+
+                            if self.cost_tracker:
+                                # Estimate token counts from transcript
+                                # Note: This is approximate; real counts would come from Gemini API
+                                transcript_tokens = len(transcript.full_text) // 4
+                                self.cost_tracker.add_cost(
+                                    provider="gemini",
+                                    model="gemini-2.5-flash",
+                                    operation="transcription",
+                                    input_tokens=transcript_tokens,
+                                    output_tokens=transcript_tokens,
+                                    episode_title=None,  # Not available here
+                                )
+                    except Exception as e:
+                        logger.warning(f"Failed to track transcription cost: {e}")
+
+                    if use_cache:
+                        _progress("caching_result")
+                        await self.cache.set(episode_url, transcript)
+
+                    duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+                    return TranscriptionResult(
+                        success=True,
+                        transcript=transcript,
+                        attempts=attempts,
+                        duration_seconds=duration,
+                        cost_usd=total_cost,
+                        from_cache=False,
+                    )
+
+                except Exception as e:
+                    # All policy attempts failed - provide detailed error message.
+                    return _audio_failure_result(e)
+
+        return _no_source_result()
 
     def _is_youtube_url(self, url: str) -> bool:
         """Return True for YouTube watch, shorts, live, and short-link URLs."""

--- a/src/inkwell/transcription/policy.py
+++ b/src/inkwell/transcription/policy.py
@@ -1,0 +1,89 @@
+"""Transcription attempt policy.
+
+The policy keeps fallback order explicit without adding new providers. It is
+small on purpose: future provider plugins can add capability-aware attempts
+without spreading ordering logic through TranscriptionManager.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class TranscriptionAttemptKind(str, Enum):
+    """Supported transcription attempt kinds."""
+
+    CACHE = "cache"
+    YOUTUBE_TRANSCRIPT = "youtube_transcript"
+    GEMINI_YOUTUBE_URL = "gemini_youtube_url"
+    GEMINI_AUDIO = "gemini_audio"
+    GEMINI_LOCAL_MEDIA = "gemini_local_media"
+
+
+@dataclass(frozen=True)
+class TranscriptionAttempt:
+    """One ordered transcription attempt."""
+
+    kind: TranscriptionAttemptKind
+    provider: str
+    record_as: str
+
+
+class TranscriptionAttemptPolicy:
+    """Produce ordered transcription attempts for the current provider set."""
+
+    def plan(
+        self,
+        *,
+        use_cache: bool,
+        skip_youtube: bool,
+        is_youtube_url: bool,
+        is_local_media: bool,
+    ) -> list[TranscriptionAttempt]:
+        """Return ordered attempts for a transcription request."""
+        if is_local_media:
+            return [
+                TranscriptionAttempt(
+                    kind=TranscriptionAttemptKind.GEMINI_LOCAL_MEDIA,
+                    provider="gemini",
+                    record_as="gemini",
+                )
+            ]
+
+        attempts: list[TranscriptionAttempt] = []
+        if use_cache:
+            attempts.append(
+                TranscriptionAttempt(
+                    kind=TranscriptionAttemptKind.CACHE,
+                    provider="cache",
+                    record_as="cache",
+                )
+            )
+
+        if not skip_youtube:
+            attempts.append(
+                TranscriptionAttempt(
+                    kind=TranscriptionAttemptKind.YOUTUBE_TRANSCRIPT,
+                    provider="youtube",
+                    record_as="youtube",
+                )
+            )
+
+        if is_youtube_url:
+            attempts.append(
+                TranscriptionAttempt(
+                    kind=TranscriptionAttemptKind.GEMINI_YOUTUBE_URL,
+                    provider="gemini",
+                    record_as="gemini",
+                )
+            )
+
+        attempts.append(
+            TranscriptionAttempt(
+                kind=TranscriptionAttemptKind.GEMINI_AUDIO,
+                provider="gemini",
+                record_as="gemini",
+            )
+        )
+        return attempts

--- a/tests/unit/transcription/test_manager.py
+++ b/tests/unit/transcription/test_manager.py
@@ -10,6 +10,11 @@ from inkwell.transcription import (
     TranscriptionManager,
     TranscriptSegment,
 )
+from inkwell.transcription.policy import (
+    TranscriptionAttempt,
+    TranscriptionAttemptKind,
+    TranscriptionAttemptPolicy,
+)
 from inkwell.utils.errors import APIError
 
 
@@ -389,6 +394,104 @@ class TestTranscriptionManager:
 
         # Gemini should have been used
         mock_gemini.transcribe.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_transcribe_respects_attempt_policy_order(
+        self,
+        mock_cache: Mock,
+        mock_youtube: Mock,
+        mock_downloader: Mock,
+        mock_gemini: Mock,
+        sample_transcript: Transcript,
+    ) -> None:
+        """A policy can put downloaded-audio Gemini before cache/YouTube."""
+
+        class AudioFirstPolicy(TranscriptionAttemptPolicy):
+            def plan(
+                self,
+                *,
+                use_cache: bool,
+                skip_youtube: bool,
+                is_youtube_url: bool,
+                is_local_media: bool,
+            ) -> list[TranscriptionAttempt]:
+                del use_cache, skip_youtube, is_youtube_url, is_local_media
+                return [
+                    TranscriptionAttempt(
+                        kind=TranscriptionAttemptKind.GEMINI_AUDIO,
+                        provider="gemini",
+                        record_as="gemini",
+                    ),
+                    TranscriptionAttempt(
+                        kind=TranscriptionAttemptKind.CACHE,
+                        provider="cache",
+                        record_as="cache",
+                    ),
+                ]
+
+        manager = TranscriptionManager(
+            cache=mock_cache,
+            youtube_transcriber=mock_youtube,
+            audio_downloader=mock_downloader,
+            gemini_transcriber=mock_gemini,
+            attempt_policy=AudioFirstPolicy(),
+        )
+        gemini_transcript = sample_transcript.model_copy(update={"source": "gemini"})
+        mock_gemini.transcribe.return_value = gemini_transcript
+
+        result = await manager.transcribe("https://youtube.com/watch?v=test")
+
+        assert result.success is True
+        assert result.attempts == ["gemini"]
+        mock_cache.get.assert_not_called()
+        mock_youtube.can_transcribe.assert_not_called()
+        mock_downloader.download.assert_called_once()
+        mock_gemini.transcribe.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_transcribe_policy_can_stop_before_gemini_audio(
+        self,
+        mock_cache: Mock,
+        mock_youtube: Mock,
+        mock_downloader: Mock,
+        mock_gemini: Mock,
+    ) -> None:
+        """If the policy omits Gemini audio, the manager does not run it."""
+
+        class YouTubeOnlyPolicy(TranscriptionAttemptPolicy):
+            def plan(
+                self,
+                *,
+                use_cache: bool,
+                skip_youtube: bool,
+                is_youtube_url: bool,
+                is_local_media: bool,
+            ) -> list[TranscriptionAttempt]:
+                del use_cache, skip_youtube, is_youtube_url, is_local_media
+                return [
+                    TranscriptionAttempt(
+                        kind=TranscriptionAttemptKind.YOUTUBE_TRANSCRIPT,
+                        provider="youtube",
+                        record_as="youtube",
+                    )
+                ]
+
+        manager = TranscriptionManager(
+            cache=mock_cache,
+            youtube_transcriber=mock_youtube,
+            audio_downloader=mock_downloader,
+            gemini_transcriber=mock_gemini,
+            attempt_policy=YouTubeOnlyPolicy(),
+        )
+        mock_youtube.transcribe.side_effect = APIError("YouTube failed")
+
+        result = await manager.transcribe("https://youtube.com/watch?v=test")
+
+        assert result.success is False
+        assert result.attempts == ["youtube"]
+        mock_downloader.download.assert_not_called()
+        mock_gemini.transcribe_youtube_url.assert_not_called()
+        mock_gemini.transcribe.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_transcribe_local_media_uses_gemini_without_download(

--- a/tests/unit/transcription/test_policy.py
+++ b/tests/unit/transcription/test_policy.py
@@ -1,0 +1,78 @@
+"""Tests for transcription attempt policy."""
+
+from inkwell.transcription.policy import TranscriptionAttemptKind, TranscriptionAttemptPolicy
+
+
+def _kinds(policy_result):
+    return [attempt.kind for attempt in policy_result]
+
+
+def test_policy_orders_default_youtube_url_attempts() -> None:
+    policy = TranscriptionAttemptPolicy()
+
+    attempts = policy.plan(
+        use_cache=True,
+        skip_youtube=False,
+        is_youtube_url=True,
+        is_local_media=False,
+    )
+
+    assert _kinds(attempts) == [
+        TranscriptionAttemptKind.CACHE,
+        TranscriptionAttemptKind.YOUTUBE_TRANSCRIPT,
+        TranscriptionAttemptKind.GEMINI_YOUTUBE_URL,
+        TranscriptionAttemptKind.GEMINI_AUDIO,
+    ]
+    assert [attempt.record_as for attempt in attempts] == [
+        "cache",
+        "youtube",
+        "gemini",
+        "gemini",
+    ]
+
+
+def test_policy_skips_cache_and_youtube_when_requested() -> None:
+    policy = TranscriptionAttemptPolicy()
+
+    attempts = policy.plan(
+        use_cache=False,
+        skip_youtube=True,
+        is_youtube_url=True,
+        is_local_media=False,
+    )
+
+    assert _kinds(attempts) == [
+        TranscriptionAttemptKind.GEMINI_YOUTUBE_URL,
+        TranscriptionAttemptKind.GEMINI_AUDIO,
+    ]
+
+
+def test_policy_uses_audio_fallback_for_non_youtube_urls() -> None:
+    policy = TranscriptionAttemptPolicy()
+
+    attempts = policy.plan(
+        use_cache=True,
+        skip_youtube=False,
+        is_youtube_url=False,
+        is_local_media=False,
+    )
+
+    assert _kinds(attempts) == [
+        TranscriptionAttemptKind.CACHE,
+        TranscriptionAttemptKind.YOUTUBE_TRANSCRIPT,
+        TranscriptionAttemptKind.GEMINI_AUDIO,
+    ]
+
+
+def test_policy_local_media_goes_directly_to_gemini() -> None:
+    policy = TranscriptionAttemptPolicy()
+
+    attempts = policy.plan(
+        use_cache=True,
+        skip_youtube=False,
+        is_youtube_url=False,
+        is_local_media=True,
+    )
+
+    assert _kinds(attempts) == [TranscriptionAttemptKind.GEMINI_LOCAL_MEDIA]
+    assert attempts[0].provider == "gemini"


### PR DESCRIPTION
## Summary
- Added a TranscriptionAttemptPolicy foundation that makes transcription fallback attempts explicit and ordered.
- Preserved the existing cache, YouTube transcript, Gemini YouTube URL, Gemini audio, and local media behavior.
- Added focused tests for policy ordering, injected policy behavior, and omitted-attempt compatibility.

## Tests
- uv run pytest tests/unit/transcription/test_policy.py tests/unit/transcription/test_manager.py
- uv run ruff format .
- uv run ruff check .
- uv run mypy src/
- uv run pytest
- git push -u origin codex/transcription-attempt-policy (pre-push: ruff, ruff format, pytest)

## Follow-up
- Later: web/article extraction, token-aware model routing, slides/OCR as separate plans/PRs after the foundation is stable.
