### PR TITLE
docs: remove static README release version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ Transform podcast episodes into structured, searchable markdown notes for Obsidi
 
 ## Status
 
-**Current release: v0.20.0**
-
-Inkwell is beta software with the core podcast-to-markdown pipeline implemented and released on PyPI. The project has automated CI, branch protection, PyPI Trusted Publishing, MkDocs documentation, and a large regression suite.
+Inkwell is beta software with the core podcast-to-markdown pipeline implemented and released on PyPI. The PyPI badge above reflects the current published release. The project has automated CI, branch protection, PyPI Trusted Publishing, MkDocs documentation, and a large regression suite.
 
 Current health baseline:
 - Podcast feed management with RSS and YouTube channel URL support


### PR DESCRIPTION
## Summary
- Removed the static Current release line from the README.
- Pointed readers to the existing PyPI badge as the source of truth for the published version.

## Tests
- uv run pre-commit run --files README.md
- uv run ruff check .
- uv run mkdocs build --strict
- git push -u origin codex/release-v0.21.0 (pre-push: pre-commit hooks and pytest)
