### PR TITLE
docs: document ingestion and CLI foundations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+        args: [--unsafe]
       - id: check-added-large-files
       - id: check-merge-conflict
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,17 @@ Inkwell is beta software with the core podcast-to-markdown pipeline implemented 
 
 Current health baseline:
 - Podcast feed management with RSS and YouTube channel URL support
+- Conservative input resolution for feeds, URLs, local files, stdin, direct media, and YouTube
 - Multi-tier transcription: cache → YouTube transcripts → Gemini YouTube URL/audio fallback
+- Transcript-only extraction for media workflows
+- Local audio/video ingestion plus local text/markdown and stdin extraction
 - Template-based LLM extraction with Claude/Gemini providers
 - Interactive interview mode
 - Obsidian-friendly markdown with frontmatter, wikilinks, and tags
+- JSON/plain output modes for scripting `fetch` and `transcribe`
 - Plugin architecture for extraction, transcription, and output providers
-- Cost tracking, retry logic, and structured errors
-- 1,200+ tests with a measured 75%+ coverage gate
+- Cost tracking, cache observability, bounded media cache controls, retry logic, and structured errors
+- 1,300+ tests with a measured 75%+ coverage gate
 
 ## Quick Start
 
@@ -69,6 +73,24 @@ inkwell fetch syntax --latest
 ```
 
 That's it! You now have a structured markdown directory ready for Obsidian.
+
+You can also start from one-off media, local files, or stdin:
+
+```bash
+# Process a YouTube or direct media URL
+inkwell fetch https://youtube.com/watch?v=xyz
+inkwell fetch https://example.com/episode.mp3
+
+# Process local audio/video
+inkwell fetch ~/Downloads/interview.mp3
+
+# Process local text/markdown or pasted text
+inkwell fetch ./notes.md
+pbpaste | inkwell fetch -
+
+# Get transcript text only
+inkwell fetch https://youtube.com/watch?v=xyz --extract
+```
 
 ## Features
 
@@ -263,18 +285,55 @@ inkwell costs --operation transcription
 inkwell costs --clear
 ```
 
+### Local Files, Stdin, And Transcript-Only Output
+
+```bash
+# Local audio/video routes through transcription
+inkwell fetch ~/Downloads/interview.mp3
+
+# Local text/markdown routes directly to extraction templates
+inkwell fetch ./conference-notes.md --templates summary,key-concepts
+
+# Stdin works the same way for already-clean source text
+pbpaste | inkwell fetch -
+
+# Transcript only, no structured extraction or note directory
+inkwell fetch https://youtube.com/watch?v=xyz --extract
+
+# Write transcript-only files and print their paths
+inkwell fetch syntax --latest --extract --output-dir ~/transcripts --plain
+```
+
+PDF, cleaned web article extraction, slides, and OCR are planned later and are not part of the current local/stdin ingestion path.
+
+### Machine-Readable Output
+
+```bash
+# JSON envelope to stdout; progress and warnings to stderr
+inkwell fetch syntax --latest --json > result.json 2> progress.log
+inkwell transcribe https://youtube.com/watch?v=xyz --json > transcript.json
+
+# Terse stdout for shell scripts
+inkwell fetch https://youtube.com/watch?v=xyz --plain
+inkwell transcribe https://youtube.com/watch?v=xyz --plain
+```
+
+See the [machine-readable output reference](./docs/reference/machine-readable-output.md) for envelope examples and the stdout/stderr contract.
+
 ### Cache Management
 
 ```bash
 # View cache stats
 inkwell cache stats
 
-# Clear all cache
+# Clear cached transcripts
 inkwell cache clear
 
-# Clear expired only
+# Clear expired cached transcripts
 inkwell cache clear-expired
 ```
+
+`inkwell cache stats` reports transcript, extraction, and media/audio caches. `clear` and `clear-expired` currently operate on transcript cache entries; media/audio retention is controlled by `cache.media.*`.
 
 ## Output Structure
 
@@ -327,6 +386,8 @@ Inkwell uses XDG Base Directory specifications:
 - **Feeds**: `~/.config/inkwell/feeds.yaml`
 - **Costs**: `~/.config/inkwell/costs.json`
 - **Cache**: `~/.cache/inkwell/transcripts/`
+- **Extraction Cache**: `~/.cache/inkwell/extractions/`
+- **Media Cache**: `~/.cache/inkwell/audio/`
 - **Logs**: `~/.local/state/inkwell/inkwell.log`
 
 ### Configuration Options
@@ -343,6 +404,12 @@ transcription:
   api_key: ""  # or use GOOGLE_API_KEY
   model_name: gemini-2.5-flash
   youtube_check: true
+
+cache:
+  media:
+    enabled: true
+    max_mb: 2048
+    ttl_days: 30
 
 extraction:
   default_provider: gemini  # or "claude"
@@ -393,9 +460,13 @@ nano ~/.config/inkwell/config.yaml
 ### High-Level Pipeline
 
 ```text
-RSS Feed → Parse Episodes → Check YouTube captions
+Feed / URL / local file / stdin → Resolve source
+       → [saved feed] Parse episodes
+       → [text/stdin] Treat as source text
+       → [media] Check transcript cache
+       → [YouTube] Check YouTube captions
        → [YouTube only] Gemini public URL fallback
-       → [Final fallback] Download Audio
+       → [Final fallback] Download or read media
        → Transcribe (YouTube captions or Gemini)
        → Extract Content (Template-based LLM)
        → Generate Wikilinks & Tags
@@ -414,6 +485,7 @@ RSS Feed → Parse Episodes → Check YouTube captions
    - YouTube transcript extraction (free)
    - Gemini public YouTube URL fallback for cloud-IP blocking
    - Gemini audio fallback (paid)
+   - Explicit attempt policy for fallback ordering
    - 30-day cache with TTL
 
 3. **Extraction** (`src/inkwell/extraction/`)
@@ -441,6 +513,11 @@ RSS Feed → Parse Episodes → Check YouTube captions
    - Automatic retry for transient failures
    - Graceful degradation
 
+8. **Input Resolution** (`src/inkwell/ingestion/`)
+   - Conservative source classification
+   - Saved feed, URL, local file, stdin, direct media, and YouTube source kinds
+   - Foundation for future universal ingestion work
+
 ### Project Structure
 
 ```
@@ -449,6 +526,7 @@ inkwell-cli/
 │   ├── cli.py               # CLI entry point
 │   ├── config/              # Configuration management
 │   ├── feeds/               # RSS parsing
+│   ├── ingestion/           # Input source classification
 │   ├── transcription/       # Transcription system
 │   ├── audio/               # Audio download
 │   ├── extraction/          # LLM extraction (Phase 3)
@@ -584,6 +662,9 @@ Manual workflow runs publish to TestPyPI only, which keeps release rehearsals sa
 - Custom templates and prompts
 - Batch processing automation
 - Export formats (PDF, HTML)
+- Cleaned web/article extraction
+- PDF, slides, and OCR ingestion
+- Token-aware model routing
 - Web dashboard for management
 - Mobile app integration
 - Community template marketplace

--- a/docs/building-in-public/devlog/2026-05-21-cache-key-observability.md
+++ b/docs/building-in-public/devlog/2026-05-21-cache-key-observability.md
@@ -31,5 +31,5 @@ This phase should be a compatibility cleanup, not a cache eviction feature. Exis
 
 - Related devlog: `./2026-05-21-machine-readable-output.md`
 - Related roadmap: `../../../2026-roadmap/03-universal-content-ingestion.md`
-- PR: TBD
+- PR: #90
 - Issue: TBD

--- a/docs/building-in-public/devlog/2026-05-21-extract-only-mode.md
+++ b/docs/building-in-public/devlog/2026-05-21-extract-only-mode.md
@@ -34,5 +34,5 @@ This is not a generic summarizer mode. It is a utility escape hatch for Inkwell 
 
 - Related devlog: `./2026-05-21-media-cache-controls.md`
 - Related roadmap: `../../../2026-roadmap/03-universal-content-ingestion.md`
-- PR: TBD
+- PR: #92
 - Issue: TBD

--- a/docs/building-in-public/devlog/2026-05-21-local-file-stdin-ingestion.md
+++ b/docs/building-in-public/devlog/2026-05-21-local-file-stdin-ingestion.md
@@ -33,5 +33,5 @@ This phase should continue to produce Inkwell-style structured knowledge notes. 
 
 - Related devlog: `./2026-05-21-extract-only-mode.md`
 - Related roadmap: `../../../2026-roadmap/03-universal-content-ingestion.md`
-- PR: TBD
+- PR: #93
 - Issue: TBD

--- a/docs/building-in-public/devlog/2026-05-21-machine-readable-output.md
+++ b/docs/building-in-public/devlog/2026-05-21-machine-readable-output.md
@@ -28,5 +28,5 @@ Open the Phase 2 PR and watch CI. If it stays green, merge it before starting Ph
 
 - Related devlog: `./2026-05-21-summarize-inspired-cli-foundation.md`
 - Related roadmap: `../../../2026-roadmap/09-multi-export-system.md`
-- PR: TBD
+- PR: #89
 - Issue: TBD

--- a/docs/building-in-public/devlog/2026-05-21-media-cache-controls.md
+++ b/docs/building-in-public/devlog/2026-05-21-media-cache-controls.md
@@ -32,5 +32,5 @@ This phase should only govern downloaded media/audio files. Transcript cache key
 
 - Related devlog: `./2026-05-21-cache-key-observability.md`
 - Related roadmap: `../../../2026-roadmap/03-universal-content-ingestion.md`
-- PR: TBD
+- PR: #91
 - Issue: TBD

--- a/docs/building-in-public/devlog/2026-05-21-summarize-inspired-cli-foundation.md
+++ b/docs/building-in-public/devlog/2026-05-21-summarize-inspired-cli-foundation.md
@@ -29,5 +29,5 @@ Move to Phase 2: add machine-readable output modes for `fetch` and `transcribe`,
 - Related research: summarize CLI architecture analysis from task context
 - Related roadmap: `../../../2026-roadmap/03-universal-content-ingestion.md`
 - Related roadmap: `../../../2026-roadmap/09-multi-export-system.md`
-- PR: TBD
+- PR: #88
 - Issue: TBD

--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -1,0 +1,90 @@
+# Cache Behavior
+
+Inkwell uses three local caches with different purposes. They all live under the XDG cache directory, usually `~/.cache/inkwell/`, but they are managed differently.
+
+---
+
+## Cache Layers
+
+| Cache | Directory | Purpose | Key inputs | Expiration/control |
+|-------|-----------|---------|------------|--------------------|
+| Transcript cache | `~/.cache/inkwell/transcripts/` | Avoid re-transcribing the same episode URL | Episode URL hash | Transcript TTL, currently 30 days |
+| Extraction cache | `~/.cache/inkwell/extractions/` | Avoid re-running LLM templates for identical inputs | Transcript hash, template name/version, provider, model, prompt hash, output schema version, cache format version | Extraction TTL, currently 30 days |
+| Media/audio cache | `~/.cache/inkwell/audio/` | Avoid re-downloading media files during transcription fallback | Episode/media URL hash | `cache.media.enabled`, `cache.media.max_mb`, `cache.media.ttl_days` |
+
+---
+
+## Inspecting Caches
+
+```bash
+inkwell cache stats
+```
+
+`stats` is observational only. It reports transcript, extraction, and media/audio cache sections, including cache directories, sizes, format versions, and basic grouping metadata.
+
+---
+
+## Clearing Caches
+
+```bash
+inkwell cache clear
+inkwell cache clear-expired
+```
+
+Important: these commands currently operate on the transcript cache.
+
+| Command | Current behavior |
+|---------|------------------|
+| `inkwell cache clear` | Clears cached transcripts |
+| `inkwell cache clear-expired` | Removes expired cached transcripts |
+| `inkwell cache stats` | Reports transcript, extraction, and media/audio cache stats |
+
+Extraction cache and media/audio cache clearing are intentionally not folded into `clear` yet, because deleting those artifacts has different cost and disk-space tradeoffs. Media/audio retention is bounded by configuration.
+
+---
+
+## Media Cache Controls
+
+Media/audio files are controlled by:
+
+```yaml
+cache:
+  media:
+    enabled: true
+    max_mb: 2048
+    ttl_days: 30
+```
+
+Set values with:
+
+```bash
+inkwell config set cache.media.enabled false
+inkwell config set cache.media.max_mb 4096
+inkwell config set cache.media.ttl_days 14
+```
+
+The media cache policy is applied when media downloads run. Expired files are removed first, then oldest files are evicted until the cache is below `max_mb`.
+
+---
+
+## Cache Format Versions
+
+Cache format versions make cache migrations explicit:
+
+| Constant | Meaning |
+|----------|---------|
+| `TRANSCRIPT_CACHE_FORMAT_VERSION` | Stored transcript cache payload format |
+| `EXTRACTION_CACHE_FORMAT_VERSION` | Stored extraction cache payload and key format |
+| `AUDIO_CACHE_FORMAT_VERSION` | Media/audio cache reporting format |
+
+Older extraction cache entries are treated as misses when the new key metadata is unavailable. This preserves existing files without corrupting them and avoids returning stale content for a changed prompt, provider, model, or output schema.
+
+---
+
+## Cost Implications
+
+- Transcript cache hits avoid transcription costs.
+- Extraction cache hits avoid LLM extraction costs for individual templates.
+- Media/audio cache hits avoid repeated downloads, but not transcription itself.
+- `--force` on `inkwell transcribe` bypasses transcript cache.
+- `--skip-cache` on `inkwell fetch` bypasses extraction cache.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -196,7 +196,7 @@ inkwell transcribe https://youtube.com/watch?v=xyz --json
 inkwell transcribe https://youtube.com/watch?v=xyz --plain
 ```
 
-`--json` and `--plain` are mutually exclusive. In both modes, stdout is reserved for the primary result so shell scripts can parse it safely.
+`--json` and `--plain` are mutually exclusive. In both modes, stdout is reserved for the primary result so shell scripts can parse it safely. See [Machine-Readable Output](machine-readable-output.md) for envelope examples and scripting notes.
 
 ---
 
@@ -213,8 +213,8 @@ inkwell cache <ACTION>
 | Action | Description |
 |--------|-------------|
 | `stats` | Show transcript, extraction, and media cache statistics |
-| `clear` | Clear cached transcripts |
-| `clear-expired` | Remove expired cached transcripts |
+| `clear` | Clear cached transcripts only |
+| `clear-expired` | Remove expired cached transcripts only |
 
 ### Examples
 
@@ -224,7 +224,7 @@ inkwell cache clear-expired
 inkwell cache clear
 ```
 
-`stats` is observational only. Downloaded media/audio retention is configured with `cache.media.enabled`, `cache.media.max_mb`, and `cache.media.ttl_days`.
+`stats` is observational only. `clear` and `clear-expired` currently operate on transcript cache entries. Downloaded media/audio retention is configured with `cache.media.enabled`, `cache.media.max_mb`, and `cache.media.ttl_days`; see [Cache Behavior](cache.md).
 
 ---
 
@@ -240,7 +240,7 @@ inkwell fetch <SOURCE> [OPTIONS]
 
 | Argument | Required | Description |
 |----------|----------|-------------|
-| `SOURCE` | Yes | Feed name, episode/media URL, local audio/video file, local `.txt`/`.md` file, or `-` for stdin text |
+| `SOURCE` | Yes | Feed name, episode/media URL, local audio/video file, local `.txt`/`.md` file, or `-` for stdin text. See [Supported Inputs](supported-inputs.md). |
 
 ### Options
 
@@ -344,7 +344,7 @@ inkwell fetch https://www.youtube.com/watch?v=abc123 --save-feed --feed-name som
 INKWELL_EXTRACTOR=gemini inkwell fetch URL
 ```
 
-`--json` and `--plain` are mutually exclusive. In both modes, stdout is reserved for the primary result and interactive progress output is sent to stderr.
+`--json` and `--plain` are mutually exclusive. In both modes, stdout is reserved for the primary result and interactive progress output is sent to stderr. See [Machine-Readable Output](machine-readable-output.md) for envelope examples and scripting notes.
 
 `--extract` is transcript-only for media workflows. It does not run templates, structured extraction, interview mode, or the episode note writer. Without `--output-dir`, transcript text is printed to stdout and progress goes to stderr. With `--output-dir`, Inkwell writes `.transcript.md` file(s) directly into that directory; combine with `--plain` to print the file path(s) to stdout.
 

--- a/docs/reference/config-options.md
+++ b/docs/reference/config-options.md
@@ -111,6 +111,8 @@ transcription:
 
 Inkwell keeps downloaded media/audio files in the local cache so retries and fallback transcription do not need to download the same episode again. Retention is enforced when media downloads run.
 
+See [Cache Behavior](cache.md) for how transcript, extraction, and media/audio caches differ.
+
 ```yaml
 cache:
   media:

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -9,11 +9,23 @@ Technical reference documentation for Inkwell.
 ### [CLI Commands](cli-commands.md)
 Complete reference for all Inkwell commands, options, and flags.
 
+### [Supported Inputs](supported-inputs.md)
+Input support matrix for saved feeds, URLs, local files, stdin, and planned future formats.
+
+### [Machine-Readable Output](machine-readable-output.md)
+JSON/plain output contracts for shell scripts and automation.
+
+### [Cache Behavior](cache.md)
+Transcript, extraction, and media/audio cache behavior, retention, and clearing semantics.
+
 ### [Templates](templates.md)
 Available extraction templates, their outputs, and how to customize them.
 
 ### [Configuration Options](config-options.md)
 All configuration options with defaults, types, and descriptions.
+
+### [Transcription Attempt Policy](transcription-attempt-policy.md)
+Developer-facing reference for transcription fallback ordering and future provider policy work.
 
 ### [Troubleshooting](troubleshooting.md)
 Common issues, error messages, and their solutions.
@@ -52,7 +64,7 @@ tail -f ~/.local/state/inkwell/inkwell.log
 | Feeds | `~/.config/inkwell/feeds.yaml` | Feed definitions |
 | Key | `~/.config/inkwell/.keyfile` | Encryption key |
 | Logs | `~/.local/state/inkwell/inkwell.log` | Application logs |
-| Cache | `~/.cache/inkwell/` | Transcripts, extractions |
+| Cache | `~/.cache/inkwell/` | Transcripts, extractions, downloaded media/audio |
 | Output | `~/inkwell-notes/` | Processed episodes (default) |
 
 ---

--- a/docs/reference/machine-readable-output.md
+++ b/docs/reference/machine-readable-output.md
@@ -1,0 +1,215 @@
+# Machine-Readable Output
+
+`inkwell fetch` and `inkwell transcribe` support script-friendly output modes for automation. These modes preserve the default human-facing Rich output unless you opt in with `--json` or `--plain`.
+
+---
+
+## Stdout And Stderr Contract
+
+In machine-readable modes:
+
+| Stream | Contents |
+|--------|----------|
+| stdout | The primary result: JSON envelope, transcript text, output directory path, or transcript file path |
+| stderr | Progress, warnings, hints, status messages, and errors |
+
+This lets shell scripts parse stdout safely:
+
+```bash
+inkwell transcribe "$URL" --json > transcript.json 2> progress.log
+inkwell fetch "$URL" --plain > output-dir.txt 2> progress.log
+```
+
+`--json` and `--plain` are mutually exclusive. `inkwell fetch --extract` is its own transcript-only mode and does not currently combine with `--json`.
+
+---
+
+## JSON Envelope Version
+
+JSON responses include:
+
+```json
+{
+  "schema_version": 1,
+  "command": "fetch",
+  "status": "success"
+}
+```
+
+Treat `schema_version` as the compatibility guard for scripts. New optional fields may be added over time, but incompatible shape changes should use a new schema version.
+
+---
+
+## `inkwell transcribe --json`
+
+Use this when you want one transcript and structured metadata without note generation.
+
+```bash
+inkwell transcribe https://youtube.com/watch?v=abc --json
+```
+
+Example response:
+
+```json
+{
+  "cache_hits": {
+    "extractions": 0,
+    "transcript": false
+  },
+  "command": "transcribe",
+  "costs": {
+    "total_usd": 0.0,
+    "transcription_usd": 0.0
+  },
+  "error": null,
+  "files": [],
+  "input": {
+    "kind": "youtube",
+    "normalized": "https://youtube.com/watch?v=abc",
+    "raw": "https://youtube.com/watch?v=abc"
+  },
+  "output": {
+    "path": null
+  },
+  "output_directory": null,
+  "schema_version": 1,
+  "status": "success",
+  "templates": [],
+  "transcript": "Full transcript text...",
+  "transcription": {
+    "attempts": ["cache", "youtube"],
+    "cost_usd": 0.0,
+    "duration_seconds": 1.2,
+    "from_cache": false,
+    "language": "en",
+    "media_duration_seconds": 3600.0,
+    "source": "youtube",
+    "word_count": 9500
+  }
+}
+```
+
+When `--output transcript.txt` is used, the `files` array and `output.path` include that file.
+
+---
+
+## `inkwell fetch --json`
+
+Use this when you want the complete structured-note pipeline and a parseable summary of the run.
+
+```bash
+inkwell fetch syntax --latest --json
+```
+
+Example response:
+
+```json
+{
+  "cache_hits": {
+    "extractions": 2,
+    "transcripts": 1
+  },
+  "command": "fetch",
+  "errors": [],
+  "files": [
+    {
+      "filename": "summary.md",
+      "path": "/Users/me/inkwell-notes/syntax-episode/summary.md",
+      "size_bytes": 2048,
+      "template": "summary"
+    }
+  ],
+  "input": {
+    "kind": "saved_feed",
+    "normalized": "syntax",
+    "raw": "syntax",
+    "selector": {
+      "count": null,
+      "episode": null,
+      "latest": true
+    }
+  },
+  "output_directory": "/Users/me/inkwell-notes",
+  "results": [
+    {
+      "cache_hits": {
+        "extractions": 2,
+        "transcript": true
+      },
+      "costs": {
+        "extraction_usd": 0.0032,
+        "interview_usd": 0.0,
+        "total_usd": 0.0032,
+        "transcription_usd": 0.0
+      },
+      "episode": {
+        "episode_title": "Modern CSS Features",
+        "episode_url": "https://youtube.com/watch?v=abc",
+        "podcast_name": "Syntax"
+      },
+      "extraction": {
+        "cached": 2,
+        "failed": 0,
+        "successful": 3,
+        "total": 3
+      },
+      "interview": {
+        "completed": false,
+        "cost_usd": 0.0
+      },
+      "output": {
+        "directory": "/Users/me/inkwell-notes/syntax-episode",
+        "files": []
+      },
+      "status": "success",
+      "templates": [],
+      "transcription": {
+        "attempts": ["cache"],
+        "cost_usd": 0.0,
+        "duration_seconds": 0.1,
+        "from_cache": true,
+        "language": "en",
+        "media_duration_seconds": 3600.0,
+        "source": "cached",
+        "word_count": 9500
+      }
+    }
+  ],
+  "schema_version": 1,
+  "status": "success",
+  "summary": {
+    "failed": 0,
+    "requested": 1,
+    "succeeded": 1,
+    "total_cost_usd": 0.0032
+  },
+  "templates": [],
+  "warnings": []
+}
+```
+
+For feed runs with `--count`, `results` contains one entry per processed episode.
+
+---
+
+## Plain Mode
+
+Plain mode is intentionally terse.
+
+```bash
+# Transcript text only
+inkwell transcribe "$URL" --plain
+
+# Generated episode directory path(s)
+inkwell fetch "$URL" --plain
+
+# Transcript file path(s), when writing extract-only output
+inkwell fetch syntax --latest --extract --output-dir ~/transcripts --plain
+```
+
+Plain mode is useful for command substitution and pipelines:
+
+```bash
+note_dir="$(inkwell fetch "$URL" --plain 2> progress.log)"
+open "$note_dir"
+```

--- a/docs/reference/supported-inputs.md
+++ b/docs/reference/supported-inputs.md
@@ -1,0 +1,77 @@
+# Supported Inputs
+
+Inkwell is still a structured knowledge-note tool for podcast and media learning workflows. The CLI now accepts more source shapes, but they all route into either transcription, template extraction, Obsidian-friendly note output, or the narrow transcript-only escape hatch.
+
+---
+
+## Input Matrix
+
+| Input | Example | Status | Route | Primary output |
+|-------|---------|--------|-------|----------------|
+| Saved feed | `inkwell fetch syntax --latest` | Supported | RSS feed selection, then episode media processing | Structured episode note directory |
+| YouTube video URL | `inkwell fetch https://youtube.com/watch?v=abc` | Supported | YouTube metadata, captions, Gemini URL fallback, then audio fallback | Structured episode note directory |
+| YouTube channel URL | `inkwell add https://youtube.com/@creator --feed-name creator` | Supported for feed add | Resolved to YouTube media RSS | Saved feed |
+| Direct media URL | `inkwell fetch https://example.com/episode.mp3` | Supported | Media transcription, then extraction templates | Structured episode note directory |
+| Other HTTP(S) URL | `inkwell fetch https://example.com/watch/episode` | Supported when it is media or handled by `yt-dlp` | Media transcription, then extraction templates | Structured episode note directory |
+| Local audio/video | `inkwell fetch ~/Downloads/interview.mp3` | Supported | Local file transcription through Gemini | Structured episode note directory |
+| Local text/markdown | `inkwell fetch ./notes.md` | Supported | Existing text is treated as source text for extraction templates | Structured episode note directory |
+| Stdin text | `inkwell fetch - < notes.txt` | Supported | Stdin is treated as source text for extraction templates | Structured episode note directory |
+| Transcript-only media | `inkwell fetch URL --extract` | Supported | Transcription only | Transcript text or `.transcript.md` file |
+| PDF | `inkwell fetch paper.pdf` | Not supported yet | Planned later | None |
+| Web article extraction | `inkwell fetch https://example.com/article` | Not supported as article cleanup yet | Planned later | None |
+| Slides/OCR/images | `inkwell fetch deck.pdf` | Not supported yet | Planned later | None |
+| Non-HTTP URL schemes | `inkwell fetch ftp://example.com/file.mp3` | Not supported | Rejected as unknown URL | None |
+
+---
+
+## What Counts As Media
+
+Direct media detection is conservative. Inkwell recognizes common audio/video extensions such as:
+
+```text
+.aac .aif .aiff .avi .flac .m4a .m4v .mkv .mov .mp3 .mp4
+.mpeg .mpg .oga .ogg .opus .wav .webm
+```
+
+Some media pages do not end in a media extension. Those can still work when `yt-dlp` can resolve them to audio, but Inkwell does not currently extract readable article text from arbitrary web pages.
+
+---
+
+## Local Text And Stdin
+
+Local `.txt` and `.md` files and stdin are treated as already-clean source text. They skip media transcription and go directly through the same extraction templates used for podcast transcripts.
+
+```bash
+inkwell fetch ./conference-notes.md --templates summary,key-concepts
+pbpaste | inkwell fetch - --templates summary,quotes
+```
+
+This keeps the output shape consistent: markdown notes, metadata, templates, and optional interview support. It is not a generic web/PDF/OCR summarizer path.
+
+---
+
+## Transcript-Only Extraction
+
+Use `--extract` when you want the transcript first and want to decide later whether to run structured extraction.
+
+```bash
+# Print transcript text to stdout; progress goes to stderr
+inkwell fetch https://youtube.com/watch?v=abc --extract
+
+# Write transcript files without creating episode note directories
+inkwell fetch syntax --latest --extract --output-dir ~/transcripts --plain
+```
+
+`--extract` skips templates, structured extraction, interview mode, and the episode note writer.
+
+---
+
+## Planned Later
+
+The current foundation intentionally leaves these as separate future phases:
+
+- cleaned web/article extraction
+- PDF text extraction
+- slide decks
+- OCR/image ingestion
+- token-aware model routing for long documents

--- a/docs/reference/templates.md
+++ b/docs/reference/templates.md
@@ -262,8 +262,11 @@ version: 2
 When a template is updated:
 
 1. Version number increases
-2. Cache is invalidated for that template
-3. New extractions use updated prompt
+2. Prompt/template hash changes
+3. Cache is invalidated for that template/provider/model/schema combination
+4. New extractions use updated prompt
+
+Extraction cache keys also include transcript hash, provider, model, prompt hash, output schema version, and cache format version. See [Cache Behavior](cache.md).
 
 ---
 

--- a/docs/reference/transcription-attempt-policy.md
+++ b/docs/reference/transcription-attempt-policy.md
@@ -1,0 +1,61 @@
+# Transcription Attempt Policy
+
+`TranscriptionAttemptPolicy` makes the transcription fallback order explicit without adding new providers. It is a small developer-facing foundation for future provider capability work.
+
+---
+
+## Default Attempt Order
+
+For a normal remote media or episode URL, the default policy can produce:
+
+1. transcript cache
+2. YouTube transcript
+3. Gemini public YouTube URL fallback, for YouTube URLs
+4. Gemini audio fallback
+
+For local media files, the policy goes directly to Gemini local media transcription. Local media does not run through `yt-dlp`.
+
+---
+
+## Attempt Types
+
+The current attempt kinds are:
+
+| Attempt kind | Provider label | Purpose |
+|--------------|----------------|---------|
+| `CACHE` | `cache` | Reuse a cached transcript |
+| `YOUTUBE_TRANSCRIPT` | `youtube` | Use free YouTube captions/transcripts |
+| `GEMINI_YOUTUBE_URL` | `gemini` | Ask Gemini to process a public YouTube URL |
+| `GEMINI_AUDIO` | `gemini` | Download media and transcribe audio with Gemini |
+| `GEMINI_LOCAL_MEDIA` | `gemini` | Transcribe an already-local audio/video file |
+
+The manager records attempts with stable labels such as `cache`, `youtube`, and `gemini`. Duplicate labels are recorded once.
+
+---
+
+## Extension Guidance
+
+Future provider work should add capability-aware planning to the policy instead of embedding more fallback order in `TranscriptionManager`.
+
+Good future policy inputs include:
+
+- whether the source is YouTube
+- whether the source is local media
+- whether a provider can handle public URLs directly
+- whether a provider can handle local media
+- whether cache use is allowed
+- whether the caller requested `--skip-youtube`
+
+Keep provider additions narrow. The policy should decide which attempts are allowed and in what order; each attempt implementation should remain in the manager or a provider/plugin boundary.
+
+---
+
+## Current Non-Goals
+
+This policy does not yet add:
+
+- new transcription providers
+- token-aware routing
+- web article extraction
+- PDF, slide, or OCR ingestion
+- cross-provider quality scoring

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -223,7 +223,15 @@ tail -f ~/.local/state/inkwell/inkwell.log
 └── audio/          # Downloaded media/audio cache
 ```
 
-Clear cache:
+Inspect cache:
+
+```bash
+inkwell cache stats
+```
+
+`inkwell cache clear` clears cached transcripts only. Media/audio retention is controlled by `cache.media.enabled`, `cache.media.max_mb`, and `cache.media.ttl_days`. See [Cache Behavior](../reference/cache.md) for the full cache model.
+
+Remove all local cache files manually:
 
 ```bash
 rm -rf ~/.cache/inkwell/

--- a/docs/user-guide/extraction.md
+++ b/docs/user-guide/extraction.md
@@ -153,9 +153,9 @@ Extractions are cached to save time and money.
 
 ### How It Works
 
-- Cache key = transcript hash + template version
+- Cache key includes transcript hash, template name/version, provider, model, prompt hash, output schema version, and cache format version
 - Default cache duration: 30 days
-- Cache location: `~/.cache/inkwell/`
+- Cache location: `~/.cache/inkwell/extractions/`
 
 ### Cache Behavior
 
@@ -164,6 +164,9 @@ Extractions are cached to save time and money.
 | Same transcript, same template | Cache hit ($0) |
 | Same transcript, different template | New extraction |
 | Template version updated | Cache invalidated |
+| Prompt, provider, model, or output schema changed | Cache invalidated |
+
+See [Cache Behavior](../reference/cache.md) for transcript, extraction, and media/audio cache details.
 
 ### Skip Cache
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -47,6 +47,16 @@ inkwell list
 # Process latest episode
 inkwell fetch <feed-name> --latest
 
+# Process local media
+inkwell fetch ~/Downloads/interview.mp3
+
+# Process local text or stdin
+inkwell fetch ./notes.md
+pbpaste | inkwell fetch -
+
+# Transcript only
+inkwell fetch <url> --extract
+
 # Process with interview
 inkwell fetch <feed-name> --latest --interview
 
@@ -82,4 +92,6 @@ inkwell costs
 
 - [Troubleshooting Guide](../reference/troubleshooting.md) - Common issues and solutions
 - [CLI Reference](../reference/cli-commands.md) - All commands and options
+- [Supported Inputs](../reference/supported-inputs.md) - Current input matrix and planned formats
+- [Machine-Readable Output](../reference/machine-readable-output.md) - JSON/plain output for scripts
 - [GitHub Issues](https://github.com/chekos/inkwell-cli/issues) - Report bugs

--- a/docs/user-guide/processing.md
+++ b/docs/user-guide/processing.md
@@ -29,6 +29,8 @@ inkwell fetch ./notes.md
 pbpaste | inkwell fetch -
 ```
 
+See [Supported Inputs](../reference/supported-inputs.md) for the full input matrix and planned future formats.
+
 ### Process from Feed
 
 If you've added a feed, process by feed name:
@@ -98,7 +100,7 @@ Step 4/4: Writing markdown files...
 
 | Option | Short | Description | Default |
 |--------|-------|-------------|---------|
-| `--output` | `-o` | Output directory | `~/inkwell-notes` |
+| `--output-dir` | `-o` | Output directory | `~/inkwell-notes` |
 | `--count` | | Latest N episodes from a saved feed | |
 | `--templates` | `-t` | Comma-separated template list | Auto-select |
 | `--category` | `-c` | Episode category | Auto-detect |
@@ -213,6 +215,8 @@ inkwell fetch my-podcast --latest --extract --output-dir ~/transcripts --plain
 Use this when you want the clean media transcript first and want to decide later whether to run Inkwell's structured note templates or reflection flow.
 
 PDFs, web article extraction, slide decks, and OCR inputs are not part of local/stdin ingestion yet.
+
+For script-friendly `--json` and `--plain` output, see [Machine-Readable Output](../reference/machine-readable-output.md).
 
 ### Re-extract with Different Templates
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,8 +67,12 @@ nav:
   - Reference:
     - Overview: reference/index.md
     - CLI Commands: reference/cli-commands.md
+    - Supported Inputs: reference/supported-inputs.md
+    - Machine-Readable Output: reference/machine-readable-output.md
+    - Cache Behavior: reference/cache.md
     - Templates: reference/templates.md
     - Configuration Options: reference/config-options.md
+    - Transcription Attempt Policy: reference/transcription-attempt-policy.md
     - Troubleshooting: reference/troubleshooting.md
 
   - Building in Public:


### PR DESCRIPTION
## Summary
- Added reference docs for supported inputs, machine-readable output, cache behavior, and transcription attempt policy.
- Updated README and user/reference docs for local file/stdin ingestion, extract-only mode, JSON/plain output, cache controls, and cache key behavior.
- Backfilled PR links in the summarize-inspired phase devlogs.
- Adjusted the YAML pre-commit hook to support MkDocs custom YAML tags used by mkdocs.yml.

## Tests
- uv run mkdocs build --strict
- uv run ruff format .
- uv run ruff check .
- uv run pre-commit run --files .pre-commit-config.yaml README.md docs/building-in-public/devlog/2026-05-21-cache-key-observability.md docs/building-in-public/devlog/2026-05-21-extract-only-mode.md docs/building-in-public/devlog/2026-05-21-local-file-stdin-ingestion.md docs/building-in-public/devlog/2026-05-21-machine-readable-output.md docs/building-in-public/devlog/2026-05-21-media-cache-controls.md docs/building-in-public/devlog/2026-05-21-summarize-inspired-cli-foundation.md docs/reference/cache.md docs/reference/cli-commands.md docs/reference/config-options.md docs/reference/index.md docs/reference/machine-readable-output.md docs/reference/supported-inputs.md docs/reference/templates.md docs/reference/transcription-attempt-policy.md docs/user-guide/configuration.md docs/user-guide/extraction.md docs/user-guide/index.md docs/user-guide/processing.md mkdocs.yml
- git push -u origin codex/docs-ingestion-cli-foundation (pre-push: pre-commit hooks and pytest)
