### PR TITLE
Implement summarize roadmap foundation

### DIFF
--- a/docs/building-in-public/adr/039-local-source-text-extraction.md
+++ b/docs/building-in-public/adr/039-local-source-text-extraction.md
@@ -1,0 +1,73 @@
+---
+title: ADR 039 - Local source-text extraction
+adr:
+  author: Codex
+  created: 07-Jul-2026
+  status: accepted
+---
+
+# ADR 039: Local source-text extraction
+
+**Date:** 2026-07-07
+**Status:** Accepted
+
+## Context
+
+Inkwell started as a podcast/media pipeline, but the same template extraction
+and markdown output path is useful for short notes, web articles, and documents.
+The active roadmap calls for local-only article extraction and text-only PDFs,
+while deferring OCR/image PDFs and hosted article fallbacks.
+
+The key boundary is source text. Once source text is available, the existing
+pipeline can skip media transcription and reuse template selection, extraction
+caching, markdown output, interview mode, and machine-readable output.
+
+## Decision
+
+Add source-text extraction paths for:
+
+1. Readable web article URLs, using local HTML fetch and `trafilatura` cleanup.
+2. Local text PDFs, using `pypdf` selectable-text extraction.
+
+These inputs become source text and bypass the transcription attempt policy.
+They still run through normal template extraction unless `--extract` is used.
+
+Keep these out of scope for now:
+
+- hosted article extraction fallbacks for blocked or script-rendered pages
+- OCR or image-only PDFs
+- slide/deck OCR
+
+## Consequences
+
+- Direct YouTube and direct media inputs keep their existing transcription
+  behavior.
+- Generic HTTP(S) pages now route as article extraction and must return readable
+  HTML.
+- Local PDFs are accepted only when they contain selectable text.
+- `--extract` now prints cleaned source text for article/PDF/text inputs, not
+  only media transcripts.
+- Machine-readable output can distinguish `article` and `pdf` input kinds.
+
+## Alternatives Considered
+
+1. Hosted extraction fallback first.
+   - Pros: better success on blocked and script-rendered pages.
+   - Cons: new service boundary, more error cases, and not needed for the first
+     local CLI slice.
+2. OCR PDFs in the same release.
+   - Pros: handles scans and image-heavy documents.
+   - Cons: larger dependency and performance surface; better handled as a
+     separate issue.
+3. Treat generic URLs as media pages until transcription fails.
+   - Pros: preserves old direct URL behavior for some media landing pages.
+   - Cons: ambiguous routing, more wasted transcription attempts, and weaker
+     article support.
+
+## References
+
+- Epic: #102
+- Article extraction issue: #104
+- PDF extraction issue: #106
+- Hosted fallback issue: #112
+- OCR/image PDF issue: #111

--- a/docs/building-in-public/devlog/2026-07-07-summarize-roadmap-implementation.md
+++ b/docs/building-in-public/devlog/2026-07-07-summarize-roadmap-implementation.md
@@ -1,0 +1,38 @@
+# Summarize Roadmap Implementation
+
+**Date:** 2026-07-07
+**Author:** Codex
+
+## Focus
+
+Implement the active summarize-inspired CLI roadmap tracked in GitHub issue #102, starting with resolver documentation cleanup and provider capability metadata.
+
+## Plan
+
+- Refresh stale `InputResolver` documentation without changing behavior.
+- Add typed provider capability metadata for transcription and extraction plugins.
+- Surface provider capabilities in plugin listing output.
+- Keep hosted web extraction fallbacks, OCR/image PDFs, and slides OCR outside this active implementation slice.
+
+## Progress
+
+- Started implementation on `codex/summarize-roadmap-foundation`.
+- Confirmed #108 only requires documentation cleanup around `InputResolver` boundaries.
+- Opened #110 implementation by reviewing plugin base classes, built-in providers, transcription policy, manager wiring, and plugin CLI output.
+- Added typed transcription/extraction capability metadata and surfaced it in plugin listing output.
+- Added token-aware extraction routing with provider/model-specific cache keys.
+- Added explicit transcript, extraction, and media cache lifecycle controls.
+- Added default-on short-content summary bypass with `--force-extraction`.
+- Added local-only article extraction and text-only PDF extraction as source-text routes.
+- Recorded the local source-text boundary in ADR 039.
+
+## Observations
+
+The existing transcription policy already gives provider fallback ordering a clean extension point. Capability metadata can inform that policy without changing today's default provider order.
+
+Article and PDF ingestion fit the pipeline best as source text, not as new transcription attempts. That keeps media-specific fallbacks separate from document cleanup and lets `--extract` work as a clean source-text escape hatch.
+
+## Links
+
+- Epic: #102
+- Issues: #103, #104, #106, #107, #108, #109, #110

--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -28,18 +28,28 @@ inkwell cache stats
 
 ```bash
 inkwell cache clear
+inkwell cache clear --transcripts
+inkwell cache clear --extractions
+inkwell cache clear --media
+inkwell cache clear --all
 inkwell cache clear-expired
+inkwell cache clear-expired --extractions
 ```
 
-Important: these commands currently operate on the transcript cache.
+For backward compatibility, `inkwell cache clear` and `inkwell cache clear-expired` still default to transcript cache entries when no target flag is provided.
 
-| Command | Current behavior |
-|---------|------------------|
+| Command | Behavior |
+|---------|----------|
 | `inkwell cache clear` | Clears cached transcripts |
+| `inkwell cache clear --transcripts` | Clears cached transcripts |
+| `inkwell cache clear --extractions` | Clears extraction cache entries |
+| `inkwell cache clear --media` | Clears downloaded media/audio cache files |
+| `inkwell cache clear --all` | Clears transcript, extraction, and media/audio caches |
 | `inkwell cache clear-expired` | Removes expired cached transcripts |
+| `inkwell cache clear-expired --extractions` | Removes expired extraction cache entries |
 | `inkwell cache stats` | Reports transcript, extraction, and media/audio cache stats |
 
-Extraction cache and media/audio cache clearing are intentionally not folded into `clear` yet, because deleting those artifacts has different cost and disk-space tradeoffs. Media/audio retention is bounded by configuration.
+`clear` confirms by default. Use `--force` for non-interactive cleanup.
 
 ---
 
@@ -64,6 +74,15 @@ inkwell config set cache.media.ttl_days 14
 ```
 
 The media cache policy is applied when media downloads run. Expired files are removed first, then oldest files are evicted until the cache is below `max_mb`.
+
+You can also enforce the media policy directly without downloading new media:
+
+```bash
+inkwell cache enforce-media-policy
+inkwell cache enforce-media-policy --force
+```
+
+Use this when reclaiming disk space or after changing `cache.media.max_mb` or `cache.media.ttl_days`.
 
 ---
 

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -213,8 +213,19 @@ inkwell cache <ACTION>
 | Action | Description |
 |--------|-------------|
 | `stats` | Show transcript, extraction, and media cache statistics |
-| `clear` | Clear cached transcripts only |
-| `clear-expired` | Remove expired cached transcripts only |
+| `clear` | Clear selected caches; defaults to transcripts |
+| `clear-expired` | Remove expired transcript/extraction entries; defaults to transcripts |
+| `enforce-media-policy` | Apply media cache TTL/size policy without downloading media |
+
+### Target Options
+
+| Option | Description |
+|--------|-------------|
+| `--transcripts` | Target transcript cache entries |
+| `--extractions` | Target extraction cache entries |
+| `--media` | Target downloaded media/audio cache files |
+| `--all` | Target transcript, extraction, and media caches |
+| `--force`, `-f` | Skip confirmation for destructive cache actions |
 
 ### Examples
 
@@ -222,9 +233,12 @@ inkwell cache <ACTION>
 inkwell cache stats
 inkwell cache clear-expired
 inkwell cache clear
+inkwell cache clear --extractions --force
+inkwell cache clear --media --force
+inkwell cache enforce-media-policy --force
 ```
 
-`stats` is observational only. `clear` and `clear-expired` currently operate on transcript cache entries. Downloaded media/audio retention is configured with `cache.media.enabled`, `cache.media.max_mb`, and `cache.media.ttl_days`; see [Cache Behavior](cache.md).
+`stats` is observational only. `clear` and `clear-expired` preserve transcript-only defaults for compatibility. Downloaded media/audio retention is configured with `cache.media.enabled`, `cache.media.max_mb`, and `cache.media.ttl_days`; see [Cache Behavior](cache.md).
 
 ---
 
@@ -240,7 +254,7 @@ inkwell fetch <SOURCE> [OPTIONS]
 
 | Argument | Required | Description |
 |----------|----------|-------------|
-| `SOURCE` | Yes | Feed name, episode/media URL, local audio/video file, local `.txt`/`.md` file, or `-` for stdin text. See [Supported Inputs](supported-inputs.md). |
+| `SOURCE` | Yes | Feed name, YouTube/media/article URL, local audio/video file, local `.txt`/`.md`/text `.pdf` file, or `-` for stdin text. See [Supported Inputs](supported-inputs.md). |
 
 ### Options
 
@@ -255,8 +269,9 @@ inkwell fetch <SOURCE> [OPTIONS]
 | `--category` | `-c` | string | Auto | Episode category |
 | `--provider` | `-p` | string | Auto | LLM provider (gemini, claude, auto) |
 | `--skip-cache` | | flag | false | Skip extraction cache |
+| `--force-extraction` | | flag | false | Run LLM extraction even when short-content bypass would apply |
 | `--dry-run` | | flag | false | Show cost estimate only |
-| `--extract` | | flag | false | Emit transcript text only; skip structured extraction, interview, and note output |
+| `--extract` | | flag | false | Emit transcript/source text only; skip structured extraction, interview, and note output |
 | `--overwrite` | | flag | false | Overwrite existing directory |
 | `--interview` | | flag | false | Enable interview mode |
 | `--interview-template` | | string | Config | Interview template (reflective, analytical, creative) |
@@ -282,6 +297,12 @@ inkwell fetch ~/Downloads/interview.mp3
 
 # From local text or markdown
 inkwell fetch ./notes.md
+
+# From local text PDF
+inkwell fetch ./paper.pdf
+
+# From a readable web article
+inkwell fetch https://example.com/article
 
 # From stdin text
 pbpaste | inkwell fetch -
@@ -319,6 +340,9 @@ inkwell fetch URL --dry-run
 # Transcript text only
 inkwell fetch URL --extract
 
+# Force LLM extraction even for short source text
+inkwell fetch ./short-note.md --force-extraction
+
 # Transcript file only, without an episode note directory
 inkwell fetch URL --extract --output-dir transcripts --plain
 
@@ -346,7 +370,7 @@ INKWELL_EXTRACTOR=gemini inkwell fetch URL
 
 `--json` and `--plain` are mutually exclusive. In both modes, stdout is reserved for the primary result and interactive progress output is sent to stderr. See [Machine-Readable Output](machine-readable-output.md) for envelope examples and scripting notes.
 
-`--extract` is transcript-only for media workflows. It does not run templates, structured extraction, interview mode, or the episode note writer. Without `--output-dir`, transcript text is printed to stdout and progress goes to stderr. With `--output-dir`, Inkwell writes `.transcript.md` file(s) directly into that directory; combine with `--plain` to print the file path(s) to stdout.
+`--extract` is transcript/source-text only. It does not run templates, structured extraction, interview mode, or the episode note writer. Without `--output-dir`, transcript or cleaned source text is printed to stdout and progress goes to stderr. With `--output-dir`, Inkwell writes `.transcript.md` file(s) directly into that directory; combine with `--plain` to print the file path(s) to stdout.
 
 ---
 
@@ -373,16 +397,16 @@ inkwell plugins list [OPTIONS]
 
 ```
 Extraction Plugins:
-  claude (built-in)     ✓ enabled   [priority: 100]  Claude API extractor
-  gemini (built-in)     ✓ enabled   [priority: 100]  Google Gemini extractor
+  claude (built-in)     ✓ enabled   [100]  text, structured, json, context=200K, model=claude-3-5-sonnet-20241022, paid  Claude API extractor
+  gemini (built-in)     ✓ enabled   [100]  text, structured, json, context=1M, model=gemini-3-pro-preview, paid        Google Gemini extractor
 
 Transcription Plugins:
-  youtube (built-in)    ✓ enabled   [priority: 100]  YouTube transcript API
-  gemini (built-in)     ✓ enabled   [priority: 100]  Gemini audio transcription
-  whisper (installed)   ✓ enabled   [priority: 50]   Local Whisper transcription
+  youtube (built-in)    ✓ enabled   [100]  url, timestamps, free                                                     YouTube transcript API
+  gemini (built-in)     ✓ enabled   [100]  url, direct-youtube, file, timestamps, formats=mp3/m4a/wav/aac+2, model=gemini-3-flash-preview, paid  Gemini audio transcription
+  whisper (installed)   ✓ enabled   [50]   file, timestamps, offline, formats=mp3/wav/m4a/mp4+1, free                Local Whisper transcription
 
 Output Plugins:
-  markdown (built-in)   ✓ enabled   [priority: 100]  Markdown file generation
+  markdown (built-in)   ✓ enabled   [100]                                                                             Markdown file generation
 
 Broken Plugins:
   broken-plugin         ✗ error     ImportError: No module named 'torch'

--- a/docs/reference/machine-readable-output.md
+++ b/docs/reference/machine-readable-output.md
@@ -38,6 +38,8 @@ JSON responses include:
 
 Treat `schema_version` as the compatibility guard for scripts. New optional fields may be added over time, but incompatible shape changes should use a new schema version.
 
+`input.kind` identifies the routed source shape. Common values include `saved_feed`, `youtube`, `direct_media`, `article`, `pdf`, `local_file`, `stdin`, and `unknown_url`.
+
 ---
 
 ## `inkwell transcribe --json`
@@ -189,6 +191,8 @@ Example response:
 ```
 
 For feed runs with `--count`, `results` contains one entry per processed episode.
+
+For generic article URLs, `input.kind` is `article` after local extraction succeeds. For local text PDFs, it is `pdf`. These sources skip media transcription; the transcription section reports text-style attempts such as `article` or `pdf`.
 
 ---
 

--- a/docs/reference/supported-inputs.md
+++ b/docs/reference/supported-inputs.md
@@ -12,13 +12,12 @@ Inkwell is still a structured knowledge-note tool for podcast and media learning
 | YouTube video URL | `inkwell fetch https://youtube.com/watch?v=abc` | Supported | YouTube metadata, captions, Gemini URL fallback, then audio fallback | Structured episode note directory |
 | YouTube channel URL | `inkwell add https://youtube.com/@creator --feed-name creator` | Supported for feed add | Resolved to YouTube media RSS | Saved feed |
 | Direct media URL | `inkwell fetch https://example.com/episode.mp3` | Supported | Media transcription, then extraction templates | Structured episode note directory |
-| Other HTTP(S) URL | `inkwell fetch https://example.com/watch/episode` | Supported when it is media or handled by `yt-dlp` | Media transcription, then extraction templates | Structured episode note directory |
+| Web article URL | `inkwell fetch https://example.com/article` | Supported for readable HTML pages | Local HTML fetch and cleanup, then extraction templates | Structured source note directory |
 | Local audio/video | `inkwell fetch ~/Downloads/interview.mp3` | Supported | Local file transcription through Gemini | Structured episode note directory |
 | Local text/markdown | `inkwell fetch ./notes.md` | Supported | Existing text is treated as source text for extraction templates | Structured episode note directory |
+| Local text PDF | `inkwell fetch ./paper.pdf` | Supported for selectable text PDFs | Local PDF text extraction, then extraction templates | Structured source note directory |
 | Stdin text | `inkwell fetch - < notes.txt` | Supported | Stdin is treated as source text for extraction templates | Structured episode note directory |
-| Transcript-only media | `inkwell fetch URL --extract` | Supported | Transcription only | Transcript text or `.transcript.md` file |
-| PDF | `inkwell fetch paper.pdf` | Not supported yet | Planned later | None |
-| Web article extraction | `inkwell fetch https://example.com/article` | Not supported as article cleanup yet | Planned later | None |
+| Transcript/source-text only | `inkwell fetch URL --extract` | Supported | Transcription or local source extraction only | Transcript/source text or `.transcript.md` file |
 | Slides/OCR/images | `inkwell fetch deck.pdf` | Not supported yet | Planned later | None |
 | Non-HTTP URL schemes | `inkwell fetch ftp://example.com/file.mp3` | Not supported | Rejected as unknown URL | None |
 
@@ -33,30 +32,39 @@ Direct media detection is conservative. Inkwell recognizes common audio/video ex
 .mpeg .mpg .oga .ogg .opus .wav .webm
 ```
 
-Some media pages do not end in a media extension. Those can still work when `yt-dlp` can resolve them to audio, but Inkwell does not currently extract readable article text from arbitrary web pages.
+Generic HTTP(S) pages that do not look like YouTube or direct media are treated as article URLs and must return readable HTML.
 
 ---
 
-## Local Text And Stdin
+## Local Text, Articles, PDFs, And Stdin
 
-Local `.txt` and `.md` files and stdin are treated as already-clean source text. They skip media transcription and go directly through the same extraction templates used for podcast transcripts.
+Local `.txt` and `.md` files, web articles, text PDFs, and stdin are treated as source text. They skip media transcription and go directly through the same extraction templates used for podcast transcripts.
 
 ```bash
 inkwell fetch ./conference-notes.md --templates summary,key-concepts
+inkwell fetch ./paper.pdf --templates summary,key-concepts
+inkwell fetch https://example.com/article --templates summary,quotes
 pbpaste | inkwell fetch - --templates summary,quotes
 ```
 
-This keeps the output shape consistent: markdown notes, metadata, templates, and optional interview support. It is not a generic web/PDF/OCR summarizer path.
+Article extraction is local-only: Inkwell fetches HTML and cleans readable text on your machine. Blocked, script-rendered, or very thin pages fail clearly; hosted extraction fallbacks are tracked separately for later.
+
+PDF support is text-only: Inkwell extracts selectable text from local PDFs. Scanned/image PDFs and OCR are deferred.
+
+This keeps the output shape consistent: markdown notes, metadata, templates, and optional interview support.
 
 ---
 
 ## Transcript-Only Extraction
 
-Use `--extract` when you want the transcript first and want to decide later whether to run structured extraction.
+Use `--extract` when you want the transcript or cleaned source text first and want to decide later whether to run structured extraction.
 
 ```bash
 # Print transcript text to stdout; progress goes to stderr
 inkwell fetch https://youtube.com/watch?v=abc --extract
+
+# Print cleaned article text to stdout
+inkwell fetch https://example.com/article --extract
 
 # Write transcript files without creating episode note directories
 inkwell fetch syntax --latest --extract --output-dir ~/transcripts --plain
@@ -70,8 +78,7 @@ inkwell fetch syntax --latest --extract --output-dir ~/transcripts --plain
 
 The current foundation intentionally leaves these as separate future phases:
 
-- cleaned web/article extraction
-- PDF text extraction
+- hosted article extraction fallbacks for blocked or script-rendered pages
+- OCR/image PDFs
 - slide decks
-- OCR/image ingestion
-- token-aware model routing for long documents
+- image ingestion

--- a/docs/reference/transcription-attempt-policy.md
+++ b/docs/reference/transcription-attempt-policy.md
@@ -1,6 +1,6 @@
 # Transcription Attempt Policy
 
-`TranscriptionAttemptPolicy` makes the transcription fallback order explicit without adding new providers. It is a small developer-facing foundation for future provider capability work.
+`TranscriptionAttemptPolicy` makes the transcription fallback order explicit without adding new providers. It uses typed provider capability metadata when available, while preserving the current built-in fallback order.
 
 ---
 
@@ -14,6 +14,8 @@ For a normal remote media or episode URL, the default policy can produce:
 4. Gemini audio fallback
 
 For local media files, the policy goes directly to Gemini local media transcription. Local media does not run through `yt-dlp`.
+
+Source-text inputs such as local text/markdown, stdin, locally extracted articles, and text PDFs bypass this policy entirely and enter extraction as text.
 
 ---
 
@@ -35,7 +37,7 @@ The manager records attempts with stable labels such as `cache`, `youtube`, and 
 
 ## Extension Guidance
 
-Future provider work should add capability-aware planning to the policy instead of embedding more fallback order in `TranscriptionManager`.
+Future provider work should extend capability-aware planning in the policy instead of embedding more fallback order in `TranscriptionManager`.
 
 Good future policy inputs include:
 
@@ -56,6 +58,5 @@ This policy does not yet add:
 
 - new transcription providers
 - token-aware routing
-- web article extraction
-- PDF, slide, or OCR ingestion
+- slide or OCR ingestion
 - cross-provider quality scoring

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -54,6 +54,10 @@ inkwell fetch ~/Downloads/interview.mp3
 inkwell fetch ./notes.md
 pbpaste | inkwell fetch -
 
+# Process a text PDF or readable article
+inkwell fetch ./paper.pdf
+inkwell fetch https://example.com/article
+
 # Transcript only
 inkwell fetch <url> --extract
 

--- a/docs/user-guide/plugins/creating-plugins.md
+++ b/docs/user-guide/plugins/creating-plugins.md
@@ -11,7 +11,7 @@ Extraction plugins use LLMs to extract structured content from transcripts.
 ### Base Class
 
 ```python
-from inkwell.plugins.types.extraction import ExtractionPlugin
+from inkwell.plugins.types.extraction import ExtractionCapabilities, ExtractionPlugin
 ```
 
 ### Required Methods
@@ -45,6 +45,17 @@ class OpenAIExtractor(ExtractionPlugin):
     MODEL: ClassVar[str] = "gpt-4-turbo"
     INPUT_PRICE_PER_M: ClassVar[float] = 10.00   # $10/M input tokens
     OUTPUT_PRICE_PER_M: ClassVar[float] = 30.00  # $30/M output tokens
+    CAPABILITY_INFO: ClassVar[ExtractionCapabilities] = ExtractionCapabilities(
+        model_name=MODEL,
+        can_extract_text=True,
+        supports_structured_output=True,
+        supports_json_mode=True,
+        max_input_tokens=128_000,
+        input_price_per_m=INPUT_PRICE_PER_M,
+        output_price_per_m=OUTPUT_PRICE_PER_M,
+        estimated_cost_label="paid",
+    )
+    CAPABILITIES: ClassVar[dict[str, Any]] = CAPABILITY_INFO.to_legacy_dict()
 
     def __init__(self, api_key: str | None = None, *, lazy_init: bool = False):
         super().__init__()
@@ -125,6 +136,7 @@ Transcription plugins convert audio/video to text.
 
 ```python
 from inkwell.plugins.types.transcription import (
+    TranscriptionCapabilities,
     TranscriptionPlugin,
     TranscriptionRequest,
 )
@@ -140,24 +152,30 @@ from inkwell.plugins.types.transcription import (
 
 | Method | Return Type | Default | Description |
 |--------|-------------|---------|-------------|
-| `can_handle()` | `bool` | Based on `CAPABILITIES` | Check if plugin can handle request |
+| `can_handle()` | `bool` | Based on `CAPABILITY_INFO` / `CAPABILITIES` | Check if plugin can handle request |
 | `estimate_cost()` | `float` | `0.0` | Estimate cost for duration |
 
 ### Class Attributes
 
 ```python
+from typing import Any, ClassVar
+
 # URL patterns this plugin handles (for auto-selection)
 HANDLES_URLS: ClassVar[list[str]] = ["youtube.com", "youtu.be"]
 
-# Capability declarations
-CAPABILITIES: ClassVar[dict] = {
-    "formats": ["mp3", "wav", "m4a", "mp4"],
-    "max_duration_hours": None,  # None = no limit
-    "requires_internet": True,
-    "supports_file": True,
-    "supports_url": False,
-    "supports_bytes": False,
-}
+# Preferred typed capability declaration. `CAPABILITIES` dictionaries still work
+# for compatibility, but typed metadata gives policy routing and plugin-list
+# output a stable shape.
+CAPABILITY_INFO: ClassVar[TranscriptionCapabilities] = TranscriptionCapabilities(
+    formats=("mp3", "wav", "m4a", "mp4"),
+    can_transcribe_file=True,
+    can_transcribe_url=False,
+    can_transcribe_bytes=False,
+    supports_timestamps=True,
+    requires_internet=True,
+    estimated_cost_label="paid",
+)
+CAPABILITIES: ClassVar[dict[str, Any]] = CAPABILITY_INFO.to_legacy_dict()
 ```
 
 ### Example: Whisper Local Transcription
@@ -169,6 +187,7 @@ from pathlib import Path
 from typing import Any, ClassVar
 
 from inkwell.plugins.types.transcription import (
+    TranscriptionCapabilities,
     TranscriptionPlugin,
     TranscriptionRequest,
 )
@@ -182,14 +201,16 @@ class WhisperTranscriber(TranscriptionPlugin):
     VERSION: ClassVar[str] = "1.0.0"
     DESCRIPTION: ClassVar[str] = "Local Whisper transcription (offline, GPU-accelerated)"
 
-    CAPABILITIES: ClassVar[dict[str, Any]] = {
-        "formats": ["mp3", "wav", "m4a", "mp4", "webm"],
-        "max_duration_hours": None,
-        "requires_internet": False,
-        "supports_file": True,
-        "supports_url": False,  # Requires downloaded file
-        "supports_bytes": False,
-    }
+    CAPABILITY_INFO: ClassVar[TranscriptionCapabilities] = TranscriptionCapabilities(
+        formats=("mp3", "wav", "m4a", "mp4", "webm"),
+        can_transcribe_file=True,
+        can_transcribe_url=False,  # Requires downloaded file
+        can_transcribe_bytes=False,
+        supports_timestamps=True,
+        requires_internet=False,
+        estimated_cost_label="free",
+    )
+    CAPABILITIES: ClassVar[dict[str, Any]] = CAPABILITY_INFO.to_legacy_dict()
 
     def __init__(self, *, lazy_init: bool = False):
         super().__init__()

--- a/docs/user-guide/plugins/index.md
+++ b/docs/user-guide/plugins/index.md
@@ -13,6 +13,7 @@ Inkwell's plugin architecture allows third-party developers to add:
 - **Output plugins**: New output formats (HTML, Notion, Obsidian Canvas, etc.)
 
 Plugins are discovered automatically via Python entry points, configured through YAML, and managed via the `inkwell plugins` CLI commands.
+`inkwell plugins list` shows each provider's declared capabilities, such as supported source types, formats, context limits, model names, and rough cost labels.
 
 !!! warning "Security Notice"
     Plugins run with full privileges and are automatically loaded when installed.
@@ -26,18 +27,24 @@ Create a minimal transcription plugin in 5 minutes:
 
 ```python
 # my_whisper_plugin.py
-from inkwell.plugins.types.transcription import TranscriptionPlugin, TranscriptionRequest
+from inkwell.plugins.types.transcription import (
+    TranscriptionCapabilities,
+    TranscriptionPlugin,
+    TranscriptionRequest,
+)
 
 class WhisperTranscriber(TranscriptionPlugin):
     NAME = "whisper"
     VERSION = "1.0.0"
     DESCRIPTION = "Local Whisper transcription"
 
-    CAPABILITIES = {
-        "supports_file": True,
-        "supports_url": False,
-        "requires_internet": False,
-    }
+    CAPABILITY_INFO = TranscriptionCapabilities(
+        formats=("mp3", "wav", "m4a"),
+        can_transcribe_file=True,
+        requires_internet=False,
+        estimated_cost_label="free",
+    )
+    CAPABILITIES = CAPABILITY_INFO.to_legacy_dict()
 
     async def transcribe(self, request: TranscriptionRequest):
         # Your implementation here

--- a/docs/user-guide/processing.md
+++ b/docs/user-guide/processing.md
@@ -16,7 +16,7 @@ inkwell fetch https://youtube.com/watch?v=xyz
 
 ### Process from Local Files or Stdin
 
-Local audio/video routes through transcription. Local text/markdown and stdin are treated as already-clean source text for the extraction templates.
+Local audio/video routes through transcription. Local text/markdown, local text PDFs, web articles, and stdin are treated as source text for the extraction templates.
 
 ```bash
 # Local audio/video
@@ -24,6 +24,12 @@ inkwell fetch ~/Downloads/interview.mp3
 
 # Local text or markdown
 inkwell fetch ./notes.md
+
+# Local text PDF
+inkwell fetch ./paper.pdf
+
+# Web article
+inkwell fetch https://example.com/article
 
 # Pasted/stdin text
 pbpaste | inkwell fetch -
@@ -51,8 +57,10 @@ When you run `inkwell fetch`, here's what happens:
 
 ```mermaid
 flowchart TD
-    A([inkwell fetch URL / feed]) --> B[Resolve source\n& episode metadata]
-    B --> C{YouTube transcript\navailable?}
+    A([inkwell fetch URL / feed / file]) --> B[Resolve source\n& episode metadata]
+    B --> S{Already text?}
+    S -- Article / PDF / text / stdin --> F[Select extraction templates\nauto or manual]
+    S -- Media / feed episode --> C{YouTube transcript\navailable?}
     C -- Yes / Free --> D[Use YouTube transcript]
     C -- No / blocked --> E{Public YouTube URL?}
     E -- Yes --> J[Gemini video URL fallback\nbounded clips]
@@ -106,8 +114,9 @@ Step 4/4: Writing markdown files...
 | `--category` | `-c` | Episode category | Auto-detect |
 | `--provider` | `-p` | LLM provider (claude, gemini) | Smart selection |
 | `--skip-cache` | | Skip extraction cache | `false` |
+| `--force-extraction` | | Run LLM extraction even when short-content bypass would apply | `false` |
 | `--dry-run` | | Cost estimate only | `false` |
-| `--extract` | | Emit transcript text only and skip note generation | `false` |
+| `--extract` | | Emit transcript/source text only and skip note generation | `false` |
 | `--overwrite` | | Overwrite existing directory | `false` |
 | `--interview` | | Enable interview mode | `false` |
 
@@ -212,9 +221,9 @@ inkwell fetch URL --extract
 inkwell fetch my-podcast --latest --extract --output-dir ~/transcripts --plain
 ```
 
-Use this when you want the clean media transcript first and want to decide later whether to run Inkwell's structured note templates or reflection flow.
+Use this when you want the clean media transcript or source text first and want to decide later whether to run Inkwell's structured note templates or reflection flow.
 
-PDFs, web article extraction, slide decks, and OCR inputs are not part of local/stdin ingestion yet.
+Web articles and text PDFs use local extraction. Hosted article fallbacks, slide decks, and OCR/image PDFs are not part of this path yet.
 
 For script-friendly `--json` and `--plain` output, see [Machine-Readable Output](../reference/machine-readable-output.md).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ dependencies = [
     "regex>=2024.11.0",
     "aiofiles>=24.1.0",
     "jinja2>=3.1.0",
+    "trafilatura>=2.1.0",
+    "pypdf>=6.14.2",
 ]
 
 [project.urls]

--- a/src/inkwell/audio/downloader.py
+++ b/src/inkwell/audio/downloader.py
@@ -120,6 +120,33 @@ class AudioDownloader:
             "extensions": extensions,
         }
 
+    @classmethod
+    def clear_cache(cls, cache_dir: Path | None = None) -> dict[str, int]:
+        """Clear all audio/media cache files.
+
+        Returns:
+            Counts of deleted files and deleted bytes.
+        """
+        resolved_cache_dir = cache_dir or cls.default_cache_dir()
+        result = {"files_deleted": 0, "bytes_deleted": 0}
+
+        if not resolved_cache_dir.exists():
+            return result
+
+        for cache_file in resolved_cache_dir.iterdir():
+            if not cache_file.is_file():
+                continue
+            try:
+                size = cache_file.stat().st_size
+                cache_file.unlink()
+            except OSError as e:
+                logger.debug(f"Failed to delete media cache file {cache_file}: {e}")
+                continue
+            result["files_deleted"] += 1
+            result["bytes_deleted"] += size
+
+        return result
+
     def _get_cache_path(self, url: str) -> Path:
         """Get cached audio file path for a URL.
 

--- a/src/inkwell/cli.py
+++ b/src/inkwell/cli.py
@@ -29,7 +29,13 @@ from inkwell.feeds.youtube_resolver import (
     is_youtube_url,
     resolve_youtube_url,
 )
-from inkwell.ingestion import ContentSource, ContentSourceKind, InputResolver
+from inkwell.ingestion import (
+    ContentSource,
+    ContentSourceKind,
+    InputResolver,
+    extract_article_text_from_url,
+    extract_text_from_pdf,
+)
 from inkwell.pipeline import PipelineOptions, PipelineOrchestrator, PipelineResult
 from inkwell.transcription import CostEstimate, TranscriptionManager, TranscriptionResult
 from inkwell.utils.datetime import now_utc
@@ -54,6 +60,7 @@ console = Console()
 err_console = Console(stderr=True)
 
 _LOCAL_TEXT_EXTENSIONS = {".txt", ".md", ".markdown"}
+_LOCAL_PDF_EXTENSIONS = {".pdf"}
 _LOCAL_MEDIA_EXTENSIONS = {
     ".aac",
     ".aif",
@@ -169,6 +176,11 @@ def _parse_and_validate_extra_templates(value: str | None) -> list[str]:
 def _is_local_text_path(path: Path) -> bool:
     """Return True for local text inputs supported in Phase 6."""
     return path.suffix.lower() in _LOCAL_TEXT_EXTENSIONS
+
+
+def _is_local_pdf_path(path: Path) -> bool:
+    """Return True for local text-PDF inputs."""
+    return path.suffix.lower() in _LOCAL_PDF_EXTENSIONS
 
 
 def _is_local_media_path(path: Path) -> bool:
@@ -308,6 +320,9 @@ def _fetch_result_payload(result: PipelineResult) -> dict[str, Any]:
             "version": extraction_result.template_version,
             "success": extraction_result.success,
             "provider": extraction_result.provider,
+            "model": extraction_result.model,
+            "bypassed": extraction_result.bypassed,
+            "bypass_reason": extraction_result.bypass_reason,
             "from_cache": extraction_result.from_cache,
             "cost_usd": extraction_result.cost_usd,
             "error": extraction_result.error,
@@ -455,6 +470,39 @@ def _validate_extract_only_options(
                 "'inkwell fetch SOURCE --extract' for transcript-only output."
             ),
         )
+
+
+def _resolve_cache_targets(
+    *,
+    transcripts: bool,
+    extractions: bool,
+    media: bool,
+    all_targets: bool,
+) -> dict[str, bool]:
+    """Resolve cache target flags while preserving transcript-only defaults."""
+    if all_targets:
+        return {"transcripts": True, "extractions": True, "media": True}
+
+    targets = {
+        "transcripts": transcripts,
+        "extractions": extractions,
+        "media": media,
+    }
+    if not any(targets.values()):
+        targets["transcripts"] = True
+    return targets
+
+
+def _format_deleted_bytes(bytes_deleted: int) -> str:
+    """Format deleted byte counts for cache command output."""
+    return f"{bytes_deleted / 1024 / 1024:.2f} MB"
+
+
+def _confirm_cache_deletion(*, force: bool, message: str) -> bool:
+    """Confirm destructive cache actions unless explicitly forced."""
+    if force:
+        return True
+    return bool(typer.confirm(message))
 
 
 def _extract_transcript_output_path(
@@ -1114,27 +1162,63 @@ def transcribe_command(
 
 @app.command("cache")
 def cache_command(
-    action: str = typer.Argument(..., help="Action: stats, clear, clear-expired"),
+    action: str = typer.Argument(
+        ...,
+        help="Action: stats, clear, clear-expired, enforce-media-policy",
+    ),
+    transcripts: bool = typer.Option(
+        False,
+        "--transcripts",
+        help="Target transcript cache entries",
+    ),
+    extractions: bool = typer.Option(
+        False,
+        "--extractions",
+        help="Target extraction cache entries",
+    ),
+    media: bool = typer.Option(
+        False,
+        "--media",
+        help="Target downloaded media/audio cache files",
+    ),
+    all_targets: bool = typer.Option(
+        False,
+        "--all",
+        help="Target transcript, extraction, and media caches",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        "-f",
+        help="Skip confirmation for destructive cache actions",
+    ),
 ) -> None:
-    """Manage transcript cache.
+    """Manage local caches.
 
     Actions:
-        stats:         Show cache statistics
-        clear:         Clear all cached transcripts
-        clear-expired: Remove expired cache entries
+        stats:                Show cache statistics
+        clear:                Clear selected caches
+        clear-expired:        Remove expired transcript/extraction entries
+        enforce-media-policy: Apply media cache TTL/size policy
 
     Examples:
         inkwell cache stats
 
-        inkwell cache clear
+        inkwell cache clear --transcripts
+
+        inkwell cache clear --extractions --force
+
+        inkwell cache clear --media --force
+
+        inkwell cache enforce-media-policy --force
     """
     try:
+        from inkwell.audio.downloader import AudioDownloader
+        from inkwell.extraction.cache import ExtractionCache
+
         manager = TranscriptionManager()
 
         if action == "stats":
-            from inkwell.audio.downloader import AudioDownloader
-            from inkwell.extraction.cache import ExtractionCache
-
             stats = manager.cache_stats()
             extraction_stats = asyncio.run(ExtractionCache().get_stats())
             audio_stats = AudioDownloader.cache_stats()
@@ -1211,23 +1295,85 @@ def cache_command(
                     console.print(f"  • {extension}: {count}")
 
         elif action == "clear":
-            confirm: bool = typer.confirm(
-                "\nAre you sure you want to clear all cached transcripts?"
+            targets = _resolve_cache_targets(
+                transcripts=transcripts,
+                extractions=extractions,
+                media=media,
+                all_targets=all_targets,
             )
-            if not confirm:
+            selected = [name for name, selected in targets.items() if selected]
+            if not _confirm_cache_deletion(
+                force=force,
+                message=f"\nClear selected caches ({', '.join(selected)})?",
+            ):
                 console.print("[yellow]Cancelled[/yellow]")
                 return
 
-            count = manager.clear_cache()
-            console.print(f"[green]✓[/green] Cleared {count} cache entries")
+            if targets["transcripts"]:
+                count = manager.clear_cache()
+                console.print(f"[green]✓[/green] Cleared {count} transcript cache entries")
+
+            if targets["extractions"]:
+                count = asyncio.run(ExtractionCache().clear())
+                console.print(f"[green]✓[/green] Cleared {count} extraction cache entries")
+
+            if targets["media"]:
+                media_result = AudioDownloader.clear_cache()
+                console.print(
+                    "[green]✓[/green] Cleared "
+                    f"{media_result['files_deleted']} media cache files "
+                    f"({_format_deleted_bytes(media_result['bytes_deleted'])})"
+                )
 
         elif action == "clear-expired":
-            count = manager.clear_expired_cache()
-            console.print(f"[green]✓[/green] Removed {count} expired cache entries")
+            if all_targets:
+                targets = {"transcripts": True, "extractions": True}
+            elif transcripts or extractions:
+                targets = {"transcripts": transcripts, "extractions": extractions}
+            elif media:
+                targets = {"transcripts": False, "extractions": False}
+            else:
+                targets = {"transcripts": True, "extractions": False}
+
+            if media or all_targets:
+                console.print(
+                    "[yellow]Media cache expiration is handled by "
+                    "inkwell cache enforce-media-policy.[/yellow]"
+                )
+
+            if targets["transcripts"]:
+                count = manager.clear_expired_cache()
+                console.print(f"[green]✓[/green] Removed {count} expired transcript cache entries")
+
+            if targets["extractions"]:
+                count = asyncio.run(ExtractionCache().clear_expired())
+                console.print(f"[green]✓[/green] Removed {count} expired extraction cache entries")
+
+        elif action == "enforce-media-policy":
+            if not _confirm_cache_deletion(
+                force=force,
+                message="\nEnforce media cache TTL/size policy now?",
+            ):
+                console.print("[yellow]Cancelled[/yellow]")
+                return
+
+            media_config = ConfigManager().load_config().cache.media
+            downloader = AudioDownloader(
+                cache_enabled=media_config.enabled,
+                cache_max_mb=media_config.max_mb,
+                cache_ttl_days=media_config.ttl_days,
+            )
+            result = downloader.enforce_cache_policy()
+            console.print(
+                "[green]✓[/green] Enforced media cache policy: "
+                f"{result['expired_files']} expired files, "
+                f"{result['size_files']} size-limit files, "
+                f"{_format_deleted_bytes(result['bytes_deleted'])} deleted"
+            )
 
         else:
             console.print(f"[red]✗[/red] Unknown action: {action}")
-            console.print("Valid actions: stats, clear, clear-expired")
+            console.print("Valid actions: stats, clear, clear-expired, enforce-media-policy")
             sys.exit(1)
 
     except InkwellError as e:
@@ -1270,6 +1416,11 @@ def fetch_command(
         None, "--provider", "-p", help="LLM provider: claude, gemini, auto (default: auto)"
     ),
     skip_cache: bool = typer.Option(False, "--skip-cache", help="Skip extraction cache"),
+    force_extraction: bool = typer.Option(
+        False,
+        "--force-extraction",
+        help="Run LLM extraction even when short-content bypass would apply",
+    ),
     dry_run: bool = typer.Option(False, "--dry-run", help="Show cost estimate without extracting"),
     extract_only: bool = typer.Option(
         False,
@@ -1491,6 +1642,18 @@ def fetch_command(
                     source_episode_title = local_path.stem
                     source_podcast_name = "Local Files"
                     url = str(local_path)
+                elif _is_local_pdf_path(local_path):
+                    source_text = extract_text_from_pdf(local_path)
+                    source_kind = "pdf"
+                    source_episode_title = local_path.stem
+                    source_podcast_name = "Documents"
+                    url = str(local_path)
+                    input_source = ContentSource(
+                        raw_input=input_source.raw_input,
+                        kind=ContentSourceKind.PDF,
+                        value=str(local_path),
+                        path=local_path,
+                    )
                 elif _is_local_media_path(local_path):
                     source_episode_title = local_path.stem
                     source_podcast_name = "Local Files"
@@ -1499,8 +1662,8 @@ def fetch_command(
                     raise ValidationError(
                         f"Unsupported local file type: {local_path.suffix or '<none>'}",
                         suggestion=(
-                            "Use local audio/video, .txt, or .md files for now. "
-                            "PDF, article, slide, and OCR ingestion are planned later."
+                            "Use local audio/video, .txt, .md, or text PDF files. "
+                            "Slides and OCR/image ingestion are planned later."
                         ),
                     )
 
@@ -1512,6 +1675,20 @@ def fetch_command(
                 source_episode_title = "stdin"
                 source_podcast_name = "Stdin"
                 url = "stdin://input"
+
+            elif input_source.kind == ContentSourceKind.URL:
+                source_url = input_source.url or input_source.value
+                source_text = extract_article_text_from_url(source_url)
+                source_kind = "article"
+                source_episode_title = derive_readable_title_from_url(source_url)
+                source_podcast_name = "Articles"
+                url = source_url
+                input_source = ContentSource(
+                    raw_input=input_source.raw_input,
+                    kind=ContentSourceKind.ARTICLE,
+                    value=source_url,
+                    url=source_url,
+                )
 
             elif not is_url:
                 # Treat as feed name - look up in configured feeds
@@ -1734,6 +1911,7 @@ def fetch_command(
                     source_kind=source_kind,
                     extractor=extractor,
                     transcriber=transcriber,
+                    force_extraction=force_extraction,
                 )
 
                 orchestrator = PipelineOrchestrator(config)

--- a/src/inkwell/cli_plugins.py
+++ b/src/inkwell/cli_plugins.py
@@ -57,6 +57,24 @@ def _get_source_label(source: str) -> str:
     return "[cyan](installed)[/cyan]"
 
 
+def _get_capabilities_display(plugin: object | None) -> str:
+    """Return concise capability metadata for plugin list output."""
+    if plugin is None:
+        return ""
+
+    get_capabilities = getattr(plugin, "get_capabilities", None)
+    if not callable(get_capabilities):
+        return ""
+
+    capabilities = get_capabilities()
+    display_parts = getattr(capabilities, "display_parts", None)
+    if not callable(display_parts):
+        return ""
+
+    parts = [str(part) for part in display_parts()]
+    return ", ".join(parts[:7])
+
+
 def _load_all_registries() -> dict[str, PluginRegistry]:
     """Load all plugin registries.
 
@@ -166,6 +184,7 @@ def list_plugins(
         table.add_column("Source", no_wrap=True)
         table.add_column("Status", no_wrap=True)
         table.add_column("Priority", style="dim", justify="right")
+        table.add_column("Capabilities", no_wrap=True)
         table.add_column("Description")
 
         for entry in entries:
@@ -179,12 +198,14 @@ def list_plugins(
             source_label = _get_source_label(entry.source)
             status_display = _get_status_display(entry)
             priority_display = f"[{entry.priority}]"
+            capabilities_display = _get_capabilities_display(entry.plugin)
 
             table.add_row(
                 entry.name,
                 source_label,
                 status_display,
                 priority_display,
+                capabilities_display,
                 description,
             )
 

--- a/src/inkwell/config/schema.py
+++ b/src/inkwell/config/schema.py
@@ -64,6 +64,16 @@ class ExtractionConfig(BaseModel):
     """Extraction service configuration."""
 
     default_provider: Literal["claude", "gemini"] = "gemini"
+    short_content_bypass_enabled: bool = Field(
+        default=True,
+        description="Skip summary LLM extraction for very short source text by default",
+    )
+    short_content_bypass_tokens: int = Field(
+        default=500,
+        ge=1,
+        le=100000,
+        description="Source token threshold for summary pass-through bypass",
+    )
     claude_api_key: str | None = Field(
         default=None,
         min_length=20,

--- a/src/inkwell/extraction/engine.py
+++ b/src/inkwell/extraction/engine.py
@@ -20,7 +20,7 @@ from ..config.schema import ExtractionConfig
 # from inkwell.extraction.extractors.base, which triggers inkwell.extraction.__init__)
 from ..plugins.discovery import discover_plugins, get_entry_point_group
 from ..plugins.registry import PluginRegistry
-from ..plugins.types.extraction import ExtractionPlugin
+from ..plugins.types.extraction import ExtractionCapabilities, ExtractionPlugin
 from ..utils.errors import ValidationError
 from ..utils.json_utils import JSONParsingError, safe_json_loads
 from .cache import ExtractionCache
@@ -33,6 +33,7 @@ from .models import (
     ExtractionSummary,
     ExtractionTemplate,
 )
+from .routing import ExtractionRoutingAttempt, ExtractionRoutingPolicy
 
 if TYPE_CHECKING:
     from ..utils.costs import CostTracker
@@ -93,6 +94,8 @@ class ExtractionEngine:
         cost_tracker: "CostTracker | None" = None,
         use_plugin_registry: bool = True,
         extractor_override: str | None = None,
+        force_extraction: bool = False,
+        routing_policy: ExtractionRoutingPolicy | None = None,
     ) -> None:
         """Initialize extraction engine.
 
@@ -106,6 +109,8 @@ class ExtractionEngine:
             use_plugin_registry: Whether to load extractors from plugin registry (default: True)
             extractor_override: Force a specific extractor plugin (e.g., "claude", "gemini").
                                Takes precedence over INKWELL_EXTRACTOR env var.
+            force_extraction: Run LLM extraction even when short-content bypass applies.
+            routing_policy: Token-aware provider routing policy.
 
         Note:
             Prefer passing `config` over individual parameters. Individual parameters
@@ -158,6 +163,71 @@ class ExtractionEngine:
         self._plugins_loaded = False
 
         self._extractor_override = extractor_override
+        self._force_extraction = force_extraction
+        self._short_content_bypass_enabled = config.short_content_bypass_enabled if config else True
+        self._short_content_bypass_tokens = config.short_content_bypass_tokens if config else 500
+        self.routing_policy = routing_policy or ExtractionRoutingPolicy()
+
+    @staticmethod
+    def _estimate_text_tokens(text: str) -> int:
+        """Estimate token count from text using the repo's existing rough ratio."""
+        return max(1, len(text) // 4)
+
+    def _should_bypass_short_content(
+        self,
+        template: ExtractionTemplate,
+        transcript: str,
+        metadata: dict[str, Any],
+    ) -> tuple[bool, int, str | None]:
+        """Return whether summary extraction should pass through short content."""
+        source_tokens = self._estimate_text_tokens(transcript)
+
+        if self._force_extraction:
+            return False, source_tokens, None
+        if not self._short_content_bypass_enabled:
+            return False, source_tokens, None
+        if template.name != "summary":
+            return False, source_tokens, None
+        if not metadata.get("episode_url") and not metadata.get("source_kind"):
+            return False, source_tokens, None
+        if source_tokens > self._short_content_bypass_tokens:
+            return False, source_tokens, None
+
+        reason = f"source_tokens={source_tokens} <= threshold={self._short_content_bypass_tokens}"
+        return True, source_tokens, reason
+
+    def _bypass_result(
+        self,
+        template: ExtractionTemplate,
+        transcript: str,
+        metadata: dict[str, Any],
+        *,
+        source_tokens: int,
+        reason: str,
+    ) -> ExtractionResult:
+        """Build a pass-through extraction result for short summary content."""
+        content = ExtractedContent(
+            template_name=template.name,
+            content=transcript.strip(),
+            metadata={
+                "bypassed": True,
+                "bypass_reason": reason,
+                "source_tokens": source_tokens,
+                "threshold_tokens": self._short_content_bypass_tokens,
+            },
+        )
+        return ExtractionResult(
+            episode_url=metadata.get("episode_url", ""),
+            template_name=template.name,
+            template_version=template.version,
+            success=True,
+            extracted_content=content,
+            cost_usd=0.0,
+            provider="bypass",
+            model=None,
+            bypassed=True,
+            bypass_reason=reason,
+        )
 
     def _load_extraction_plugins(self) -> None:
         """Load extraction plugins from entry points into registry.
@@ -344,6 +414,50 @@ class ExtractionEngine:
         }
         return default_models.get(provider, "unknown")
 
+    def _cache_key_options_for_provider(
+        self,
+        template: ExtractionTemplate,
+        *,
+        provider: str,
+        model: str,
+    ) -> dict[str, str]:
+        """Build cache-key metadata for a selected provider/model."""
+        return {
+            "provider": provider,
+            "model": model,
+            "prompt_hash": self._template_prompt_hash(template),
+            "output_schema_version": self._output_schema_version(template),
+        }
+
+    def _available_extraction_capabilities(self) -> dict[str, ExtractionCapabilities]:
+        """Return enabled extraction provider capabilities."""
+        capabilities: dict[str, ExtractionCapabilities] = {}
+        for name, plugin in self.extraction_registry.get_enabled():
+            get_capabilities = getattr(plugin, "get_capabilities", None)
+            if callable(get_capabilities):
+                capabilities[name] = get_capabilities()
+            else:
+                model_name = self._model_name_for_extractor(plugin)
+                capabilities[name] = ExtractionCapabilities(model_name=model_name)
+        return capabilities
+
+    def _plan_extraction_attempts(
+        self,
+        template: ExtractionTemplate,
+        transcript: str,
+        metadata: dict[str, Any],
+    ) -> list[ExtractionRoutingAttempt]:
+        """Plan ordered extraction attempts for one template."""
+        override = self._extractor_override or os.environ.get("INKWELL_EXTRACTOR")
+        return self.routing_policy.plan(
+            template=template,
+            transcript=transcript,
+            metadata=metadata,
+            available_capabilities=self._available_extraction_capabilities(),
+            default_provider=self.default_provider,
+            override=override,
+        )
+
     def _template_prompt_hash(self, template: ExtractionTemplate) -> str:
         """Hash prompt/template inputs that affect extraction output."""
         payload = {
@@ -372,6 +486,94 @@ class ExtractionEngine:
         schema_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
         return f"{template.expected_format}:{schema_hash}"
 
+    async def _extract_with_single_extractor(
+        self,
+        *,
+        template: ExtractionTemplate,
+        transcript: str,
+        metadata: dict[str, Any],
+        use_cache: bool,
+        episode_url: str,
+    ) -> ExtractionResult:
+        """Compatibility path for callers/tests that inject `_select_extractor`."""
+        extractor = self._select_extractor(template)
+        provider_name = self._provider_name_for_extractor(extractor)
+        model_name = self._model_name_for_extractor(extractor)
+        cache_key_options = self._cache_key_options(template, extractor)
+
+        if use_cache:
+            cached = await self.cache.get(
+                template.name,
+                template.version,
+                transcript,
+                **cache_key_options,
+            )
+            if cached:
+                content = self._parse_output(cached, template)
+                return ExtractionResult(
+                    episode_url=episode_url,
+                    template_name=template.name,
+                    template_version=template.version,
+                    success=True,
+                    extracted_content=content,
+                    cost_usd=0.0,
+                    provider="cache",
+                    model=model_name,
+                    from_cache=True,
+                )
+
+        estimated_cost = extractor.estimate_cost(template, len(transcript))
+
+        try:
+            raw_output = await extractor.extract(template, transcript, metadata)
+            content = self._parse_output(raw_output, template)
+
+            if use_cache:
+                await self.cache.set(
+                    template.name,
+                    template.version,
+                    transcript,
+                    raw_output,
+                    **cache_key_options,
+                )
+
+            if self.cost_tracker:
+                input_tokens = len(transcript) // 4
+                output_tokens = len(raw_output) // 4
+                self.cost_tracker.add_cost(
+                    provider=provider_name,
+                    model=model_name,
+                    operation="extraction",
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    episode_title=metadata.get("episode_title"),
+                    template_name=template.name,
+                )
+
+            return ExtractionResult(
+                episode_url=episode_url,
+                template_name=template.name,
+                template_version=template.version,
+                success=True,
+                extracted_content=content,
+                cost_usd=estimated_cost,
+                provider=provider_name,
+                model=model_name,
+            )
+        except Exception as e:
+            error_msg = _sanitize_error_message(str(e))
+            return ExtractionResult(
+                episode_url=episode_url,
+                template_name=template.name,
+                template_version=template.version,
+                success=False,
+                extracted_content=None,
+                error=error_msg,
+                cost_usd=0.0,
+                provider=provider_name,
+                model=model_name,
+            )
+
     async def extract(
         self,
         template: ExtractionTemplate,
@@ -394,109 +596,151 @@ class ExtractionEngine:
             ExtractionError: If extraction fails
         """
         episode_url = metadata.get("episode_url", "")
-        policy_cache_key_options = self._cache_key_options(template)
-
-        if use_cache:
-            cached = await self.cache.get(
-                template.name,
-                template.version,
+        should_bypass, source_tokens, bypass_reason = self._should_bypass_short_content(
+            template, transcript, metadata
+        )
+        if should_bypass and bypass_reason is not None:
+            return self._bypass_result(
+                template,
                 transcript,
-                **policy_cache_key_options,
+                metadata,
+                source_tokens=source_tokens,
+                reason=bypass_reason,
             )
-            if cached:
-                content = self._parse_output(cached, template)
-                return ExtractionResult(
-                    episode_url=episode_url,
-                    template_name=template.name,
-                    template_version=template.version,
-                    success=True,
-                    extracted_content=content,
-                    cost_usd=0.0,  # Cached, no cost
-                    provider="cache",
-                    from_cache=True,
-                )
 
-        extractor = self._select_extractor(template)
-        provider_name = self._provider_name_for_extractor(extractor)
-        cache_key_options = self._cache_key_options(template, extractor)
-
-        if use_cache and cache_key_options != policy_cache_key_options:
-            cached = await self.cache.get(
-                template.name,
-                template.version,
-                transcript,
-                **cache_key_options,
-            )
-            if cached:
-                content = self._parse_output(cached, template)
-                return ExtractionResult(
-                    episode_url=episode_url,
-                    template_name=template.name,
-                    template_version=template.version,
-                    success=True,
-                    extracted_content=content,
-                    cost_usd=0.0,
-                    provider="cache",
-                    from_cache=True,
-                )
-
-        # Estimate cost
-        estimated_cost = extractor.estimate_cost(template, len(transcript))
-
-        try:
-            # Extract
-            raw_output = await extractor.extract(template, transcript, metadata)
-
-            content = self._parse_output(raw_output, template)
-
-            if use_cache:
-                await self.cache.set(
-                    template.name,
-                    template.version,
-                    transcript,
-                    raw_output,
-                    **cache_key_options,
-                )
-
-            if self.cost_tracker:
-                # Estimate token counts based on transcript length
-                # This is an approximation; real token counts would come from API response
-                input_tokens = len(transcript) // 4  # Rough approximation
-                output_tokens = len(raw_output) // 4
-
-                self.cost_tracker.add_cost(
-                    provider=provider_name,
-                    model=extractor.model if hasattr(extractor, "model") else "unknown",
-                    operation="extraction",
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                    episode_title=metadata.get("episode_title"),
-                    template_name=template.name,
-                )
-
-            return ExtractionResult(
+        if "_select_extractor" in self.__dict__:
+            return await self._extract_with_single_extractor(
+                template=template,
+                transcript=transcript,
+                metadata=metadata,
+                use_cache=use_cache,
                 episode_url=episode_url,
-                template_name=template.name,
-                template_version=template.version,
-                success=True,
-                extracted_content=content,
-                cost_usd=estimated_cost,
-                provider=provider_name,
             )
 
-        except Exception as e:
-            # Sanitize error message to prevent API key leakage
-            error_msg = _sanitize_error_message(str(e))
+        attempts = self._plan_extraction_attempts(template, transcript, metadata)
+        if not attempts:
+            estimated_tokens = self.routing_policy.estimate_prompt_tokens(
+                template=template,
+                transcript=transcript,
+                metadata=metadata,
+            )
             return ExtractionResult(
                 episode_url=episode_url,
                 template_name=template.name,
                 template_version=template.version,
                 success=False,
                 extracted_content=None,
-                error=error_msg,
+                error=(
+                    "No configured extraction provider can handle the estimated "
+                    f"{estimated_tokens} token prompt."
+                ),
                 cost_usd=0.0,
-                provider=provider_name,
+                provider=None,
+                model=None,
             )
+
+        if use_cache:
+            for attempt in attempts:
+                cache_key_options = self._cache_key_options_for_provider(
+                    template,
+                    provider=attempt.provider,
+                    model=attempt.model,
+                )
+                cached = await self.cache.get(
+                    template.name,
+                    template.version,
+                    transcript,
+                    **cache_key_options,
+                )
+                if cached:
+                    content = self._parse_output(cached, template)
+                    return ExtractionResult(
+                        episode_url=episode_url,
+                        template_name=template.name,
+                        template_version=template.version,
+                        success=True,
+                        extracted_content=content,
+                        cost_usd=0.0,
+                        provider="cache",
+                        model=attempt.model,
+                        from_cache=True,
+                    )
+
+        last_error: str | None = None
+        last_attempt: ExtractionRoutingAttempt | None = None
+
+        for attempt in attempts:
+            last_attempt = attempt
+            extractor = self.extraction_registry.get(attempt.provider)
+            if extractor is None:
+                last_error = f"Provider '{attempt.provider}' is not available"
+                continue
+
+            estimated_cost = extractor.estimate_cost(template, len(transcript))
+            cache_key_options = self._cache_key_options_for_provider(
+                template,
+                provider=attempt.provider,
+                model=attempt.model,
+            )
+
+            try:
+                raw_output = await extractor.extract(template, transcript, metadata)
+                content = self._parse_output(raw_output, template)
+
+                if use_cache:
+                    await self.cache.set(
+                        template.name,
+                        template.version,
+                        transcript,
+                        raw_output,
+                        **cache_key_options,
+                    )
+
+                if self.cost_tracker:
+                    input_tokens = len(transcript) // 4
+                    output_tokens = len(raw_output) // 4
+
+                    self.cost_tracker.add_cost(
+                        provider=attempt.provider,
+                        model=attempt.model,
+                        operation="extraction",
+                        input_tokens=input_tokens,
+                        output_tokens=output_tokens,
+                        episode_title=metadata.get("episode_title"),
+                        template_name=template.name,
+                    )
+
+                return ExtractionResult(
+                    episode_url=episode_url,
+                    template_name=template.name,
+                    template_version=template.version,
+                    success=True,
+                    extracted_content=content,
+                    cost_usd=estimated_cost,
+                    provider=attempt.provider,
+                    model=attempt.model,
+                )
+            except Exception as e:
+                last_error = _sanitize_error_message(str(e))
+                logger.warning(
+                    "Extraction attempt failed for template '%s' with provider '%s': %s",
+                    template.name,
+                    attempt.provider,
+                    last_error,
+                )
+                continue
+
+        return ExtractionResult(
+            episode_url=episode_url,
+            template_name=template.name,
+            template_version=template.version,
+            success=False,
+            extracted_content=None,
+            error=last_error or "All extraction attempts failed",
+            cost_usd=0.0,
+            provider=last_attempt.provider if last_attempt else None,
+            model=last_attempt.model if last_attempt else None,
+        )
 
     async def extract_all(
         self,
@@ -606,24 +850,44 @@ class ExtractionEngine:
         self,
         templates: list[ExtractionTemplate],
         transcript: str,
-        episode_url: str,
+        metadata: dict[str, Any],
     ) -> dict[str, ExtractionResult]:
         """Lookup multiple templates in cache concurrently.
 
         Args:
             templates: List of templates to check
             transcript: Episode transcript for cache key
-            episode_url: Episode URL for results
+            metadata: Episode/source metadata for routing and results
 
         Returns:
             Dict mapping template name to ExtractionResult (only cache hits)
         """
         import asyncio
 
+        episode_url = metadata.get("episode_url", "")
+
         async def lookup_one(
             template: ExtractionTemplate,
-        ) -> tuple[ExtractionTemplate, str | None]:
+        ) -> tuple[ExtractionTemplate, str | None, dict[str, str]]:
             """Lookup single template in cache."""
+            if "_select_extractor" not in self.__dict__:
+                attempts = self._plan_extraction_attempts(template, transcript, metadata)
+                for attempt in attempts:
+                    cache_key_options = self._cache_key_options_for_provider(
+                        template,
+                        provider=attempt.provider,
+                        model=attempt.model,
+                    )
+                    result = await self.cache.get(
+                        template.name,
+                        template.version,
+                        transcript,
+                        **cache_key_options,
+                    )
+                    if result is not None:
+                        return (template, result, cache_key_options)
+                return (template, None, {})
+
             policy_cache_key_options = self._cache_key_options(template)
             result = await self.cache.get(
                 template.name,
@@ -632,7 +896,7 @@ class ExtractionEngine:
                 **policy_cache_key_options,
             )
             if result is not None:
-                return (template, result)
+                return (template, result, policy_cache_key_options)
 
             extractor = self._select_extractor(template)
             cache_key_options = self._cache_key_options(template, extractor)
@@ -643,12 +907,14 @@ class ExtractionEngine:
                     transcript,
                     **cache_key_options,
                 )
-            return (template, result)
+                if result is not None:
+                    return (template, result, cache_key_options)
+            return (template, result, policy_cache_key_options)
 
         results = await asyncio.gather(*[lookup_one(t) for t in templates])
 
         cached_results = {}
-        for template, cached_raw in results:
+        for template, cached_raw, cache_key_options in results:
             if cached_raw is not None:
                 content = self._parse_output(cached_raw, template)
                 cached_results[template.name] = ExtractionResult(
@@ -659,6 +925,7 @@ class ExtractionEngine:
                     extracted_content=content,
                     cost_usd=0.0,
                     provider="cache",
+                    model=cache_key_options["model"],
                     from_cache=True,
                 )
 
@@ -704,68 +971,83 @@ class ExtractionEngine:
 
         episode_url = metadata.get("episode_url", "")
 
+        bypassed_results: dict[str, ExtractionResult] = {}
+        processable_templates: list[ExtractionTemplate] = []
+        for template in templates:
+            should_bypass, source_tokens, bypass_reason = self._should_bypass_short_content(
+                template,
+                transcript,
+                metadata,
+            )
+            if should_bypass and bypass_reason is not None:
+                bypassed_results[template.name] = self._bypass_result(
+                    template,
+                    transcript,
+                    metadata,
+                    source_tokens=source_tokens,
+                    reason=bypass_reason,
+                )
+            else:
+                processable_templates.append(template)
+
         cached_results = {}
         uncached_templates = []
 
         if use_cache:
             # Batch lookup all templates at once
             cache_start = time.time()
-            cached_results = await self._batch_cache_lookup(templates, transcript, episode_url)
+            cached_results = await self._batch_cache_lookup(
+                processable_templates,
+                transcript,
+                metadata,
+            )
             cache_duration = time.time() - cache_start
 
             logger.debug(
-                f"Cache lookup took {cache_duration:.3f}s for {len(templates)} templates "
-                f"({len(cached_results)} hits, {len(templates) - len(cached_results)} misses)"
+                f"Cache lookup took {cache_duration:.3f}s for {len(processable_templates)} "
+                f"templates ({len(cached_results)} hits, "
+                f"{len(processable_templates) - len(cached_results)} misses)"
             )
 
             # Separate cached from uncached
-            for template in templates:
+            for template in processable_templates:
                 if template.name not in cached_results:
                     uncached_templates.append(template)
         else:
-            uncached_templates = templates
-
-        # If all cached, return early with summary
-        if not uncached_templates:
-            logger.info("All templates found in cache, returning cached results")
-            results_list = [cached_results[t.name] for t in templates]
-
-            attempts = [
-                ExtractionAttempt(
-                    template_name=t.name,
-                    status=ExtractionStatus.CACHED,
-                    result=cached_results[t.name],
-                    duration_seconds=0.0,
-                )
-                for t in templates
-            ]
-            summary = ExtractionSummary(
-                total=len(templates),
-                successful=0,
-                failed=0,
-                cached=len(templates),
-                attempts=attempts,
-            )
-            return results_list, summary
+            uncached_templates = processable_templates
 
         # Extract each template individually for focused, reliable results
-        logger.info(f"Extracting {len(uncached_templates)} templates individually")
-        batch_results = await self._extract_individually(
-            uncached_templates, transcript, metadata, episode_url
-        )
+        batch_results = {}
+        if uncached_templates:
+            logger.info(f"Extracting {len(uncached_templates)} templates individually")
+            batch_results = await self._extract_individually(
+                uncached_templates, transcript, metadata, episode_url
+            )
+        else:
+            logger.info("No uncached templates require LLM extraction")
 
         if use_cache:
             for template in uncached_templates:
                 result = batch_results.get(template.name)
-                if result and result.success and result.extracted_content:
+                provider = result.provider if result else None
+                if (
+                    result
+                    and result.success
+                    and result.extracted_content
+                    and provider is not None
+                    and provider not in {"cache", "bypass"}
+                ):
                     raw_output = self._serialize_extracted_content(result.extracted_content)
-                    extractor = self._select_extractor(template)
                     await self.cache.set(
                         template.name,
                         template.version,
                         transcript,
                         raw_output,
-                        **self._cache_key_options(template, extractor),
+                        **self._cache_key_options_for_provider(
+                            template,
+                            provider=provider,
+                            model=result.model or self._cache_model_for_provider(provider),
+                        ),
                     )
 
         # Combine cached and new results in original order and build summary
@@ -774,7 +1056,18 @@ class ExtractionEngine:
         batch_duration = time.time() - batch_start_time
 
         for template in templates:
-            if template.name in cached_results:
+            if template.name in bypassed_results:
+                result = bypassed_results[template.name]
+                all_results.append(result)
+                attempts.append(
+                    ExtractionAttempt(
+                        template_name=template.name,
+                        status=ExtractionStatus.SUCCESS,
+                        result=result,
+                        duration_seconds=0.0,
+                    )
+                )
+            elif template.name in cached_results:
                 result = cached_results[template.name]
                 all_results.append(result)
                 attempts.append(

--- a/src/inkwell/extraction/extractors/claude.py
+++ b/src/inkwell/extraction/extractors/claude.py
@@ -5,7 +5,7 @@ from typing import Any
 from anthropic import Anthropic, AsyncAnthropic
 from anthropic.types import Message
 
-from ...plugins.types.extraction import ExtractionPlugin
+from ...plugins.types.extraction import ExtractionCapabilities, ExtractionPlugin
 from ...utils.api_keys import get_validated_api_key
 from ...utils.errors import APIError, ValidationError
 from ...utils.rate_limiter import get_rate_limiter
@@ -36,6 +36,19 @@ class ClaudeExtractor(ExtractionPlugin):
     # Pricing per million tokens (USD)
     INPUT_PRICE_PER_M = 3.00
     OUTPUT_PRICE_PER_M = 15.00
+
+    CAPABILITY_INFO = ExtractionCapabilities(
+        model_name=MODEL,
+        can_extract_text=True,
+        supports_structured_output=True,
+        supports_json_mode=True,
+        requires_internet=True,
+        max_input_tokens=200_000,
+        input_price_per_m=INPUT_PRICE_PER_M,
+        output_price_per_m=OUTPUT_PRICE_PER_M,
+        estimated_cost_label="paid",
+    )
+    CAPABILITIES = CAPABILITY_INFO.to_legacy_dict()
 
     def __init__(self, api_key: str | None = None, *, lazy_init: bool = False) -> None:
         """Initialize Claude extractor.

--- a/src/inkwell/extraction/extractors/gemini.py
+++ b/src/inkwell/extraction/extractors/gemini.py
@@ -6,7 +6,7 @@ from typing import Any
 from google import genai
 from google.genai import types
 
-from ...plugins.types.extraction import ExtractionPlugin
+from ...plugins.types.extraction import ExtractionCapabilities, ExtractionPlugin
 from ...utils.api_keys import get_validated_api_key
 from ...utils.errors import APIError, ValidationError
 from ...utils.rate_limiter import get_rate_limiter
@@ -43,6 +43,19 @@ class GeminiExtractor(ExtractionPlugin):
     INPUT_PRICE_PER_M = 2.00  # Default for base class (short context)
     OUTPUT_PRICE_PER_M = 12.00  # < 200K tokens (using base rate)
     CONTEXT_THRESHOLD = 200_000  # Token threshold for pricing
+
+    CAPABILITY_INFO = ExtractionCapabilities(
+        model_name=MODEL,
+        can_extract_text=True,
+        supports_structured_output=True,
+        supports_json_mode=True,
+        requires_internet=True,
+        max_input_tokens=1_000_000,
+        input_price_per_m=INPUT_PRICE_PER_M,
+        output_price_per_m=OUTPUT_PRICE_PER_M,
+        estimated_cost_label="paid",
+    )
+    CAPABILITIES = CAPABILITY_INFO.to_legacy_dict()
 
     def __init__(self, api_key: str | None = None, *, lazy_init: bool = False) -> None:
         """Initialize Gemini extractor.

--- a/src/inkwell/extraction/models.py
+++ b/src/inkwell/extraction/models.py
@@ -232,6 +232,9 @@ class ExtractionResult(BaseModel):
     tokens_used: int = Field(0, description="Total tokens used (input + output)", ge=0)
     cost_usd: float = Field(0.0, description="Cost in USD", ge=0)
     provider: str | None = Field(None, description="LLM provider used")
+    model: str | None = Field(None, description="Model used for extraction")
+    bypassed: bool = Field(False, description="Whether LLM extraction was bypassed")
+    bypass_reason: str | None = Field(None, description="Reason extraction was bypassed")
 
     from_cache: bool = Field(False, description="Whether result came from cache")
     cache_key: str | None = Field(None, description="Cache key if cached")

--- a/src/inkwell/extraction/routing.py
+++ b/src/inkwell/extraction/routing.py
@@ -1,0 +1,140 @@
+"""Token-aware extraction routing policy."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from jinja2 import Template
+
+from inkwell.plugins.types import ExtractionCapabilities
+
+from .models import ExtractionTemplate
+
+
+@dataclass(frozen=True)
+class ExtractionRoutingAttempt:
+    """One ordered extraction provider/model attempt."""
+
+    provider: str
+    model: str
+    estimated_prompt_tokens: int
+    reason: str
+
+
+class ExtractionRoutingPolicy:
+    """Plan ordered extraction attempts from prompt size and provider capabilities."""
+
+    def estimate_prompt_tokens(
+        self,
+        *,
+        template: ExtractionTemplate,
+        transcript: str,
+        metadata: Mapping[str, Any],
+    ) -> int:
+        """Estimate input plus expected output tokens for a template request."""
+        rendered_prompt = self._render_user_prompt(template, transcript, metadata)
+        prompt_text = "\n\n".join([template.system_prompt, rendered_prompt])
+        return max(1, len(prompt_text) // 4) + template.max_tokens
+
+    def plan(
+        self,
+        *,
+        template: ExtractionTemplate,
+        transcript: str,
+        metadata: Mapping[str, Any],
+        available_capabilities: Mapping[str, ExtractionCapabilities],
+        default_provider: str,
+        override: str | None = None,
+    ) -> list[ExtractionRoutingAttempt]:
+        """Return ordered provider/model attempts that can fit the prompt."""
+        estimated_tokens = self.estimate_prompt_tokens(
+            template=template,
+            transcript=transcript,
+            metadata=metadata,
+        )
+        candidates = self._candidate_order(template, default_provider, override)
+        attempts: list[ExtractionRoutingAttempt] = []
+
+        for provider in candidates:
+            capabilities = available_capabilities.get(provider)
+            if capabilities is None:
+                continue
+            if capabilities.max_input_tokens is not None:
+                if estimated_tokens > capabilities.max_input_tokens:
+                    continue
+            attempts.append(
+                ExtractionRoutingAttempt(
+                    provider=provider,
+                    model=capabilities.model_name,
+                    estimated_prompt_tokens=estimated_tokens,
+                    reason="override" if override else "auto",
+                )
+            )
+
+        return attempts
+
+    def _candidate_order(
+        self,
+        template: ExtractionTemplate,
+        default_provider: str,
+        override: str | None,
+    ) -> list[str]:
+        """Build a deduplicated candidate order before capability filtering."""
+        if override:
+            return [override]
+
+        candidates: list[str] = []
+        if template.model_preference:
+            candidates.append(template.model_preference)
+
+        if "quote" in template.name.lower():
+            candidates.extend(["claude", default_provider, "gemini"])
+        elif template.expected_format == "json" and template.output_schema:
+            required_fields = template.output_schema.get("required", [])
+            if len(required_fields) > 5:
+                candidates.extend(["claude", default_provider, "gemini"])
+            else:
+                candidates.extend([default_provider, "gemini", "claude"])
+        else:
+            candidates.extend([default_provider, "gemini", "claude"])
+
+        return self._dedupe(candidates)
+
+    @staticmethod
+    def _dedupe(values: Sequence[str]) -> list[str]:
+        seen: set[str] = set()
+        result: list[str] = []
+        for value in values:
+            if value in seen:
+                continue
+            seen.add(value)
+            result.append(value)
+        return result
+
+    @staticmethod
+    def _render_user_prompt(
+        template: ExtractionTemplate,
+        transcript: str,
+        metadata: Mapping[str, Any],
+    ) -> str:
+        examples_text = ""
+        if template.few_shot_examples:
+            examples_text = "\n\nExamples:\n"
+            for i, example in enumerate(template.few_shot_examples, 1):
+                examples_text += f"\nExample {i}:\n"
+                if "input" in example:
+                    examples_text += f"Input: {example['input']}\n"
+                if "output" in example:
+                    examples_text += f"Output:\n{json.dumps(example['output'], indent=2)}\n"
+
+        prompt = Template(template.user_prompt_template).render(
+            transcript=transcript,
+            metadata=dict(metadata),
+            examples=examples_text,
+        )
+        if examples_text:
+            return examples_text + "\n\n" + prompt
+        return prompt

--- a/src/inkwell/ingestion/__init__.py
+++ b/src/inkwell/ingestion/__init__.py
@@ -1,5 +1,17 @@
 """Input classification primitives for Inkwell ingestion."""
 
 from .resolver import ContentSource, ContentSourceKind, InputResolver
+from .source_extractors import (
+    extract_article_text_from_html,
+    extract_article_text_from_url,
+    extract_text_from_pdf,
+)
 
-__all__ = ["ContentSource", "ContentSourceKind", "InputResolver"]
+__all__ = [
+    "ContentSource",
+    "ContentSourceKind",
+    "InputResolver",
+    "extract_article_text_from_html",
+    "extract_article_text_from_url",
+    "extract_text_from_pdf",
+]

--- a/src/inkwell/ingestion/resolver.py
+++ b/src/inkwell/ingestion/resolver.py
@@ -1,8 +1,11 @@
 """Conservative input classification for CLI ingestion.
 
-This module intentionally stops at classification. It does not fetch RSS feeds,
-open local files, read stdin, or route content through extraction. Those are
-separate phases once the source model is stable.
+This module owns only source classification and minimal path checks. The CLI
+uses the resulting `ContentSource` to route saved feeds, URLs, local media,
+local text, and stdin into the appropriate pipeline path. More expensive work
+such as feed fetching, file reading, PDF parsing, article cleanup,
+transcription, and extraction stays outside the resolver. Dedicated slide and
+OCR routes remain separate follow-up ingestion work.
 """
 
 from __future__ import annotations
@@ -25,6 +28,8 @@ class ContentSourceKind(str, Enum):
     STDIN = "stdin"
     DIRECT_MEDIA = "direct_media"
     YOUTUBE = "youtube"
+    ARTICLE = "article"
+    PDF = "pdf"
     UNKNOWN_URL = "unknown_url"
 
 
@@ -53,6 +58,7 @@ class ContentSource:
             ContentSourceKind.URL,
             ContentSourceKind.DIRECT_MEDIA,
             ContentSourceKind.YOUTUBE,
+            ContentSourceKind.ARTICLE,
         }
 
 

--- a/src/inkwell/ingestion/source_extractors.py
+++ b/src/inkwell/ingestion/source_extractors.py
@@ -1,0 +1,152 @@
+"""Local source-text extraction for article URLs and text PDFs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import trafilatura
+from pypdf import PdfReader
+
+from inkwell.utils.errors import ValidationError
+
+ARTICLE_MIN_CHARACTERS = 80
+ARTICLE_TIMEOUT_SECONDS = 15.0
+ARTICLE_USER_AGENT = "inkwell-cli/0.1 (+https://github.com/chekos/inkwell-cli)"
+
+
+def extract_article_text_from_url(url: str) -> str:
+    """Fetch an HTTP(S) URL and extract readable article text locally."""
+    html = fetch_article_html(url)
+    return extract_article_text_from_html(html, url=url)
+
+
+def fetch_article_html(url: str) -> str:
+    """Fetch article HTML with user-facing failure messages."""
+    try:
+        with httpx.Client(
+            follow_redirects=True,
+            timeout=ARTICLE_TIMEOUT_SECONDS,
+            headers={"User-Agent": ARTICLE_USER_AGENT, "Accept": "text/html,application/xhtml+xml"},
+        ) as client:
+            response = client.get(url)
+            response.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        raise ValidationError(
+            f"Article URL returned HTTP {e.response.status_code}: {url}",
+            suggestion=(
+                "Local-only article extraction cannot bypass blocked pages. "
+                "Hosted extraction fallbacks are deferred to #112."
+            ),
+        ) from e
+    except httpx.RequestError as e:
+        raise ValidationError(
+            f"Could not fetch article URL locally: {url}",
+            suggestion=(
+                "Check the URL or network connection. Hosted extraction fallbacks "
+                "are deferred to #112."
+            ),
+        ) from e
+
+    content_type = response.headers.get("content-type", "").lower()
+    if content_type and not any(
+        accepted in content_type
+        for accepted in ("text/html", "application/xhtml+xml", "application/xml")
+    ):
+        raise ValidationError(
+            f"Article URL did not return HTML content: {content_type}",
+            suggestion="Use direct media URLs for audio/video, or provide a readable HTML article.",
+        )
+
+    if not response.text.strip():
+        raise ValidationError(
+            "Article URL returned an empty response",
+            suggestion=(
+                "The page may be blocked or script-rendered. Hosted fallbacks are deferred to #112."
+            ),
+        )
+
+    return response.text
+
+
+def extract_article_text_from_html(html: str, *, url: str | None = None) -> str:
+    """Extract readable article text from an HTML string using local parsing."""
+    if not html.strip():
+        raise ValidationError(
+            "Article HTML is empty",
+            suggestion="Provide a readable HTML page or use local text input.",
+        )
+
+    extracted = trafilatura.extract(
+        html,
+        url=url,
+        output_format="txt",
+        include_comments=False,
+        include_tables=True,
+        deduplicate=True,
+    )
+    text = _normalize_extracted_text(extracted or "")
+    if len(text) < ARTICLE_MIN_CHARACTERS:
+        raise ValidationError(
+            "Could not extract readable article text locally",
+            suggestion=(
+                "The page may be blocked, script-rendered, or too thin. "
+                "Hosted extraction fallbacks are deferred to #112."
+            ),
+        )
+    return text
+
+
+def extract_text_from_pdf(path: Path) -> str:
+    """Extract selectable text from a local text PDF."""
+    try:
+        reader = PdfReader(path)
+    except Exception as e:
+        raise ValidationError(
+            f"Could not read PDF file: {path}",
+            suggestion="Only unencrypted text PDFs are supported right now.",
+        ) from e
+
+    if reader.is_encrypted:
+        raise ValidationError(
+            f"Encrypted PDFs are not supported: {path}",
+            suggestion="Export an unencrypted text PDF, or convert the content to .txt or .md.",
+        )
+
+    pages: list[str] = []
+    for page in reader.pages:
+        try:
+            page_text = page.extract_text() or ""
+        except Exception as e:
+            raise ValidationError(
+                f"Could not extract selectable text from PDF: {path}",
+                suggestion="Text-only PDFs are supported; OCR/image PDFs are deferred to #111.",
+            ) from e
+        page_text = _normalize_extracted_text(page_text)
+        if page_text:
+            pages.append(page_text)
+
+    text = "\n\n".join(pages).strip()
+    if not text:
+        raise ValidationError(
+            "No selectable text found in PDF",
+            suggestion=(
+                "Text-only PDF extraction is supported now. OCR/image PDF support "
+                "is deferred to #111."
+            ),
+        )
+    return text
+
+
+def _normalize_extracted_text(text: str) -> str:
+    """Trim lines and collapse excessive blank space without reflowing prose."""
+    lines = [line.strip() for line in text.splitlines()]
+    normalized_lines: list[str] = []
+    previous_blank = False
+    for line in lines:
+        is_blank = not line
+        if is_blank and previous_blank:
+            continue
+        normalized_lines.append(line)
+        previous_blank = is_blank
+    return "\n".join(normalized_lines).strip()

--- a/src/inkwell/output/markdown.py
+++ b/src/inkwell/output/markdown.py
@@ -145,9 +145,18 @@ class MarkdownOutput(OutputPlugin):
             "extracted_with": result.provider,
             "cost_usd": round(result.cost_usd, 4),
         }
+        if result.model:
+            frontmatter_data["model"] = result.model
+        if result.bypassed:
+            frontmatter_data["extraction_bypassed"] = True
+            frontmatter_data["bypass_reason"] = result.bypass_reason
 
         if "episode_url" in episode_metadata:
             frontmatter_data["url"] = episode_metadata["episode_url"]
+        custom_fields = episode_metadata.get("custom_fields") or {}
+        source_kind = custom_fields.get("source_kind")
+        if source_kind:
+            frontmatter_data["source_kind"] = source_kind
 
         tags = self._generate_tags(result.template_name)
         if tags:

--- a/src/inkwell/pipeline/models.py
+++ b/src/inkwell/pipeline/models.py
@@ -39,6 +39,7 @@ class PipelineOptions:
     # Plugin overrides (from CLI flags or env vars)
     extractor: str | None = None
     transcriber: str | None = None
+    force_extraction: bool = False
 
 
 @dataclass

--- a/src/inkwell/pipeline/orchestrator.py
+++ b/src/inkwell/pipeline/orchestrator.py
@@ -228,6 +228,7 @@ class PipelineOrchestrator:
             episode_title=effective_episode_title,
             episode_url=options.url,
             transcription_source=transcript.source,
+            custom_fields={"source_kind": options.source_kind} if options.source_kind else {},
         )
 
         if progress_callback:
@@ -286,6 +287,7 @@ class PipelineOrchestrator:
             skip_cache=options.skip_cache,
             dry_run=options.dry_run,
             extractor_override=options.extractor,
+            force_extraction=options.force_extraction,
         )
 
         if progress_callback:
@@ -537,6 +539,7 @@ class PipelineOrchestrator:
         skip_cache: bool,
         dry_run: bool,
         extractor_override: str | None = None,
+        force_extraction: bool = False,
     ) -> tuple[list["ExtractionResult"], "ExtractionSummary", float]:
         """Extract content using templates and LLM.
 
@@ -563,6 +566,7 @@ class PipelineOrchestrator:
             gemini_api_key=shared_gemini_key,
             cost_tracker=self.cost_tracker,
             extractor_override=extractor_override,
+            force_extraction=force_extraction,
         )
 
         # Estimate cost

--- a/src/inkwell/plugins/__init__.py
+++ b/src/inkwell/plugins/__init__.py
@@ -69,7 +69,14 @@ from .registry import (
 )
 
 # Plugin type base classes
-from .types import ExtractionPlugin, OutputPlugin, TranscriptionPlugin, TranscriptionRequest
+from .types import (
+    ExtractionCapabilities,
+    ExtractionPlugin,
+    OutputPlugin,
+    TranscriptionCapabilities,
+    TranscriptionPlugin,
+    TranscriptionRequest,
+)
 
 __all__ = [
     # Constants
@@ -78,8 +85,10 @@ __all__ = [
     # Base classes
     "InkwellPlugin",
     "BrokenPlugin",
+    "ExtractionCapabilities",
     "ExtractionPlugin",
     "OutputPlugin",
+    "TranscriptionCapabilities",
     "TranscriptionPlugin",
     "TranscriptionRequest",
     # Exceptions

--- a/src/inkwell/plugins/types/__init__.py
+++ b/src/inkwell/plugins/types/__init__.py
@@ -24,13 +24,15 @@ Example:
     ...     DESCRIPTION = "Custom output format"
 """
 
-from .extraction import ExtractionPlugin
+from .extraction import ExtractionCapabilities, ExtractionPlugin
 from .output import OutputPlugin
-from .transcription import TranscriptionPlugin, TranscriptionRequest
+from .transcription import TranscriptionCapabilities, TranscriptionPlugin, TranscriptionRequest
 
 __all__ = [
+    "ExtractionCapabilities",
     "ExtractionPlugin",
     "OutputPlugin",
+    "TranscriptionCapabilities",
     "TranscriptionPlugin",
     "TranscriptionRequest",
 ]

--- a/src/inkwell/plugins/types/extraction.py
+++ b/src/inkwell/plugins/types/extraction.py
@@ -4,6 +4,7 @@ This module defines the base class that all extraction plugins must implement.
 It combines the plugin lifecycle with the BaseExtractor interface.
 """
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from inkwell.extraction.extractors.base import BaseExtractor
@@ -13,6 +14,93 @@ from inkwell.utils.json_utils import JSONParsingError, safe_json_loads
 
 if TYPE_CHECKING:
     from inkwell.utils.costs import CostTracker
+
+
+@dataclass(frozen=True)
+class ExtractionCapabilities:
+    """Typed capability metadata for extraction providers."""
+
+    model_name: str = "unknown"
+    can_extract_text: bool = True
+    supports_structured_output: bool = True
+    supports_json_mode: bool = True
+    requires_internet: bool = True
+    max_input_tokens: int | None = None
+    input_price_per_m: float = 0.0
+    output_price_per_m: float = 0.0
+    estimated_cost_label: str | None = None
+
+    @classmethod
+    def from_legacy(
+        cls,
+        capabilities: dict[str, Any] | None,
+        *,
+        model_name: str = "unknown",
+        input_price_per_m: float = 0.0,
+        output_price_per_m: float = 0.0,
+    ) -> "ExtractionCapabilities":
+        """Build typed metadata from legacy class attributes or dictionaries."""
+        caps = capabilities or {}
+        return cls(
+            model_name=str(caps.get("model_name") or model_name),
+            can_extract_text=bool(caps.get("can_extract_text", True)),
+            supports_structured_output=bool(caps.get("supports_structured_output", True)),
+            supports_json_mode=bool(caps.get("supports_json_mode", True)),
+            requires_internet=bool(caps.get("requires_internet", True)),
+            max_input_tokens=(
+                int(caps["max_input_tokens"]) if caps.get("max_input_tokens") is not None else None
+            ),
+            input_price_per_m=float(caps.get("input_price_per_m", input_price_per_m)),
+            output_price_per_m=float(caps.get("output_price_per_m", output_price_per_m)),
+            estimated_cost_label=(
+                str(caps["estimated_cost_label"])
+                if caps.get("estimated_cost_label") is not None
+                else None
+            ),
+        )
+
+    def to_legacy_dict(self) -> dict[str, Any]:
+        """Return a compatibility dictionary for existing plugin code."""
+        return {
+            "model_name": self.model_name,
+            "can_extract_text": self.can_extract_text,
+            "supports_structured_output": self.supports_structured_output,
+            "supports_json_mode": self.supports_json_mode,
+            "requires_internet": self.requires_internet,
+            "max_input_tokens": self.max_input_tokens,
+            "input_price_per_m": self.input_price_per_m,
+            "output_price_per_m": self.output_price_per_m,
+            "estimated_cost_label": self.estimated_cost_label,
+        }
+
+    def display_parts(self) -> list[str]:
+        """Return concise, safe capability labels for CLI display."""
+        parts: list[str] = []
+        if self.can_extract_text:
+            parts.append("text")
+        if self.supports_structured_output:
+            parts.append("structured")
+        if self.supports_json_mode:
+            parts.append("json")
+        if not self.requires_internet:
+            parts.append("offline")
+        if self.max_input_tokens is not None:
+            parts.append(f"context={self._format_count(self.max_input_tokens)}")
+        if self.model_name != "unknown":
+            parts.append(f"model={self.model_name}")
+        if self.estimated_cost_label:
+            parts.append(self.estimated_cost_label)
+        elif self.input_price_per_m or self.output_price_per_m:
+            parts.append(f"${self.input_price_per_m:g}/${self.output_price_per_m:g} per 1M tokens")
+        return parts
+
+    @staticmethod
+    def _format_count(value: int) -> str:
+        if value >= 1_000_000 and value % 1_000_000 == 0:
+            return f"{value // 1_000_000}M"
+        if value >= 1_000 and value % 1_000 == 0:
+            return f"{value // 1_000}K"
+        return str(value)
 
 
 class ExtractionPlugin(InkwellPlugin, BaseExtractor):
@@ -57,6 +145,9 @@ class ExtractionPlugin(InkwellPlugin, BaseExtractor):
     INPUT_PRICE_PER_M: ClassVar[float] = 0.0
     OUTPUT_PRICE_PER_M: ClassVar[float] = 0.0
 
+    CAPABILITIES: ClassVar[dict[str, Any]] = {}
+    CAPABILITY_INFO: ClassVar[ExtractionCapabilities | None] = None
+
     def __init__(self) -> None:
         """Initialize the extraction plugin.
 
@@ -68,6 +159,22 @@ class ExtractionPlugin(InkwellPlugin, BaseExtractor):
     def model(self) -> str:
         """Get the model identifier for this extractor."""
         return self.MODEL
+
+    @classmethod
+    def capability_info(cls) -> ExtractionCapabilities:
+        """Return typed capability metadata for this provider class."""
+        if cls.CAPABILITY_INFO is not None:
+            return cls.CAPABILITY_INFO
+        return ExtractionCapabilities.from_legacy(
+            cls.CAPABILITIES,
+            model_name=cls.MODEL,
+            input_price_per_m=cls.INPUT_PRICE_PER_M,
+            output_price_per_m=cls.OUTPUT_PRICE_PER_M,
+        )
+
+    def get_capabilities(self) -> ExtractionCapabilities:
+        """Return typed capability metadata for this provider instance."""
+        return self.__class__.capability_info()
 
     # Abstract methods (extract, estimate_cost, supports_structured_output)
     # and helper methods (build_prompt, _count_tokens) are inherited from BaseExtractor

--- a/src/inkwell/plugins/types/transcription.py
+++ b/src/inkwell/plugins/types/transcription.py
@@ -5,6 +5,7 @@ It provides the transcription interface with flexible input handling via Transcr
 """
 
 from abc import abstractmethod
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
@@ -63,6 +64,154 @@ class TranscriptionRequest:
             raise ValueError("Exactly one of url, file_path, or audio_bytes must be provided")
 
 
+@dataclass(frozen=True)
+class TranscriptionCapabilities:
+    """Typed capability metadata for transcription providers.
+
+    `CAPABILITIES` dictionaries remain supported for third-party plugin
+    compatibility. Built-in providers should prefer this typed declaration and
+    derive legacy dictionaries from it.
+    """
+
+    formats: tuple[str, ...] = ()
+    can_transcribe_url: bool = False
+    can_transcribe_file: bool = False
+    can_transcribe_bytes: bool = False
+    supports_timestamps: bool = False
+    supports_diarization: bool = False
+    supports_direct_youtube_url: bool = False
+    requires_internet: bool = True
+    max_duration_seconds: float | None = None
+    max_input_tokens: int | None = None
+    model_name: str | None = None
+    estimated_cost_label: str | None = None
+
+    @classmethod
+    def from_legacy(
+        cls,
+        capabilities: Mapping[str, Any] | None,
+        *,
+        handles_urls: Sequence[str] = (),
+        model_name: str | None = None,
+    ) -> "TranscriptionCapabilities":
+        """Build typed metadata from the legacy `CAPABILITIES` dictionary."""
+        caps = capabilities or {}
+        formats = tuple(str(fmt).lower().lstrip(".") for fmt in caps.get("formats", ()) or ())
+
+        max_duration_seconds = caps.get("max_duration_seconds")
+        if max_duration_seconds is None and caps.get("max_duration_hours") is not None:
+            max_duration_seconds = float(caps["max_duration_hours"]) * 3600
+
+        capability_model = caps.get("model_name") or model_name
+
+        return cls(
+            formats=formats,
+            can_transcribe_url=bool(
+                caps.get("can_transcribe_url", caps.get("supports_url", bool(handles_urls)))
+            ),
+            can_transcribe_file=bool(
+                caps.get("can_transcribe_file", caps.get("supports_file", True))
+            ),
+            can_transcribe_bytes=bool(
+                caps.get("can_transcribe_bytes", caps.get("supports_bytes", False))
+            ),
+            supports_timestamps=bool(caps.get("supports_timestamps", False)),
+            supports_diarization=bool(caps.get("supports_diarization", False)),
+            supports_direct_youtube_url=bool(caps.get("supports_direct_youtube_url", False)),
+            requires_internet=bool(caps.get("requires_internet", True)),
+            max_duration_seconds=(
+                float(max_duration_seconds) if max_duration_seconds is not None else None
+            ),
+            max_input_tokens=(
+                int(caps["max_input_tokens"]) if caps.get("max_input_tokens") is not None else None
+            ),
+            model_name=str(capability_model) if capability_model else None,
+            estimated_cost_label=(
+                str(caps["estimated_cost_label"])
+                if caps.get("estimated_cost_label") is not None
+                else None
+            ),
+        )
+
+    def to_legacy_dict(self) -> dict[str, Any]:
+        """Return a compatibility dictionary for existing plugin code."""
+        max_duration_hours = (
+            self.max_duration_seconds / 3600 if self.max_duration_seconds is not None else None
+        )
+        return {
+            "formats": list(self.formats),
+            "max_duration_hours": max_duration_hours,
+            "max_duration_seconds": self.max_duration_seconds,
+            "requires_internet": self.requires_internet,
+            "supports_file": self.can_transcribe_file,
+            "supports_url": self.can_transcribe_url,
+            "supports_bytes": self.can_transcribe_bytes,
+            "can_transcribe_file": self.can_transcribe_file,
+            "can_transcribe_url": self.can_transcribe_url,
+            "can_transcribe_bytes": self.can_transcribe_bytes,
+            "supports_timestamps": self.supports_timestamps,
+            "supports_diarization": self.supports_diarization,
+            "supports_direct_youtube_url": self.supports_direct_youtube_url,
+            "max_input_tokens": self.max_input_tokens,
+            "model_name": self.model_name,
+            "estimated_cost_label": self.estimated_cost_label,
+        }
+
+    def display_parts(self) -> list[str]:
+        """Return concise, safe capability labels for CLI display."""
+        parts: list[str] = []
+
+        if self.can_transcribe_url:
+            parts.append("url")
+        if self.supports_direct_youtube_url:
+            parts.append("direct-youtube")
+        if self.can_transcribe_file:
+            parts.append("file")
+        if self.can_transcribe_bytes:
+            parts.append("bytes")
+        if self.supports_timestamps:
+            parts.append("timestamps")
+        if self.supports_diarization:
+            parts.append("diarization")
+        if not self.requires_internet:
+            parts.append("offline")
+        if self.formats:
+            parts.append(f"formats={self._format_values(self.formats)}")
+        if self.max_duration_seconds is not None:
+            parts.append(f"max={self._format_duration(self.max_duration_seconds)}")
+        if self.max_input_tokens is not None:
+            parts.append(f"context={self._format_count(self.max_input_tokens)}")
+        if self.model_name:
+            parts.append(f"model={self.model_name}")
+        if self.estimated_cost_label:
+            parts.append(self.estimated_cost_label)
+
+        return parts
+
+    @staticmethod
+    def _format_values(values: Sequence[str]) -> str:
+        displayed = "/".join(values[:4])
+        if len(values) > 4:
+            displayed = f"{displayed}+{len(values) - 4}"
+        return displayed
+
+    @staticmethod
+    def _format_duration(seconds: float) -> str:
+        if seconds >= 3600 and seconds % 3600 == 0:
+            return f"{int(seconds / 3600)}h"
+        if seconds >= 60 and seconds % 60 == 0:
+            return f"{int(seconds / 60)}m"
+        return f"{int(seconds)}s"
+
+    @staticmethod
+    def _format_count(value: int) -> str:
+        if value >= 1_000_000 and value % 1_000_000 == 0:
+            return f"{value // 1_000_000}M"
+        if value >= 1_000 and value % 1_000 == 0:
+            return f"{value // 1_000}K"
+        return str(value)
+
+
 class TranscriptionPlugin(InkwellPlugin):
     """Base class for transcription plugins.
 
@@ -108,6 +257,7 @@ class TranscriptionPlugin(InkwellPlugin):
         "supports_url": False,
         "supports_bytes": False,
     }
+    CAPABILITY_INFO: ClassVar[TranscriptionCapabilities | None] = None
 
     def __init__(self) -> None:
         """Initialize the transcription plugin.
@@ -161,6 +311,21 @@ class TranscriptionPlugin(InkwellPlugin):
             return bool(caps.get("supports_file", True))
         else:  # bytes
             return bool(caps.get("supports_bytes", False))
+
+    @classmethod
+    def capability_info(cls) -> TranscriptionCapabilities:
+        """Return typed capability metadata for this provider class."""
+        if cls.CAPABILITY_INFO is not None:
+            return cls.CAPABILITY_INFO
+        return TranscriptionCapabilities.from_legacy(
+            cls.CAPABILITIES,
+            handles_urls=cls.HANDLES_URLS,
+            model_name=getattr(cls, "MODEL", None),
+        )
+
+    def get_capabilities(self) -> TranscriptionCapabilities:
+        """Return typed capability metadata for this provider instance."""
+        return self.__class__.capability_info()
 
     def estimate_cost(self, duration_seconds: float) -> float:
         """Estimate cost for transcribing audio of given duration.

--- a/src/inkwell/transcription/__init__.py
+++ b/src/inkwell/transcription/__init__.py
@@ -13,6 +13,7 @@ Key components:
 - manager: High-level orchestration
 """
 
+from inkwell.plugins.types.transcription import TranscriptionCapabilities
 from inkwell.transcription.cache import (
     TRANSCRIPT_CACHE_FORMAT_VERSION,
     CacheError,
@@ -48,6 +49,7 @@ __all__ = [
     "TranscriptionAttempt",
     "TranscriptionAttemptKind",
     "TranscriptionAttemptPolicy",
+    "TranscriptionCapabilities",
     "TranscriptSegment",
     "TranscriptionResult",
     "YouTubeTranscriber",

--- a/src/inkwell/transcription/gemini.py
+++ b/src/inkwell/transcription/gemini.py
@@ -12,7 +12,11 @@ from google import genai
 from google.genai import types
 from pydantic import BaseModel, Field
 
-from inkwell.plugins.types.transcription import TranscriptionPlugin, TranscriptionRequest
+from inkwell.plugins.types.transcription import (
+    TranscriptionCapabilities,
+    TranscriptionPlugin,
+    TranscriptionRequest,
+)
 from inkwell.transcription.chunking import (
     CHUNK_DURATION_SECONDS,
     OVERLAP_SECONDS,
@@ -90,14 +94,19 @@ class GeminiTranscriber(TranscriptionPlugin):
 
     # Transcription-specific metadata
     HANDLES_URLS: ClassVar[list[str]] = ["youtube.com", "youtu.be"]
-    CAPABILITIES: ClassVar[dict[str, Any]] = {
-        "formats": ["mp3", "m4a", "wav", "aac", "ogg", "flac"],
-        "max_duration_hours": None,  # Handles long audio via chunking
-        "requires_internet": True,
-        "supports_file": True,
-        "supports_url": True,
-        "supports_bytes": False,
-    }
+    CAPABILITY_INFO: ClassVar[TranscriptionCapabilities] = TranscriptionCapabilities(
+        formats=("mp3", "m4a", "wav", "aac", "ogg", "flac"),
+        can_transcribe_url=True,
+        can_transcribe_file=True,
+        can_transcribe_bytes=False,
+        supports_timestamps=True,
+        supports_diarization=False,
+        supports_direct_youtube_url=True,
+        requires_internet=True,
+        model_name=MODEL,
+        estimated_cost_label="paid",
+    )
+    CAPABILITIES: ClassVar[dict[str, Any]] = CAPABILITY_INFO.to_legacy_dict()
 
     def __init__(
         self,

--- a/src/inkwell/transcription/manager.py
+++ b/src/inkwell/transcription/manager.py
@@ -1,6 +1,7 @@
 """Transcription manager orchestrating multi-tier transcription."""
 
 import asyncio
+import inspect
 import logging
 import os
 import warnings
@@ -17,11 +18,19 @@ from inkwell.config.schema import MediaCacheConfig, TranscriptionConfig
 # Import from specific submodules to avoid potential circular imports
 from inkwell.plugins.discovery import discover_plugins
 from inkwell.plugins.registry import PluginRegistry
-from inkwell.plugins.types.transcription import TranscriptionPlugin, TranscriptionRequest
+from inkwell.plugins.types.transcription import (
+    TranscriptionCapabilities,
+    TranscriptionPlugin,
+    TranscriptionRequest,
+)
 from inkwell.transcription.cache import TranscriptCache
 from inkwell.transcription.gemini import CostEstimate, GeminiTranscriber
 from inkwell.transcription.models import Transcript, TranscriptionResult
-from inkwell.transcription.policy import TranscriptionAttemptKind, TranscriptionAttemptPolicy
+from inkwell.transcription.policy import (
+    TranscriptionAttempt,
+    TranscriptionAttemptKind,
+    TranscriptionAttemptPolicy,
+)
 from inkwell.transcription.youtube import YouTubeTranscriber
 from inkwell.utils.errors import APIError
 
@@ -151,6 +160,56 @@ class TranscriptionManager:
             except ValueError:
                 # No API key available - Gemini tier will be disabled
                 self.gemini_transcriber = None
+
+    def _provider_capabilities(self) -> dict[str, TranscriptionCapabilities]:
+        """Return known provider capabilities for policy planning."""
+        capabilities: dict[str, TranscriptionCapabilities] = {}
+
+        if isinstance(self.youtube_transcriber, TranscriptionPlugin):
+            capabilities["youtube"] = self.youtube_transcriber.get_capabilities()
+        else:
+            capabilities["youtube"] = YouTubeTranscriber.capability_info()
+
+        if isinstance(self.gemini_transcriber, TranscriptionPlugin):
+            capabilities["gemini"] = self.gemini_transcriber.get_capabilities()
+        else:
+            capabilities["gemini"] = GeminiTranscriber.capability_info()
+
+        return capabilities
+
+    def _policy_accepts_provider_capabilities(self) -> bool:
+        """Return True when the injected policy accepts typed provider metadata."""
+        parameters = inspect.signature(self.attempt_policy.plan).parameters
+        if "provider_capabilities" in parameters:
+            return True
+        return any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters.values()
+        )
+
+    def _plan_transcription_attempts(
+        self,
+        *,
+        use_cache: bool,
+        skip_youtube: bool,
+        is_youtube_url: bool,
+        is_local_media: bool,
+    ) -> list[TranscriptionAttempt]:
+        """Call the attempt policy while preserving older override signatures."""
+        if self._policy_accepts_provider_capabilities():
+            return self.attempt_policy.plan(
+                use_cache=use_cache,
+                skip_youtube=skip_youtube,
+                is_youtube_url=is_youtube_url,
+                is_local_media=is_local_media,
+                provider_capabilities=self._provider_capabilities(),
+            )
+
+        return self.attempt_policy.plan(
+            use_cache=use_cache,
+            skip_youtube=skip_youtube,
+            is_youtube_url=is_youtube_url,
+            is_local_media=is_local_media,
+        )
 
     def _load_transcription_plugins(self) -> None:
         """Load transcription plugins from entry points into registry.
@@ -386,7 +445,7 @@ class TranscriptionManager:
             )
 
         is_youtube_url = self._is_youtube_url(episode_url)
-        attempt_plan = self.attempt_policy.plan(
+        attempt_plan = self._plan_transcription_attempts(
             use_cache=use_cache,
             skip_youtube=skip_youtube,
             is_youtube_url=is_youtube_url,

--- a/src/inkwell/transcription/policy.py
+++ b/src/inkwell/transcription/policy.py
@@ -7,8 +7,11 @@ without spreading ordering logic through TranscriptionManager.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import Enum
+
+from inkwell.plugins.types.transcription import TranscriptionCapabilities
 
 
 class TranscriptionAttemptKind(str, Enum):
@@ -33,6 +36,22 @@ class TranscriptionAttempt:
 class TranscriptionAttemptPolicy:
     """Produce ordered transcription attempts for the current provider set."""
 
+    @staticmethod
+    def _provider_can(
+        provider_capabilities: Mapping[str, TranscriptionCapabilities] | None,
+        provider: str,
+        capability: str,
+        *,
+        default: bool,
+    ) -> bool:
+        """Return provider capability with legacy-default fallback."""
+        if provider_capabilities is None:
+            return default
+        provider_info = provider_capabilities.get(provider)
+        if provider_info is None:
+            return default
+        return bool(getattr(provider_info, capability))
+
     def plan(
         self,
         *,
@@ -40,9 +59,17 @@ class TranscriptionAttemptPolicy:
         skip_youtube: bool,
         is_youtube_url: bool,
         is_local_media: bool,
+        provider_capabilities: Mapping[str, TranscriptionCapabilities] | None = None,
     ) -> list[TranscriptionAttempt]:
         """Return ordered attempts for a transcription request."""
         if is_local_media:
+            if not self._provider_can(
+                provider_capabilities,
+                "gemini",
+                "can_transcribe_file",
+                default=True,
+            ):
+                return []
             return [
                 TranscriptionAttempt(
                     kind=TranscriptionAttemptKind.GEMINI_LOCAL_MEDIA,
@@ -61,7 +88,12 @@ class TranscriptionAttemptPolicy:
                 )
             )
 
-        if not skip_youtube:
+        if not skip_youtube and self._provider_can(
+            provider_capabilities,
+            "youtube",
+            "can_transcribe_url",
+            default=True,
+        ):
             attempts.append(
                 TranscriptionAttempt(
                     kind=TranscriptionAttemptKind.YOUTUBE_TRANSCRIPT,
@@ -70,7 +102,12 @@ class TranscriptionAttemptPolicy:
                 )
             )
 
-        if is_youtube_url:
+        if is_youtube_url and self._provider_can(
+            provider_capabilities,
+            "gemini",
+            "supports_direct_youtube_url",
+            default=True,
+        ):
             attempts.append(
                 TranscriptionAttempt(
                     kind=TranscriptionAttemptKind.GEMINI_YOUTUBE_URL,
@@ -79,11 +116,17 @@ class TranscriptionAttemptPolicy:
                 )
             )
 
-        attempts.append(
-            TranscriptionAttempt(
-                kind=TranscriptionAttemptKind.GEMINI_AUDIO,
-                provider="gemini",
-                record_as="gemini",
+        if self._provider_can(
+            provider_capabilities,
+            "gemini",
+            "can_transcribe_file",
+            default=True,
+        ):
+            attempts.append(
+                TranscriptionAttempt(
+                    kind=TranscriptionAttemptKind.GEMINI_AUDIO,
+                    provider="gemini",
+                    record_as="gemini",
+                )
             )
-        )
         return attempts

--- a/src/inkwell/transcription/youtube.py
+++ b/src/inkwell/transcription/youtube.py
@@ -18,7 +18,11 @@ from youtube_transcript_api._errors import (
     VideoUnavailable,
 )
 
-from inkwell.plugins.types.transcription import TranscriptionPlugin, TranscriptionRequest
+from inkwell.plugins.types.transcription import (
+    TranscriptionCapabilities,
+    TranscriptionPlugin,
+    TranscriptionRequest,
+)
 from inkwell.transcription.models import Transcript, TranscriptSegment
 from inkwell.utils.errors import APIError
 
@@ -59,14 +63,18 @@ class YouTubeTranscriber(TranscriptionPlugin):
 
     # Transcription-specific metadata
     HANDLES_URLS: ClassVar[list[str]] = ["youtube.com", "youtu.be", "m.youtube.com"]
-    CAPABILITIES: ClassVar[dict[str, Any]] = {
-        "formats": [],  # YouTube handles its own formats
-        "max_duration_hours": None,
-        "requires_internet": True,
-        "supports_file": False,
-        "supports_url": True,
-        "supports_bytes": False,
-    }
+    CAPABILITY_INFO: ClassVar[TranscriptionCapabilities] = TranscriptionCapabilities(
+        formats=(),
+        can_transcribe_url=True,
+        can_transcribe_file=False,
+        can_transcribe_bytes=False,
+        supports_timestamps=True,
+        supports_diarization=False,
+        supports_direct_youtube_url=False,
+        requires_internet=True,
+        estimated_cost_label="free",
+    )
+    CAPABILITIES: ClassVar[dict[str, Any]] = CAPABILITY_INFO.to_legacy_dict()
 
     def __init__(
         self,

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -418,6 +418,38 @@ class TestCLIFetchMachineOutput:
         assert item["cache_hits"] == {"extractions": 0, "transcript": True}
         assert item["costs"]["total_usd"] == 0.02
 
+    def test_fetch_json_identifies_article_inputs(self, tmp_path: Path, monkeypatch) -> None:
+        """Generic HTTP URLs that extract as articles are labeled distinctly."""
+        monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
+        monkeypatch.setattr(
+            "inkwell.cli.extract_article_text_from_url",
+            lambda _url: "Readable article text for local extraction.",
+        )
+
+        output_dir = tmp_path / "episode-dir"
+        output_dir.mkdir()
+
+        async def fake_process(*_args, **_kwargs):
+            return _sample_pipeline_result(output_dir)
+
+        monkeypatch.setattr("inkwell.pipeline.PipelineOrchestrator.process_episode", fake_process)
+
+        result = runner.invoke(
+            app,
+            [
+                "fetch",
+                "https://example.com/articles/local-extraction",
+                "--json",
+                "--output-dir",
+                str(tmp_path),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["input"]["kind"] == "article"
+        assert payload["input"]["normalized"] == "https://example.com/articles/local-extraction"
+
         assert "Inkwell Extraction Pipeline" not in result.stdout
         assert "Inkwell Extraction Pipeline" in result.stderr
 
@@ -1487,6 +1519,48 @@ class TestCLIFetchSaveFeed:
         assert seen["source_kind"] == "local_text"
         assert seen["episode_title"] == "notes"
 
+    def test_fetch_local_pdf_routes_source_text_to_pipeline(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Text PDFs bypass media transcription and feed extraction templates."""
+        monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
+        monkeypatch.setattr(
+            "inkwell.cli.extract_text_from_pdf",
+            lambda _path: "Selectable PDF text for extraction.",
+        )
+
+        local_pdf = tmp_path / "paper.pdf"
+        local_pdf.write_bytes(b"%PDF")
+        output_dir = tmp_path / "episode-dir"
+        output_dir.mkdir()
+        seen: dict[str, object] = {}
+
+        async def fake_process(_orchestrator, options, *_args, **_kwargs):
+            seen["url"] = options.url
+            seen["source_text"] = options.source_text
+            seen["source_kind"] = options.source_kind
+            seen["episode_title"] = options.episode_title
+            return _sample_pipeline_result(output_dir)
+
+        monkeypatch.setattr("inkwell.pipeline.PipelineOrchestrator.process_episode", fake_process)
+
+        result = runner.invoke(
+            app,
+            [
+                "fetch",
+                str(local_pdf),
+                "--dry-run",
+                "--output-dir",
+                str(tmp_path),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert seen["url"] == str(local_pdf)
+        assert seen["source_text"] == "Selectable PDF text for extraction."
+        assert seen["source_kind"] == "pdf"
+        assert seen["episode_title"] == "paper"
+
     def test_fetch_stdin_routes_source_text_to_pipeline(self, tmp_path: Path, monkeypatch) -> None:
         """Stdin text bypasses transcription and feeds extraction templates."""
         monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
@@ -1516,18 +1590,58 @@ class TestCLIFetchSaveFeed:
         assert seen["source_kind"] == "stdin"
         assert seen["episode_title"] == "stdin"
 
+    def test_fetch_article_url_routes_source_text_to_pipeline(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Generic article URLs are locally extracted into source text."""
+        monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
+        monkeypatch.setattr(
+            "inkwell.cli.extract_article_text_from_url",
+            lambda _url: "Readable article text for extraction.",
+        )
+
+        output_dir = tmp_path / "episode-dir"
+        output_dir.mkdir()
+        seen: dict[str, object] = {}
+
+        async def fake_process(_orchestrator, options, *_args, **_kwargs):
+            seen["url"] = options.url
+            seen["source_text"] = options.source_text
+            seen["source_kind"] = options.source_kind
+            seen["episode_title"] = options.episode_title
+            return _sample_pipeline_result(output_dir)
+
+        monkeypatch.setattr("inkwell.pipeline.PipelineOrchestrator.process_episode", fake_process)
+
+        result = runner.invoke(
+            app,
+            [
+                "fetch",
+                "https://example.com/articles/source-routing",
+                "--dry-run",
+                "--output-dir",
+                str(tmp_path),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert seen["url"] == "https://example.com/articles/source-routing"
+        assert seen["source_text"] == "Readable article text for extraction."
+        assert seen["source_kind"] == "article"
+        assert seen["episode_title"] == "source routing"
+
     def test_fetch_unsupported_local_file_type_errors(self, tmp_path: Path, monkeypatch) -> None:
-        """PDF/article/OCR-style inputs remain out of scope for Phase 6."""
+        """Slides and unsupported local file formats still fail clearly."""
         monkeypatch.setattr("inkwell.utils.paths.get_config_dir", lambda: tmp_path)
 
-        local_pdf = tmp_path / "paper.pdf"
-        local_pdf.write_bytes(b"%PDF")
+        local_slide = tmp_path / "deck.pptx"
+        local_slide.write_bytes(b"fake slide deck")
 
-        result = runner.invoke(app, ["fetch", str(local_pdf), "--dry-run"])
+        result = runner.invoke(app, ["fetch", str(local_slide), "--dry-run"])
 
         assert result.exit_code != 0
         assert "Unsupported local file type" in result.output
-        assert "PDF" in result.output
+        assert "Slides" in result.output or "OCR" in result.output
 
 
 class TestCLIFetchHintSuppression:
@@ -2057,6 +2171,132 @@ class TestCLICache:
         assert "Transcript Cache Statistics" in result.stdout
         assert "Extraction Cache Statistics" in result.stdout
         assert "Media Cache Statistics" in result.stdout
+
+    def test_cache_clear_extractions_only(self, monkeypatch) -> None:
+        """Cache clear can target extraction entries without touching others."""
+        calls = {"transcripts": 0, "extractions": 0, "media": 0}
+
+        class FakeManager:
+            def clear_cache(self) -> int:
+                calls["transcripts"] += 1
+                return 3
+
+        class FakeExtractionCache:
+            async def clear(self) -> int:
+                calls["extractions"] += 1
+                return 2
+
+        class FakeAudioDownloader:
+            @classmethod
+            def clear_cache(cls):
+                calls["media"] += 1
+                return {"files_deleted": 1, "bytes_deleted": 5}
+
+        monkeypatch.setattr("inkwell.cli.TranscriptionManager", lambda: FakeManager())
+        monkeypatch.setattr("inkwell.extraction.cache.ExtractionCache", FakeExtractionCache)
+        monkeypatch.setattr("inkwell.audio.downloader.AudioDownloader", FakeAudioDownloader)
+
+        result = runner.invoke(app, ["cache", "clear", "--extractions", "--force"])
+
+        assert result.exit_code == 0, result.output
+        assert calls == {"transcripts": 0, "extractions": 1, "media": 0}
+        assert "Cleared 2 extraction cache entries" in result.stdout
+
+    def test_cache_clear_all_targets(self, monkeypatch) -> None:
+        """Cache clear can remove transcript, extraction, and media artifacts."""
+        calls = {"transcripts": 0, "extractions": 0, "media": 0}
+
+        class FakeManager:
+            def clear_cache(self) -> int:
+                calls["transcripts"] += 1
+                return 3
+
+        class FakeExtractionCache:
+            async def clear(self) -> int:
+                calls["extractions"] += 1
+                return 2
+
+        class FakeAudioDownloader:
+            @classmethod
+            def clear_cache(cls):
+                calls["media"] += 1
+                return {"files_deleted": 1, "bytes_deleted": 5}
+
+        monkeypatch.setattr("inkwell.cli.TranscriptionManager", lambda: FakeManager())
+        monkeypatch.setattr("inkwell.extraction.cache.ExtractionCache", FakeExtractionCache)
+        monkeypatch.setattr("inkwell.audio.downloader.AudioDownloader", FakeAudioDownloader)
+
+        result = runner.invoke(app, ["cache", "clear", "--all", "--force"])
+
+        assert result.exit_code == 0, result.output
+        assert calls == {"transcripts": 1, "extractions": 1, "media": 1}
+        assert "transcript cache entries" in result.stdout
+        assert "extraction cache entries" in result.stdout
+        assert "media cache files" in result.stdout
+
+    def test_cache_enforce_media_policy(self, monkeypatch) -> None:
+        """Media cache policy can be enforced without downloading new media."""
+        from types import SimpleNamespace
+
+        calls = {"enforced": 0}
+
+        class FakeManager:
+            pass
+
+        class FakeMediaConfig:
+            enabled = True
+            max_mb = 10
+            ttl_days = 7
+
+        class FakeConfig:
+            cache = SimpleNamespace(media=FakeMediaConfig())
+
+        class FakeConfigManager:
+            def load_config(self):
+                return FakeConfig()
+
+        class FakeAudioDownloader:
+            def __init__(self, *, cache_enabled, cache_max_mb, cache_ttl_days):
+                assert cache_enabled is True
+                assert cache_max_mb == 10
+                assert cache_ttl_days == 7
+
+            def enforce_cache_policy(self):
+                calls["enforced"] += 1
+                return {"expired_files": 1, "size_files": 0, "bytes_deleted": 5}
+
+        monkeypatch.setattr("inkwell.cli.TranscriptionManager", lambda: FakeManager())
+        monkeypatch.setattr("inkwell.cli.ConfigManager", FakeConfigManager)
+        monkeypatch.setattr("inkwell.audio.downloader.AudioDownloader", FakeAudioDownloader)
+
+        result = runner.invoke(app, ["cache", "enforce-media-policy", "--force"])
+
+        assert result.exit_code == 0, result.output
+        assert calls == {"enforced": 1}
+        assert "Enforced media cache policy" in result.stdout
+
+    def test_cache_clear_expired_media_points_to_policy_command(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Media clear-expired uses the explicit policy command instead."""
+
+        class FakeManager:
+            pass
+
+        monkeypatch.setattr("inkwell.cli.TranscriptionManager", lambda: FakeManager())
+        monkeypatch.setattr(
+            "inkwell.transcription.cache.user_cache_dir",
+            lambda *_args: str(tmp_path / "transcripts-root"),
+        )
+        monkeypatch.setattr(
+            "inkwell.audio.downloader.platformdirs.user_cache_dir",
+            lambda *_args: str(tmp_path / "media-root"),
+        )
+
+        result = runner.invoke(app, ["cache", "clear-expired", "--media", "--force"])
+
+        assert result.exit_code == 0, result.output
+        assert "enforce-media-policy" in result.stdout
 
     def test_cache_invalid_action(self) -> None:
         """Test cache command with invalid action."""

--- a/tests/integration/test_cli_plugins.py
+++ b/tests/integration/test_cli_plugins.py
@@ -47,6 +47,14 @@ class TestPluginsList:
         # Should only show transcription plugins
         assert "youtube" in result.stdout.lower()
 
+    def test_plugins_list_shows_capabilities(self) -> None:
+        """Test that plugin list includes capability labels."""
+        result = runner.invoke(app, ["plugins", "list", "--type", "transcription"])
+
+        assert result.exit_code == 0
+        assert "direct-youtube" in result.stdout
+        assert "timestamps" in result.stdout
+
     def test_plugins_list_invalid_type(self) -> None:
         """Test error handling for invalid plugin type."""
         result = runner.invoke(app, ["plugins", "list", "--type", "invalid"])

--- a/tests/unit/audio/test_downloader.py
+++ b/tests/unit/audio/test_downloader.py
@@ -157,6 +157,25 @@ class TestAudioDownloader:
         assert stats["cache_format_version"] == AUDIO_CACHE_FORMAT_VERSION
         assert stats["extensions"] == {".m4a": 1, ".webm": 1}
 
+    def test_clear_cache_removes_media_files(self, cache_dir: Path) -> None:
+        """Media cache clear removes files and reports bytes deleted."""
+        (cache_dir / "one.m4a").write_bytes(b"abc")
+        (cache_dir / "two.webm").write_bytes(b"abcd")
+        (cache_dir / "nested").mkdir()
+
+        result = AudioDownloader.clear_cache(cache_dir)
+
+        assert result == {"files_deleted": 2, "bytes_deleted": 7}
+        assert not (cache_dir / "one.m4a").exists()
+        assert not (cache_dir / "two.webm").exists()
+        assert (cache_dir / "nested").exists()
+
+    def test_clear_cache_handles_missing_directory(self, tmp_path: Path) -> None:
+        """Media cache clear is safe when the cache directory does not exist."""
+        result = AudioDownloader.clear_cache(tmp_path / "missing-cache")
+
+        assert result == {"files_deleted": 0, "bytes_deleted": 0}
+
     def test_cache_disabled_does_not_create_cache_directory(
         self, temp_dir: Path, tmp_path: Path
     ) -> None:

--- a/tests/unit/plugins/test_extraction_plugin.py
+++ b/tests/unit/plugins/test_extraction_plugin.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from inkwell.plugins import ExtractionPlugin, PluginRegistry
+from inkwell.plugins import ExtractionCapabilities, ExtractionPlugin, PluginRegistry
 from inkwell.plugins.base import PLUGIN_API_VERSION
 
 
@@ -32,6 +32,42 @@ class TestExtractionPluginBase:
         """Test that ExtractionPlugin has correct API version."""
         assert ExtractionPlugin.API_VERSION == PLUGIN_API_VERSION
 
+    def test_plugin_exposes_typed_capabilities_from_legacy_dict(self) -> None:
+        """Test that legacy extraction metadata produces typed capabilities."""
+
+        class LegacyExtractor(ExtractionPlugin):
+            NAME = "legacy"
+            VERSION = "1.0.0"
+            DESCRIPTION = "Legacy extractor"
+            MODEL = "legacy-model"
+            INPUT_PRICE_PER_M = 1.0
+            OUTPUT_PRICE_PER_M = 2.0
+            CAPABILITIES = {
+                "max_input_tokens": 8000,
+                "supports_json_mode": False,
+                "requires_internet": False,
+            }
+
+            async def extract(self, template, transcript, metadata, **kwargs):
+                pass
+
+            def estimate_cost(self, template, transcript_length) -> float:
+                return 0.0
+
+            def supports_structured_output(self) -> bool:
+                return True
+
+        caps = LegacyExtractor.capability_info()
+
+        assert isinstance(caps, ExtractionCapabilities)
+        assert caps.model_name == "legacy-model"
+        assert caps.input_price_per_m == 1.0
+        assert caps.output_price_per_m == 2.0
+        assert caps.max_input_tokens == 8000
+        assert caps.supports_json_mode is False
+        assert caps.requires_internet is False
+        assert "offline" in caps.display_parts()
+
 
 class TestClaudePluginIntegration:
     """Tests for ClaudeExtractor as a plugin."""
@@ -59,6 +95,12 @@ class TestClaudePluginIntegration:
         assert ClaudeExtractor.INPUT_PRICE_PER_M > 0
         assert ClaudeExtractor.OUTPUT_PRICE_PER_M > 0
 
+        caps = ClaudeExtractor.capability_info()
+        assert caps.model_name == ClaudeExtractor.MODEL
+        assert caps.supports_structured_output is True
+        assert caps.supports_json_mode is True
+        assert caps.max_input_tokens == 200_000
+
 
 class TestGeminiPluginIntegration:
     """Tests for GeminiExtractor as a plugin."""
@@ -85,6 +127,11 @@ class TestGeminiPluginIntegration:
         assert GeminiExtractor.MODEL is not None
         assert GeminiExtractor.INPUT_PRICE_PER_M > 0
         assert GeminiExtractor.OUTPUT_PRICE_PER_M > 0
+
+        caps = GeminiExtractor.capability_info()
+        assert caps.model_name == GeminiExtractor.MODEL
+        assert caps.supports_structured_output is True
+        assert caps.max_input_tokens == 1_000_000
 
 
 class TestExtractionPluginRegistry:

--- a/tests/unit/plugins/test_transcription_plugin.py
+++ b/tests/unit/plugins/test_transcription_plugin.py
@@ -4,7 +4,12 @@ from pathlib import Path
 
 import pytest
 
-from inkwell.plugins import PluginRegistry, TranscriptionPlugin, TranscriptionRequest
+from inkwell.plugins import (
+    PluginRegistry,
+    TranscriptionCapabilities,
+    TranscriptionPlugin,
+    TranscriptionRequest,
+)
 from inkwell.plugins.base import PLUGIN_API_VERSION
 
 
@@ -84,6 +89,37 @@ class TestTranscriptionPluginBase:
         assert "supports_url" in TranscriptionPlugin.CAPABILITIES
         assert "requires_internet" in TranscriptionPlugin.CAPABILITIES
 
+    def test_plugin_exposes_typed_capabilities_from_legacy_dict(self) -> None:
+        """Test that legacy CAPABILITIES dictionaries produce typed metadata."""
+
+        class LegacyPlugin(TranscriptionPlugin):
+            NAME = "legacy"
+            VERSION = "1.0.0"
+            DESCRIPTION = "Legacy plugin"
+            CAPABILITIES = {
+                "formats": ["MP3", ".WAV"],
+                "max_duration_hours": 2,
+                "requires_internet": False,
+                "supports_file": True,
+                "supports_url": False,
+                "supports_bytes": True,
+            }
+
+            async def transcribe(self, request: TranscriptionRequest):
+                pass
+
+        caps = LegacyPlugin.capability_info()
+
+        assert isinstance(caps, TranscriptionCapabilities)
+        assert caps.formats == ("mp3", "wav")
+        assert caps.can_transcribe_file is True
+        assert caps.can_transcribe_url is False
+        assert caps.can_transcribe_bytes is True
+        assert caps.requires_internet is False
+        assert caps.max_duration_seconds == 7200
+        assert "offline" in caps.display_parts()
+        assert LegacyPlugin().get_capabilities() == caps
+
     def test_default_estimate_cost_is_zero(self) -> None:
         """Test that default estimate_cost returns 0 (free)."""
 
@@ -132,6 +168,12 @@ class TestYouTubePluginIntegration:
         assert caps["supports_url"] is True
         assert caps["supports_file"] is False
         assert caps["requires_internet"] is True
+
+        typed_caps = YouTubeTranscriber.capability_info()
+        assert typed_caps.can_transcribe_url is True
+        assert typed_caps.can_transcribe_file is False
+        assert typed_caps.supports_timestamps is True
+        assert typed_caps.estimated_cost_label == "free"
 
     def test_youtube_can_handle_youtube_url(self) -> None:
         """Test can_handle for YouTube URLs."""
@@ -190,6 +232,12 @@ class TestGeminiPluginIntegration:
         assert caps["requires_internet"] is True
         assert "mp3" in caps["formats"]
         assert "wav" in caps["formats"]
+
+        typed_caps = GeminiTranscriber.capability_info()
+        assert typed_caps.can_transcribe_file is True
+        assert typed_caps.supports_direct_youtube_url is True
+        assert typed_caps.model_name == GeminiTranscriber.MODEL
+        assert typed_caps.estimated_cost_label == "paid"
 
     def test_gemini_can_handle_file_request(self, tmp_path: Path) -> None:
         """Test can_handle for file requests."""

--- a/tests/unit/test_batch_extraction.py
+++ b/tests/unit/test_batch_extraction.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from inkwell.config.schema import ExtractionConfig
 from inkwell.extraction.cache import ExtractionCache
 from inkwell.extraction.engine import ExtractionEngine
 from inkwell.extraction.models import ExtractionTemplate
@@ -94,6 +95,7 @@ class TestBatchedExtraction:
         """Test successful batched extraction of multiple templates."""
         # Pass API key directly so engine knows gemini is available
         engine = ExtractionEngine(
+            config=ExtractionConfig(short_content_bypass_enabled=False),
             cache=temp_cache,
             gemini_api_key="AIzaSyD" + "X" * 32,
         )
@@ -214,7 +216,10 @@ class TestBatchedExtraction:
             patch("inkwell.extraction.extractors.claude.ClaudeExtractor"),
             patch("inkwell.extraction.extractors.gemini.GeminiExtractor"),
         ):
-            engine = ExtractionEngine(cache=temp_cache)
+            engine = ExtractionEngine(
+                config=ExtractionConfig(short_content_bypass_enabled=False),
+                cache=temp_cache,
+            )
 
             transcript = "Test transcript"
             metadata = {"episode_url": "https://example.com/ep1"}

--- a/tests/unit/test_extraction_engine.py
+++ b/tests/unit/test_extraction_engine.py
@@ -9,7 +9,7 @@ import pytest
 from inkwell.config.schema import ExtractionConfig
 from inkwell.extraction.cache import ExtractionCache
 from inkwell.extraction.engine import ExtractionEngine
-from inkwell.extraction.models import ExtractionTemplate
+from inkwell.extraction.models import ExtractionResult, ExtractionTemplate
 
 
 @pytest.fixture
@@ -278,6 +278,125 @@ class TestExtractionEngineConfigInjection:
             assert engine1.default_provider == "claude"
             assert engine2.default_provider == "gemini"
             assert engine3.default_provider == "claude"
+
+
+class TestShortContentBypass:
+    """Tests for default-on short-content summary bypass."""
+
+    @pytest.mark.asyncio
+    async def test_summary_bypasses_short_source_by_default(
+        self, text_template: ExtractionTemplate, temp_cache: ExtractionCache
+    ) -> None:
+        """Short source-backed summary extraction passes through without LLM calls."""
+        engine = ExtractionEngine(cache=temp_cache)
+
+        result = await engine.extract(
+            template=text_template,
+            transcript="A short note.",
+            metadata={"episode_url": "https://example.com/short"},
+        )
+
+        assert result.success is True
+        assert result.provider == "bypass"
+        assert result.bypassed is True
+        assert result.bypass_reason is not None
+        assert result.cost_usd == 0.0
+        assert result.extracted_content is not None
+        assert result.extracted_content.content == "A short note."
+        assert result.extracted_content.metadata["bypassed"] is True
+
+    @pytest.mark.asyncio
+    async def test_force_extraction_runs_summary_llm(
+        self, mock_api_keys: None, text_template: ExtractionTemplate, temp_cache: ExtractionCache
+    ) -> None:
+        """force_extraction disables the short-content bypass."""
+        engine = ExtractionEngine(
+            cache=temp_cache,
+            force_extraction=True,
+            gemini_api_key="AIzaSyD" + "X" * 32,
+        )
+        mock_extractor = Mock()
+        mock_extractor.extract = AsyncMock(return_value="Model summary")
+        mock_extractor.estimate_cost = Mock(return_value=0.01)
+        mock_extractor.model = "test-model"
+        mock_extractor.__class__.__name__ = "GeminiExtractor"
+
+        with patch.object(engine, "_select_extractor", return_value=mock_extractor):
+            result = await engine.extract(
+                template=text_template,
+                transcript="A short note.",
+                metadata={"episode_url": "https://example.com/short"},
+            )
+
+        assert result.provider == "gemini"
+        assert result.model == "test-model"
+        assert result.bypassed is False
+        assert result.extracted_content is not None
+        assert result.extracted_content.content == "Model summary"
+        mock_extractor.extract.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_non_summary_templates_do_not_bypass(
+        self, mock_api_keys: None, json_template: ExtractionTemplate, temp_cache: ExtractionCache
+    ) -> None:
+        """Structured templates still run even when the source is short."""
+        engine = ExtractionEngine(
+            cache=temp_cache,
+            gemini_api_key="AIzaSyD" + "X" * 32,
+        )
+        mock_extractor = Mock()
+        mock_extractor.extract = AsyncMock(return_value='{"quotes": ["short"]}')
+        mock_extractor.estimate_cost = Mock(return_value=0.02)
+        mock_extractor.model = "test-model"
+        mock_extractor.__class__.__name__ = "GeminiExtractor"
+
+        with patch.object(engine, "_select_extractor", return_value=mock_extractor):
+            result = await engine.extract(
+                template=json_template,
+                transcript="A short note.",
+                metadata={"episode_url": "https://example.com/short"},
+            )
+
+        assert result.provider == "gemini"
+        assert result.bypassed is False
+        mock_extractor.extract.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_batched_path_bypasses_only_summary_template(
+        self,
+        text_template: ExtractionTemplate,
+        json_template: ExtractionTemplate,
+        temp_cache: ExtractionCache,
+    ) -> None:
+        """Mixed batches bypass summary while preserving structured extraction."""
+        engine = ExtractionEngine(cache=temp_cache)
+        structured_result = ExtractionResult(
+            episode_url="https://example.com/short",
+            template_name=json_template.name,
+            template_version=json_template.version,
+            success=True,
+            extracted_content=None,
+            cost_usd=0.02,
+            provider="gemini",
+            model="test-model",
+        )
+        extract_individually = AsyncMock(return_value={json_template.name: structured_result})
+
+        with patch.object(engine, "_extract_individually", extract_individually):
+            results, summary = await engine.extract_all_batched(
+                templates=[text_template, json_template],
+                transcript="A short note.",
+                metadata={"episode_url": "https://example.com/short"},
+                use_cache=False,
+            )
+
+        assert [result.template_name for result in results] == ["summary", "quotes"]
+        assert results[0].provider == "bypass"
+        assert results[0].bypassed is True
+        assert results[1].provider == "gemini"
+        assert summary.successful == 2
+        assert summary.cached == 0
+        extract_individually.assert_awaited_once()
 
 
 class TestExtractionEngineExtract:

--- a/tests/unit/test_extraction_routing.py
+++ b/tests/unit/test_extraction_routing.py
@@ -1,0 +1,106 @@
+"""Tests for token-aware extraction routing policy."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from inkwell.config.schema import ExtractionConfig
+from inkwell.extraction.cache import ExtractionCache
+from inkwell.extraction.engine import ExtractionEngine
+from inkwell.extraction.models import ExtractionTemplate
+from inkwell.extraction.routing import ExtractionRoutingPolicy
+from inkwell.plugins.types import ExtractionCapabilities
+
+
+@pytest.fixture
+def summary_template() -> ExtractionTemplate:
+    return ExtractionTemplate(
+        name="summary",
+        version="1.0",
+        description="Summary",
+        system_prompt="Summarize the source.",
+        user_prompt_template="Title: {{ metadata.title }}\n\n{{ transcript }}",
+        expected_format="text",
+        max_tokens=100,
+    )
+
+
+def test_routing_policy_uses_override_as_hard_candidate(
+    summary_template: ExtractionTemplate,
+) -> None:
+    policy = ExtractionRoutingPolicy()
+
+    attempts = policy.plan(
+        template=summary_template,
+        transcript="short transcript",
+        metadata={"title": "Example"},
+        available_capabilities={
+            "claude": ExtractionCapabilities(
+                model_name="claude-test",
+                max_input_tokens=1000,
+            ),
+            "gemini": ExtractionCapabilities(
+                model_name="gemini-test",
+                max_input_tokens=1000,
+            ),
+        },
+        default_provider="gemini",
+        override="claude",
+    )
+
+    assert [attempt.provider for attempt in attempts] == ["claude"]
+    assert attempts[0].model == "claude-test"
+    assert attempts[0].reason == "override"
+
+
+def test_routing_policy_skips_models_that_cannot_fit_prompt(
+    summary_template: ExtractionTemplate,
+) -> None:
+    policy = ExtractionRoutingPolicy()
+    transcript = "word " * 200
+
+    attempts = policy.plan(
+        template=summary_template,
+        transcript=transcript,
+        metadata={"title": "Example"},
+        available_capabilities={
+            "gemini": ExtractionCapabilities(
+                model_name="gemini-small",
+                max_input_tokens=10,
+            ),
+            "claude": ExtractionCapabilities(
+                model_name="claude-roomy",
+                max_input_tokens=1000,
+            ),
+        },
+        default_provider="gemini",
+    )
+
+    assert [attempt.provider for attempt in attempts] == ["claude"]
+    assert attempts[0].estimated_prompt_tokens > 10
+
+
+@pytest.mark.asyncio
+async def test_engine_fails_before_api_spend_when_no_attempt_fits(
+    summary_template: ExtractionTemplate,
+    tmp_path,
+) -> None:
+    policy = Mock(spec=ExtractionRoutingPolicy)
+    policy.plan.return_value = []
+    policy.estimate_prompt_tokens.return_value = 999999
+    engine = ExtractionEngine(
+        config=ExtractionConfig(short_content_bypass_enabled=False),
+        cache=ExtractionCache(cache_dir=tmp_path / "cache"),
+        use_plugin_registry=False,
+        routing_policy=policy,
+    )
+
+    result = await engine.extract(
+        template=summary_template,
+        transcript="source",
+        metadata={"episode_url": "https://example.com/source"},
+    )
+
+    assert result.success is False
+    assert "No configured extraction provider" in (result.error or "")
+    policy.plan.assert_called_once()

--- a/tests/unit/test_extraction_summary.py
+++ b/tests/unit/test_extraction_summary.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from inkwell.config.schema import ExtractionConfig
 from inkwell.extraction.engine import ExtractionEngine
 from inkwell.extraction.models import (
     ExtractionAttempt,
@@ -474,6 +475,7 @@ class TestExtractionEngineWithSummary:
         # Use temp cache to avoid cross-test contamination
         temp_cache = ExtractionCache(cache_dir=tmp_path / "cache")
         engine = ExtractionEngine(
+            config=ExtractionConfig(short_content_bypass_enabled=False),
             cache=temp_cache,
             gemini_api_key="AIzaSyD" + "X" * 32,
             claude_api_key="sk-ant-api03-" + "X" * 32,

--- a/tests/unit/test_source_extractors.py
+++ b/tests/unit/test_source_extractors.py
@@ -1,0 +1,90 @@
+"""Tests for local article and PDF source extraction."""
+
+from pathlib import Path
+
+import pytest
+
+from inkwell.ingestion.source_extractors import (
+    extract_article_text_from_html,
+    extract_text_from_pdf,
+)
+from inkwell.utils.errors import ValidationError
+
+
+def test_extract_article_text_from_html_returns_clean_readable_text() -> None:
+    html = """
+    <html>
+      <head><title>Readable Article</title></head>
+      <body>
+        <nav>Navigation links should not matter</nav>
+        <article>
+          <h1>Readable Article</h1>
+          <p>This article explains a useful workflow with enough detail for extraction.</p>
+          <p>It includes a second paragraph so local cleanup has meaningful article text.</p>
+        </article>
+      </body>
+    </html>
+    """
+
+    text = extract_article_text_from_html(html, url="https://example.com/article")
+
+    assert "Readable Article" in text
+    assert "useful workflow" in text
+    assert "second paragraph" in text
+
+
+def test_extract_article_text_from_html_errors_for_thin_pages() -> None:
+    html = "<html><body><main>Subscribe</main></body></html>"
+
+    with pytest.raises(ValidationError, match="readable article text"):
+        extract_article_text_from_html(html, url="https://example.com/blocked")
+
+
+def test_extract_text_from_pdf_combines_selectable_pages(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakePage:
+        def __init__(self, text: str) -> None:
+            self.text = text
+
+        def extract_text(self) -> str:
+            return self.text
+
+    class FakeReader:
+        is_encrypted = False
+        pages = [
+            FakePage(" Page one text. \n\n"),
+            FakePage("Page two text."),
+        ]
+
+    monkeypatch.setattr("inkwell.ingestion.source_extractors.PdfReader", lambda _path: FakeReader())
+
+    text = extract_text_from_pdf(Path("paper.pdf"))
+
+    assert text == "Page one text.\n\nPage two text."
+
+
+def test_extract_text_from_pdf_errors_for_empty_or_scanned_pdf(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakePage:
+        def extract_text(self) -> str:
+            return ""
+
+    class FakeReader:
+        is_encrypted = False
+        pages = [FakePage()]
+
+    monkeypatch.setattr("inkwell.ingestion.source_extractors.PdfReader", lambda _path: FakeReader())
+
+    with pytest.raises(ValidationError, match="No selectable text"):
+        extract_text_from_pdf(Path("scanned.pdf"))
+
+
+def test_extract_text_from_pdf_errors_for_encrypted_pdf(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeReader:
+        is_encrypted = True
+        pages: list[object] = []
+
+    monkeypatch.setattr("inkwell.ingestion.source_extractors.PdfReader", lambda _path: FakeReader())
+
+    with pytest.raises(ValidationError, match="Encrypted PDFs"):
+        extract_text_from_pdf(Path("locked.pdf"))

--- a/tests/unit/transcription/test_manager.py
+++ b/tests/unit/transcription/test_manager.py
@@ -494,6 +494,48 @@ class TestTranscriptionManager:
         mock_gemini.transcribe.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_transcribe_passes_provider_capabilities_to_policy(
+        self,
+        mock_cache: Mock,
+        mock_youtube: Mock,
+        mock_downloader: Mock,
+        mock_gemini: Mock,
+    ) -> None:
+        """The default manager supplies typed provider metadata to capable policies."""
+
+        class CapturingPolicy(TranscriptionAttemptPolicy):
+            provider_capabilities = None
+
+            def plan(
+                self,
+                *,
+                use_cache: bool,
+                skip_youtube: bool,
+                is_youtube_url: bool,
+                is_local_media: bool,
+                provider_capabilities=None,
+            ) -> list[TranscriptionAttempt]:
+                del use_cache, skip_youtube, is_youtube_url, is_local_media
+                self.provider_capabilities = provider_capabilities
+                return []
+
+        policy = CapturingPolicy()
+        manager = TranscriptionManager(
+            cache=mock_cache,
+            youtube_transcriber=mock_youtube,
+            audio_downloader=mock_downloader,
+            gemini_transcriber=mock_gemini,
+            attempt_policy=policy,
+        )
+
+        result = await manager.transcribe("https://youtube.com/watch?v=test")
+
+        assert result.success is False
+        assert policy.provider_capabilities is not None
+        assert policy.provider_capabilities["youtube"].can_transcribe_url is True
+        assert policy.provider_capabilities["gemini"].can_transcribe_file is True
+
+    @pytest.mark.asyncio
     async def test_transcribe_local_media_uses_gemini_without_download(
         self,
         tmp_path: Path,

--- a/tests/unit/transcription/test_policy.py
+++ b/tests/unit/transcription/test_policy.py
@@ -1,5 +1,6 @@
 """Tests for transcription attempt policy."""
 
+from inkwell.plugins.types.transcription import TranscriptionCapabilities
 from inkwell.transcription.policy import TranscriptionAttemptKind, TranscriptionAttemptPolicy
 
 
@@ -76,3 +77,53 @@ def test_policy_local_media_goes_directly_to_gemini() -> None:
 
     assert _kinds(attempts) == [TranscriptionAttemptKind.GEMINI_LOCAL_MEDIA]
     assert attempts[0].provider == "gemini"
+
+
+def test_policy_omits_direct_youtube_attempt_when_provider_lacks_capability() -> None:
+    policy = TranscriptionAttemptPolicy()
+
+    attempts = policy.plan(
+        use_cache=True,
+        skip_youtube=False,
+        is_youtube_url=True,
+        is_local_media=False,
+        provider_capabilities={
+            "gemini": TranscriptionCapabilities(
+                can_transcribe_file=True,
+                supports_direct_youtube_url=False,
+            )
+        },
+    )
+
+    assert TranscriptionAttemptKind.GEMINI_YOUTUBE_URL not in _kinds(attempts)
+    assert TranscriptionAttemptKind.GEMINI_AUDIO in _kinds(attempts)
+
+
+def test_policy_omits_gemini_file_attempts_when_provider_lacks_file_capability() -> None:
+    policy = TranscriptionAttemptPolicy()
+
+    attempts = policy.plan(
+        use_cache=True,
+        skip_youtube=False,
+        is_youtube_url=True,
+        is_local_media=False,
+        provider_capabilities={
+            "gemini": TranscriptionCapabilities(
+                can_transcribe_file=False,
+                supports_direct_youtube_url=True,
+            )
+        },
+    )
+
+    assert TranscriptionAttemptKind.GEMINI_YOUTUBE_URL in _kinds(attempts)
+    assert TranscriptionAttemptKind.GEMINI_AUDIO not in _kinds(attempts)
+
+    local_attempts = policy.plan(
+        use_cache=True,
+        skip_youtube=False,
+        is_youtube_url=False,
+        is_local_media=True,
+        provider_capabilities={"gemini": TranscriptionCapabilities(can_transcribe_file=False)},
+    )
+
+    assert local_attempts == []

--- a/uv.lock
+++ b/uv.lock
@@ -563,6 +563,20 @@ wheels = [
 ]
 
 [[package]]
+name = "courlan"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "tld" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/16/2a771612ee0b3acaa95ac21cc7e8a3319e815d6360f8ffc5987d1ce28499/courlan-1.4.0.tar.gz", hash = "sha256:fbbac7b7fcde2195ea08e707609503c81cf39c891e8d26cdb1fed4585782d63d", size = 208997, upload-time = "2026-06-01T17:30:17.306Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/38/ce65091ff20a16e06d17418c4353af5f56d3190821b1a06983c79ae79274/courlan-1.4.0-py3-none-any.whl", hash = "sha256:ad1dbdefd912ca7238d4607dc855df5df097f56bac175dd662c84eed3802f49e", size = 34193, upload-time = "2026-06-01T17:30:14.984Z" },
+]
+
+[[package]]
 name = "coverage"
 version = "7.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -721,6 +735,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/94/64/2923570ac1c0bd3a737aa366ac3abbbbde273042308b8cde95e2364a6e6a/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:b47db11c2c3525083296069b98ac5221907455e989ae0c2e3008bde851921615", size = 4675885, upload-time = "2026-06-12T20:01:55.49Z" },
     { url = "https://files.pythonhosted.org/packages/ab/f8/614dc7e051418cfe53d55173c1e24c6b0085e89996fe90508c2fdf769aef/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:084ef1af862eb07ec46d25f68689f2102a9fc0e05ce7b80f14f5fe51e4eef0f6", size = 4715449, upload-time = "2026-06-12T20:02:05.469Z" },
     { url = "https://files.pythonhosted.org/packages/aa/50/a9caea39ad19c431c1a3f8a31114df65b260cdfe67786b6c7e7c040c4c44/cryptography-49.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be9fcb48a55f023493482827d4f459bd263cc20efde64f204b97c123201850c6", size = 3783731, upload-time = "2026-06-12T20:02:43.319Z" },
+]
+
+[[package]]
+name = "dateparser"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "regex" },
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/f4/561c49bca97af561d34eed27e3e831135eb5cb88e754c1150be41820f5c6/dateparser-1.4.1.tar.gz", hash = "sha256:f265df13c0380e2e07543ba74b67c0681aaa1096981ffcd35227e1aa0cb81c7c", size = 314734, upload-time = "2026-06-15T08:45:47.659Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/7c/2e5dcf53909deddd0bf38cbe277ad9806be038276b1c6c436561b4d9b2e2/dateparser-1.4.1-py3-none-any.whl", hash = "sha256:f25d4e051a84be27a35bd297e3e1dc59ff78373701b89be352ba80372d22d0d0", size = 300503, upload-time = "2026-06-15T08:45:45.951Z" },
 ]
 
 [[package]]
@@ -1025,6 +1054,22 @@ wheels = [
 ]
 
 [[package]]
+name = "htmldate"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "charset-normalizer" },
+    { name = "dateparser" },
+    { name = "lxml" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/1f/e7cf83e23d7b68105de8b874a8b36ba23b450d6f71388583e4ca3ce475ca/htmldate-1.10.0.tar.gz", hash = "sha256:a38df10772ab5d7dbb11896e3f6a852a8491fb1b0965465bc174e23fc2baae58", size = 44455, upload-time = "2026-06-01T17:43:53.437Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/17/d3356233c826c641f940983d9479eab27faec59d49f4070bc58e80fcc021/htmldate-1.10.0-py3-none-any.whl", hash = "sha256:9211dae35ab94147c8ed9e5fc2c9287a5cf31d2394cb7857e7f5dd814eb2aad6", size = 31561, upload-time = "2026-06-01T17:43:51.797Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1102,10 +1147,12 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pypdf" },
     { name = "pyyaml" },
     { name = "regex" },
     { name = "rich" },
     { name = "tenacity" },
+    { name = "trafilatura" },
     { name = "typer" },
     { name = "youtube-transcript-api" },
     { name = "yt-dlp" },
@@ -1164,6 +1211,7 @@ requires-dist = [
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.6.0" },
     { name = "pydantic", specifier = ">=2.10.0" },
     { name = "pydantic-settings", specifier = ">=2.10.0" },
+    { name = "pypdf", specifier = ">=6.14.2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
@@ -1174,6 +1222,7 @@ requires-dist = [
     { name = "rich", specifier = ">=14.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3.0" },
     { name = "tenacity", specifier = ">=9.0.0" },
+    { name = "trafilatura", specifier = ">=2.1.0" },
     { name = "typer", specifier = ">=0.15.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'" },
     { name = "youtube-transcript-api", specifier = ">=1.0.0" },
@@ -1311,6 +1360,18 @@ wheels = [
 ]
 
 [[package]]
+name = "justext"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml", extra = ["html-clean"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/f3/45890c1b314f0d04e19c1c83d534e611513150939a7cf039664d9ab1e649/justext-3.0.2.tar.gz", hash = "sha256:13496a450c44c4cd5b5a75a5efcd9996066d2a189794ea99a49949685a0beb05", size = 828521, upload-time = "2025-02-25T20:21:49.934Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/ac/52f4e86d1924a7fc05af3aeb34488570eccc39b4af90530dd6acecdf16b5/justext-3.0.2-py2.py3-none-any.whl", hash = "sha256:62b1c562b15c3c6265e121cc070874243a443bfd53060e869393f09d6b6cc9a7", size = 837940, upload-time = "2025-02-25T20:21:44.179Z" },
+]
+
+[[package]]
 name = "librt"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1393,6 +1454,141 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/15/1f/dc6771a52592a4451be6effa200cbfc9cec61e4393d3033d81a9d307961d/librt-0.11.0-cp314-cp314t-win32.whl", hash = "sha256:2b481d846ac894c4e8403c5fd0e87c5d11d6499e404b474602508a224ff531c8", size = 103562, upload-time = "2026-05-10T18:17:03.99Z" },
     { url = "https://files.pythonhosted.org/packages/62/4a/7d1415567027286a75ba1093ec4aca11f073e0f559c530cf3e0a757ad55c/librt-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:28edb433edde181112a908c78907af28f964eabc15f4dd16c9d66c834302677c", size = 124327, upload-time = "2026-05-10T18:17:05.465Z" },
     { url = "https://files.pythonhosted.org/packages/ce/62/b40b382fa0c66fee1478073eb8db352a4a6beda4a1adccf1df911d8c289c/librt-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dee008f20b542e3cd162ba338a7f9ec0f6d23d395f66fe8aeeec3c9d067ea253", size = 102572, upload-time = "2026-05-10T18:17:06.809Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/da/dbe4dfc01ac226fb0504fad035f4d69f3202f3502e20e68537631daddd96/lxml-6.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:09dd5b7075dc2f7709654a46543ba1ea3c2e217b2ed8fbd413a8a945a0f40f60", size = 8541124, upload-time = "2026-05-18T19:17:11.589Z" },
+    { url = "https://files.pythonhosted.org/packages/78/20/f7095ed9fc2c025f9cfe71cc6ec9f1feb05624edc1812423b5f1aecf3d4b/lxml-6.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f6ac4ef4d82dff54670227a69c67782ae0b811b5cf6b17954f1e8f7502fc0d1d", size = 4602783, upload-time = "2026-05-18T19:17:20.888Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/a4/65c63ca98bd129f6cff7b8c2fa48953ab058cc6005b541354e7dd54d8000/lxml-6.1.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:556e94a63c9b04716f8e4de2abb65775061f846e89331b6c5be79183a24f98ea", size = 5002687, upload-time = "2026-05-18T19:17:01.738Z" },
+    { url = "https://files.pythonhosted.org/packages/96/1d/ab7a5c4b5a394d98a94e2d0fc67bab8297597426770dd4978370fbdaf531/lxml-6.1.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5c6bf403fbb3b3e348a561a5f4f0b9961835657981c802a1df03653eef8a9074", size = 5155099, upload-time = "2026-05-18T19:17:05.159Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b1/07603bfeeb891a2596d5c2a68f7d2f70f7d11c841ebe391412c69c2857b0/lxml-6.1.1-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1dde6131244bba38a17c745836ba190bc753fd73c9291666287fd0a3fa3dcf30", size = 5057225, upload-time = "2026-05-18T19:17:08.117Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/16/cb391ee4b90186fa16d9ebcbe3ea96c71b8da3b0686386c8dcbcc3c67d44/lxml-6.1.1-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98fc784c2c1440667aeedf8465bdfe10208acf0ead656a2c68627299f546b315", size = 5287643, upload-time = "2026-05-18T19:17:11.507Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d6/b619717f918fd76747448fdbaee0e769edbc70e659b5b5d0112b7020b7a3/lxml-6.1.1-cp310-cp310-manylinux_2_28_i686.whl", hash = "sha256:add8cf6ddf9a65116119a28ece0f7886e30af27ba724a7594305f1d1b58a92a1", size = 5412445, upload-time = "2026-05-18T19:17:22.182Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/80/12bc5390ac0a3edeb579d9535e5049a5dda663438728e179d52fb319c33a/lxml-6.1.1-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:cf9d57306d848218f3601fee7601fab1a327c942d56e2e97610583cb4dd74206", size = 4770864, upload-time = "2026-05-18T19:17:26.851Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/59/6500c09da3137f54f020e908d81cfc5ee3e8888e908fd380207afad7c2e6/lxml-6.1.1-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:88136950da4d13c318bde414ce10219931937851327f44328f2df4d2c4614067", size = 5359594, upload-time = "2026-05-18T19:17:32.527Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9b/f64b4cc6b7ebcf75d95af3cde934d254b5f2f10d4163928d838d86b6eb48/lxml-6.1.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cecdd5dfdc87b1fd87dbf81d4b037a544f47f4c744200a67013771682d67686a", size = 5107713, upload-time = "2026-05-18T19:17:04.402Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/c7388ad5d3a72315d2832dc1458cbf4f2af7f2b990b606ff4876efd04511/lxml-6.1.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:cd312b9692e831d2ffcad61eab31d91d4b4655a962e61de8fb410472cbcd37aa", size = 4803973, upload-time = "2026-05-18T19:17:06.545Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/22/76197f0bbf165f0b9e75be59be4997e5259cde973f12f098c1b54c7f5d60/lxml-6.1.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:5b7328b46d49fc9477d91ae8f6d55340347d827b7734ba3ea33faae0efef1383", size = 5349925, upload-time = "2026-05-18T19:17:09.743Z" },
+    { url = "https://files.pythonhosted.org/packages/24/52/d2a0cfeccb9bcdc47c7ee05cdae5d69b48c9acf20997790a6338bb0d0b3b/lxml-6.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:37a58976370f36d9329d118ad0b953c5aeb9119ac9c6a4e258942a225d0573a1", size = 5309825, upload-time = "2026-05-18T19:17:13.831Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4a/b30944266776c2f49749ef2445aa7e78898194134b80ad776386f61b56ae/lxml-6.1.1-cp310-cp310-win32.whl", hash = "sha256:cea3f4c1af79af13cdb2da0c028111d8f8522d4f22a000c82385535f24e5cf3a", size = 3598402, upload-time = "2026-05-18T19:17:08.21Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/97/33691c66a4d7ec1a5a98e7c909a5b83ee45c7f7ba4cf92b1c4cf26e98079/lxml-6.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:3abf332af33a74288675d936fe861fd4344da0dd6622193fbc4f2bfbb35536b5", size = 4021295, upload-time = "2026-05-18T19:17:28.638Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/5f/26a4dd0e12b9456ff7b12a21af5b491eb6629680d1edd73f4140fd386bcf/lxml-6.1.1-cp310-cp310-win_arm64.whl", hash = "sha256:8dadbe5b217ff35b6a8d16610dd710219b59b76d13f0e3f0d9f36786206e4485", size = 3667717, upload-time = "2026-05-19T19:22:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b0/83f481780d1548750b8ce2ec824073deef2f452d9cd1a6faff8507e3d16d/lxml-6.1.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:53b7d2b7a10b1c35c0a5e21e9224accf60c1bbfba523990732e521b2b73adef2", size = 8526461, upload-time = "2026-05-18T19:17:25.862Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d5/30fa0f808002c7329397bfbb24e306789c0b29f04aa5842c07b174b4216f/lxml-6.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ff3f333630ab480244a1bff72043e511a91eb22e7595dead8653ee5612dd8f3d", size = 4595375, upload-time = "2026-05-18T19:17:34.555Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/d2/edb71cf0e561581a7c5eb2626244320eb04e9f8ce6d563184fd668b45073/lxml-6.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a4bbea04c97f6d78a48e3fbc1cb9116d2780b1b39e03a23f6eb9b603fd61f510", size = 4923654, upload-time = "2026-05-18T19:17:42.917Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/77/1bc7eeb0de4577d783fb625aa092cc9357883bba35845a3666bf1259f3dc/lxml-6.1.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db1d75f6617a49c1c01bc7023713e0ff59ab32c9579ae62a7674c0e34f3b0b0a", size = 5067921, upload-time = "2026-05-18T19:17:49.175Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/3c/c0690d74bd2bc17bc03b5b0d093569ead597dd0bfa088bf99eef8c24e19c/lxml-6.1.1-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a12689be69a28ddaa0ab99a5a1137da2afd5f8f16df7b5680b66f616d3eda1d", size = 5002456, upload-time = "2026-05-18T19:17:59.715Z" },
+    { url = "https://files.pythonhosted.org/packages/66/8d/d1b3271af0c0f1e27e8472a849e4d2c65bc7766884b9ad2da9e76e145c88/lxml-6.1.1-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18b73c339ae29b90fd2d06e58ebd555a751bde9cd6bbd36cc0281b9a2c94e9d8", size = 5202776, upload-time = "2026-05-18T19:18:08.924Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/45/689824ffb237fd10125ad273f32b28ff04dc6203c2822c85ff65a93df65e/lxml-6.1.1-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:752d3bbfe874715ccd0aec7f88d7fc623c0f1fd7aa7b3238a084e017bad2a009", size = 5329945, upload-time = "2026-05-18T19:18:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/c0/ef73af53767e958fd87d437c170f272e2f6e6c0f854939f133a895f1e711/lxml-6.1.1-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:6b1761fbf9ec984e2e9d9c589ef5f5fd684b7c19f92aadd567a26c5224958db6", size = 4659237, upload-time = "2026-05-18T19:18:18.657Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/5e/e1158e40397585e91cb0472374a1f63d0926a1ddeaa92f13d1a1ffe306d5/lxml-6.1.1-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d680fbcb768404c601ecb43519ecd8461f6954cb11c06a78962f666832ccfca8", size = 5265904, upload-time = "2026-05-18T19:18:24.883Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/16/8687e5d1400ed1c0bc41dace232ebb7553952b618ea1f2e5fb6e2cfbbe23/lxml-6.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:162af1091cd785f2f27e62d3547ae9bc58ec5c86dd314d67021fd02463708d83", size = 5045225, upload-time = "2026-05-18T19:17:20.073Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/18/d877bd1ae2e5ffdfd4836565aba350db31feb2f2656d6ce70316ed66a05e/lxml-6.1.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:e9308ff8241c532df3f3e570f9a5aeed6c853f888512ba4b75638d7c11c95ef6", size = 4712721, upload-time = "2026-05-18T19:17:40.512Z" },
+    { url = "https://files.pythonhosted.org/packages/44/4d/1f44fd1d770b10dacbf6b5c6e520f4d6e0708744930f719dc04e67cab981/lxml-6.1.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:5f6994074ebae6ffb04447268e37dc16edc304f9859cf91acb86e0af6c1b395c", size = 5252549, upload-time = "2026-05-18T19:17:51.236Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5d/1d66b84f850089254c230ef6ea6b267a5a54e2e179a5d960036a05d501d7/lxml-6.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:80c2dfadb855da477cf73373ad29a333535dedb9b12bad02c9814c8e2b43bf08", size = 5226877, upload-time = "2026-05-18T19:18:00.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/00/84c4b5302d42a2d0184f38d538c8a197f33b52a50bd4f7bcfe990bce3036/lxml-6.1.1-cp311-cp311-win32.whl", hash = "sha256:30a89d3ac8faec007453fb541f3f46807eeec88edd5826f6e3fe001752a2c621", size = 3594072, upload-time = "2026-05-18T19:17:12.714Z" },
+    { url = "https://files.pythonhosted.org/packages/61/9d/2e2f7d876349f45e0f3e29f72da311668853d59b58d473a2dea4f0160135/lxml-6.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:abbefa31eee84842140f67acef1c828e28bba8bbf0c3bc6e5492a9af88152c28", size = 4025469, upload-time = "2026-05-18T19:17:50.566Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d5/570e6390e4110331e6208b2ba83d1482cc9146808ee118b22824a34c1070/lxml-6.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:dcb292aa7fe485ceff7af4f92e46c5af397daec5dff64871a528f0fc47a3cc5b", size = 3667640, upload-time = "2026-05-19T19:22:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:104c09bda8d2a562824c0e319d0768ce26a779b7601e0931d33b09b53c392ef7", size = 8570821, upload-time = "2026-05-18T19:17:42.068Z" },
+    { url = "https://files.pythonhosted.org/packages/22/00/ff3009c88e65de8011630acf8ab5a09cb2becd2aaf47fba2f3449f6224e9/lxml-6.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:25c6997a9a534e016695a0ba06b2f07945de682731ff01065b6d5a4474179da1", size = 4624252, upload-time = "2026-05-18T19:17:47.897Z" },
+    { url = "https://files.pythonhosted.org/packages/42/95/bb63f0fd62e554fe078e1fb3c8fe9083c14ddc7ad7fa178d10e57e071ac7/lxml-6.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c921ba5c51e4e9f63b8b00267d06566e1f63407408a0496da2d1d0bfc819c7fc", size = 4930746, upload-time = "2026-05-18T19:18:29.637Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/99/0013e8d9b5960f4f041cf0b73e2f80c23eb5205b1f7bfb20203243651359/lxml-6.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:54a7f95e4de5fb94e2f9f4b9055c6ba33bf3d628fd77a1d647c5923caa2cdcdc", size = 5093723, upload-time = "2026-05-18T19:18:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/29/91/317b332636bfc7bddcff828d41b3307f50043f4b237e40849c333d80fa1a/lxml-6.1.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f2ec43df44b1f76249ee0a615334f9b5b060e1c8bd90e706dad2d14d02f383", size = 5005557, upload-time = "2026-05-18T19:18:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2f/cc9bf06afe70f9c9093ae60855d9759da9db601ec4080f7473319666ffd7/lxml-6.1.1-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:70ef8a7e102a1508f8121aae5b0867abd663f72c14f0a9c937e6554cb4587b7b", size = 5631036, upload-time = "2026-05-18T19:18:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ebe6af670449830d6d9b752c256a983291c766a1365ba5d5460048f9e33a7818", size = 5240367, upload-time = "2026-05-18T19:18:49.217Z" },
+    { url = "https://files.pythonhosted.org/packages/78/83/8555d40948b09ce86f1bd0c68a7ac31d07b1929f92cc1b074006c97ef2d2/lxml-6.1.1-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:27acc820660aaffa4f7c087f29120e12980f7779d56d8492d263170111284740", size = 5350171, upload-time = "2026-05-18T19:18:52.779Z" },
+    { url = "https://files.pythonhosted.org/packages/63/75/5d92da93729b7bad783689e6496049fa40927b45bec7bf183c981de3ca70/lxml-6.1.1-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:1db753c9115ec7100d073b744d17e25e88a8f90f5c39b2f5dd878149af59671f", size = 4694874, upload-time = "2026-05-18T19:18:55.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b5/3aad415a9a25b822e783f15deeb4dffccf5113030f1afa2222dd929313d9/lxml-6.1.1-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4f469aebd783bb741c2ecb2a681008fd26bfe5c16a9a72ed5467f834e810df2", size = 5244492, upload-time = "2026-05-18T19:19:01.28Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a1/5fcf7eb9904b80086aa47dcf0027de07b1bb990afad2e6823144c368ae04/lxml-6.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:766b010012d59470072c1816b5b6c69f1d243e5db36ea5968e94accf430a4635", size = 5048232, upload-time = "2026-05-18T19:18:12.67Z" },
+    { url = "https://files.pythonhosted.org/packages/77/74/1f601b63c7a69fcdf10fa9b148c81da8442204194f6c55509cc485c786b9/lxml-6.1.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b8d812c6011c08b8111a15e54dd990b8923692d80adf35488bee34026c35accf", size = 4777023, upload-time = "2026-05-18T19:18:15.928Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b9/7a78f51aec95b1bf780d78e12705a9f6533284f8693dc5c0e6724fa53d3f/lxml-6.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:fe0306bd29505a9177aac19f1877174b0e7422c222a59f70b2cd41633448c3dc", size = 5645773, upload-time = "2026-05-18T19:18:23.223Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6e/98a7b7ad54e4e74fa1f20fff776913980619d0ebe5558232d7da6580bdd8/lxml-6.1.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5ba186ad207446c65d3bb3d3e0412b032b1d9f595e59861e2354798c5703d955", size = 5233088, upload-time = "2026-05-18T19:18:31.433Z" },
+    { url = "https://files.pythonhosted.org/packages/65/d1/bc0ed2427bf609f2ee10da303a6a226f9c8bce94f945dc29a32ce55de6e4/lxml-6.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aa366a1e55b8ebfe8ca8ddc3cfe75c8ebade181aeb0f661d0cb05986b647f72a", size = 5260995, upload-time = "2026-05-18T19:18:37.091Z" },
+    { url = "https://files.pythonhosted.org/packages/69/8b/6772e1a4b513fc50a8d931f19edde0e13ae6918510a1e13ff67864f3e5ed/lxml-6.1.1-cp312-cp312-win32.whl", hash = "sha256:126c93f7f56f0eda92f6d8c619edc463a4f23d9252f1c9d0405a76f25fa9f11a", size = 3596382, upload-time = "2026-05-18T19:17:18.37Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/89/45198e9624762af2dfd2cb8782598477ceb29f6e59caab560388ae1f4ec1/lxml-6.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:26e6eda8d38c1fcab1090dd196ee87cbd13788e531937610e2589085de074e77", size = 3997255, upload-time = "2026-05-18T19:17:56.781Z" },
+    { url = "https://files.pythonhosted.org/packages/90/a9/7a54b6834088d9ae528a7b780584ba6a39a9457b0ac330479f20ffbc9449/lxml-6.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:6540377fbd53fe1b629172288c464fb18db11ce1fa7dc15891da10aa9dcc3e7f", size = 3659610, upload-time = "2026-05-19T19:22:50.843Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/eb/7e6f37c5584ccbb2ff267f56fd0339016938c1c8684cfefab9b33ffc2f36/lxml-6.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:68a9198d0fc122d14bb76837de9aa80cf84caed990b5b237f532ed87d3706736", size = 8559780, upload-time = "2026-05-18T19:17:57.661Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/36/587c2521cf23a2cd6c9c22108aa7528f683a1f195ed7ccd23a4b1786ad36/lxml-6.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7d47866cb32fb503450b6edc9df355d10dc49836af2e89901bd6ac6b0896d9d9", size = 4618006, upload-time = "2026-05-18T19:18:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ca/ab7bfe2bf4c972af5e7878262845ead3a24a929a9b04bc11c7c1ece6c82a/lxml-6.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb7c9811bfaa8b1ed5ed319f5d370dfbcaa59d52ea64be2a5a85e18195930354", size = 4924139, upload-time = "2026-05-18T19:19:04.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/55/a0c72851dfee5ecc689f949723a73dea457758912542cb955b108eaf0d8f/lxml-6.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:762ff394d5bd56da0cf034a23dcce4e13923f15321a2adfa2ac00201dc6d3fca", size = 5082329, upload-time = "2026-05-18T19:19:09.728Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b6/0608f7d61a3b96cc67e5648a3d906e31a5082093e10e7be65b3886289938/lxml-6.1.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a088f287f7d8275a33c07f2cac6c50b9319309a0200a39e7e75d80c707723099", size = 4993564, upload-time = "2026-05-18T19:19:13.608Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/66/ae227524b066d29d55bf0b453d93d2d793c40218657d643dcbbca13b8faf/lxml-6.1.1-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e902da4b04e6b52e5893900d4b8ab46068f75f3561f01bf1080957f9fd932ed6", size = 5613467, upload-time = "2026-05-18T19:19:16.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/76/dbe4a00b50385e40194231dcfe5a12c059de7cf90e89c83407d2b085b719/lxml-6.1.1-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d4962d4c66bf830a7e59ed6cfc17d148149898a3aefa8ec6e59763e6e3ed085", size = 5228304, upload-time = "2026-05-18T19:19:19.354Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/01/00b1b8442ed2041793336868ba0b9ea4b13d7da7c085c6404c207a63bf79/lxml-6.1.1-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:581d4c8ae690a6609e64862dd6b7c2489635c2d13907fc2b20f2bc200ff1d21e", size = 5341607, upload-time = "2026-05-18T19:19:22.297Z" },
+    { url = "https://files.pythonhosted.org/packages/63/36/1ad29931e9a4638bb707869f01d423a6c815f82152138d1a40dfcfde2b95/lxml-6.1.1-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:876e1ff5930ed8bf295ec5ef9a8155e9b6b1876bbf1deed8b3a8069311875a8f", size = 4700168, upload-time = "2026-05-18T19:19:25.133Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/a9536cecf9be18a0dc72d32bead283a2332d1ffebd2dd3ac70ce444686e5/lxml-6.1.1-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9eb9b5a968f6e0f6d640092a567e14529ff8cea2e29d00da6f78a79fa49f013c", size = 5232487, upload-time = "2026-05-18T19:19:28.603Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/77/b4fb1e03bf5d130e879214d3100092e386418807fb74dd0adc4b0a48f351/lxml-6.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:aa49e06d94aba782c6a02eecb7e507969e7e7a41b267f1b359bb35585f295d5b", size = 5044231, upload-time = "2026-05-18T19:18:42.246Z" },
+    { url = "https://files.pythonhosted.org/packages/26/4c/d00daeeb0a5530c4028a9232aa1b93db3ef4ed2158c116ea73c79a9765b3/lxml-6.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:70cdfd80589d59e43e18005dd7244e8895e93db8ab6a620b7e23df5445a4e3d2", size = 4769450, upload-time = "2026-05-18T19:18:48.013Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/6a/715a3a8d156ce42f29cf014706f5410c2ff3b02267774110fc23266409fe/lxml-6.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:aad9aa39483ed8ec44d6d2e59e5b98a0d80676ef0d92f44bfc374836111f62f5", size = 5635874, upload-time = "2026-05-18T19:18:51.914Z" },
+    { url = "https://files.pythonhosted.org/packages/45/37/0544bc21dde2a88f3a17b504e6fc79c0e01d25a33c2f6079724e9e72b9c7/lxml-6.1.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d49514be2f28d895c38cf9d2b72d7b9a07d00314519f456c0b50b53cfcf4c785", size = 5223987, upload-time = "2026-05-18T19:18:59.715Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f8/f6a5e8185bcb28c2befae3d31f8e3df3b811cb0f47746517a81279fcafe1/lxml-6.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:47402e62c52ff5988c1e8c6c63177f5708bccf48e366dea4e3dcf1e645e04947", size = 5250276, upload-time = "2026-05-18T19:19:03.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f2/1a2b9f1b7a49d45495369be7ef9ad05b262930f2eab3e3145706fca8083f/lxml-6.1.1-cp313-cp313-win32.whl", hash = "sha256:3483644525531e1d5762b0c44a8e18b6efba321b6dcf8a8952de10b037618bca", size = 3596903, upload-time = "2026-05-18T19:17:29.863Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/99/f4ffb024f238eec2131aaa09f3278fb6129cf892741bf68e1fc1afb8c100/lxml-6.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:a10bd2fd62e8ce916ececb342f348f190724a098c1faa056fdfb2a22ad5e8660", size = 3995869, upload-time = "2026-05-18T19:18:02.596Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/53/70eb8c5c6037f27448f1e3c54ebede9545a801ae63f0a7254afca4fe8e45/lxml-6.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:424aa57aca0897eb922aef34395bd1289b3b6f04e6bae20ea123c0c7e333cffc", size = 3658490, upload-time = "2026-05-19T19:22:53.846Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e2/2e325795566de01d0d7c3bb57d3c370616b2d07b01214e84eec5d3b10963/lxml-6.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:19b7ab10b210b0b3ad7985d9ac4eb66ab09a90b20fe6e2f7ba55d01a234345d0", size = 8577146, upload-time = "2026-05-18T19:18:17.765Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cf/5630b5e4be7d2e6bee8efe83865c925221103cf0221303b104ce134b01e2/lxml-6.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c08e5c694306507275f2290073350c4f32e383db15213b2c69e7ff39c1193840", size = 4623866, upload-time = "2026-05-18T19:18:30.669Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/51/3904907c063451cf8d4a5c9fe0cad95fa1f4ec57f4e3884fa0731bd7a305/lxml-6.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:74a9717fd0d82effef5c2854f0d917231d5324b5a3eb7275c43ac9fa32f97a14", size = 4950022, upload-time = "2026-05-18T19:19:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/94/cd/9c7611a51c37a2830928405817cc5d56a97f64fab83cc3f628748b135749/lxml-6.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:efe0374196335f93b53269acd811b944f2e6bdc88e8894f214bd636455484909", size = 5086695, upload-time = "2026-05-18T19:19:34.764Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d6/24e3b5906abb0b674ff2ae195bc3ce59708df2bcd17cf17703b2d7dd643a/lxml-6.1.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac931cdc9442c1763b8a8f6cd62c0c938737eafc5be75eff88df55fc73bc0d00", size = 5031642, upload-time = "2026-05-18T19:19:37.771Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/db/6ec54f99019838bff54785c51da07f189eb4676861c5f2730962b0d8d665/lxml-6.1.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:aee395f5d0927f947758b4ec119fd5fc8ec71f07a1c5c52077b30b04c0fa6955", size = 5647338, upload-time = "2026-05-18T19:19:40.553Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/ef4dcfffd22d27a61805d8ed9f7fb888495bc6aa88648fa07c1eaa5586b6/lxml-6.1.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9395002973c827b3ed67db77e6ec09f092919a587022174554096a269378fb13", size = 5239528, upload-time = "2026-05-18T19:19:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bb/37fb3f0dff146bdcfa78eec47879273820b2a0bf350ec236ce14bd0b1c26/lxml-6.1.1-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:73bc2086f141224ebddb7fc5c6a36ca58b31b94b561e1dfe8e073e3270fad1e7", size = 5350730, upload-time = "2026-05-18T19:19:46.307Z" },
+    { url = "https://files.pythonhosted.org/packages/90/42/43253f168388df4fae1f38c01df36ddb9bee39e2048167b54cdcbae85ea3/lxml-6.1.1-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3779def59032b81e44a5f70096ef6bf2082f8d901937dca354474ba09782e245", size = 4697530, upload-time = "2026-05-18T19:19:49.889Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a8/c5a8504f81bbdfc8e7094c2c850cdb4ed6777fc4d5ddd9e5ab819f3b0d54/lxml-6.1.1-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:86c89b9d55ebf820ad7c90bc533410f0d098054f293351f10603c0c46ff598f5", size = 5250670, upload-time = "2026-05-18T19:19:53.199Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b7/c7e76ab18744d75e21f320ebf9ff9d1ceae2b54dd431ea5a64caf26c9672/lxml-6.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19607c6bbff2a44cf3fe8250abccd20942d3462473e0a721d01d379ed017e462", size = 5084485, upload-time = "2026-05-18T19:19:08.422Z" },
+    { url = "https://files.pythonhosted.org/packages/31/31/b35c53f8ef7b7c31cacd23d3638652fff7bcd1deb6eedb709ab43b685908/lxml-6.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c6ed5141a5c7507cf3ee76bd363b0d6f801e3321adc35b5d825a23115faa5465", size = 4737635, upload-time = "2026-05-18T19:19:12.321Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/06/31f23c813a7fe8e0cb1b175e915b08c9bf4e86d225b210feadbdbe519667/lxml-6.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:62aeb7e85b5d60320b9d77eef2e773994e2c0ce10121b277e0a19804e1654a5a", size = 5670681, upload-time = "2026-05-18T19:19:15.001Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bc/ce619bccc89b1fd9ad8a8e1330ee3f3beff9f2ff95b712d7bbcdd6e22fc3/lxml-6.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b1b963fd8f5caa68e99dfae060d54de1fe9cba899b8718b44a00cdca53c3e590", size = 5238229, upload-time = "2026-05-18T19:19:18.131Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5d/b329acbbedc0b619ebc2be6cf7ee9ed07e80892c88d4dfd612c33805789a/lxml-6.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:63876be28efefa04a1df615b46770e82042cce445cfdce55160522f57b231ccb", size = 5264191, upload-time = "2026-05-18T19:19:21.118Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/85/be36fb1425b30db3c3f9df75fe86343ebffb79e6320bd7f588e25bfeac39/lxml-6.1.1-cp314-cp314-win32.whl", hash = "sha256:7f7a92e8583f06b1fd49d01158143b8461cfcd135dcb10ec807270a3051bd603", size = 3657202, upload-time = "2026-05-18T19:17:39.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ce/3cf9a827342269f54d405a6202397de63f07c69cbd6ce7d183a3f0cba1e9/lxml-6.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:b2d444f2e66624d68e9c6b211e28a76e22fff5fcabcfff4deac18b529b7d4137", size = 4064497, upload-time = "2026-05-18T19:18:14.662Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3e/1a957bde8f0760039e627f94699f82caa782c9d838d86c3d28245ee67212/lxml-6.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:3fd9728a2735fda14f4e8235830c86b539e9661e849665bf926d3f867943b4bf", size = 3741991, upload-time = "2026-05-19T19:22:59.111Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b2/00ed55b3a2efa4658fb795c38d1090ec9b3e8a6c3683d4441fa517f09c3b/lxml-6.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:787b2496d0dbe8cd180984e8d29e3a6f76e7ea34db781cb3bd55e4ba1ef8b4ee", size = 8827545, upload-time = "2026-05-18T19:18:41.193Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/73/74573db19baa618d5f266f2407898b087ff6927115b00b71e5fc1b700847/lxml-6.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2c8daa471358dc2d6fcf02165e80ec68f77871a286df95bc5cc3816153b0fd2c", size = 4735736, upload-time = "2026-05-18T19:18:46.761Z" },
+    { url = "https://files.pythonhosted.org/packages/16/02/6f7061f4f95f51e545d48e87647c54791d204a4e881be4156e7a26ba5338/lxml-6.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:acd7d70b64c0aae0c7922cca83d288a16f5f6da523637697872253415269baef", size = 4970291, upload-time = "2026-05-18T19:19:56.215Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/02/55fc057d8283427dea7d6edb102e7a840239c77a64a983d92f62a304c0e9/lxml-6.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4f0dd2f01f9f8a89f565d000e03abcf0a13d692a346c8d22f628d49af098777a", size = 5102822, upload-time = "2026-05-18T19:19:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/48/8e1cf78d89d66850121d9255a2a24414c98f775da93b90cf976956c24b14/lxml-6.1.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b7e8a14c8634bf6f7a568634cb395305a6d964aeb5b7ee32248094bed3a7e2c", size = 5027923, upload-time = "2026-05-18T19:20:01.549Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/00/0632a0647612c8af24d26997b3b961397daa9d5b2581444805933629a4cb/lxml-6.1.1-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:86281fbdd6a8162756f8d603f37e3435bfa38043adb79c6dc6a2dfee065e7525", size = 5595843, upload-time = "2026-05-18T19:20:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/86/ab008a7dc360711b66858d61c80a5979a70a09f2aa2b05d9698df80b803d/lxml-6.1.1-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5d7152ec39ca7c402d8fb9bad86140a15b9503bd0c54484e3f1bbe3dd37ceca", size = 5224515, upload-time = "2026-05-18T19:20:06.381Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c6/2702ff375e728e34f56d9a45339a9cf7e4427e917f542225242d63a05afa/lxml-6.1.1-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:88d8cb75b9d82858497a5393e3c63cfbf03035225e4b35a49ed7ccb151e4dc0e", size = 5312511, upload-time = "2026-05-18T19:20:09.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/a5807c98f87a86f10ef9ffab35516df7c0f0c4b6d5d33e9f608ab9c04a31/lxml-6.1.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f64ec5397ea6a41fc1b4af0380d79b44a755b5531dcaccd9940fb260dca93038", size = 4639206, upload-time = "2026-05-18T19:20:11.704Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e1/8a0a2c35734812395f4da4eaf33748a7e5705bfb2a58b128da764339d5ec/lxml-6.1.1-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d34bbf07dbc7ca5970671b1512e928991fb5e9d95365636c9b2d8b4f53af405e", size = 5232404, upload-time = "2026-05-18T19:20:14.064Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e2/0e6a4dd5ad84d01d99aa7bae7cfefd4a760a0e0f8176818241de17d9b6c0/lxml-6.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:17e0e18d4ad8adbd0399291bc44845b69d9dd68439a3cdebdf35ff902ec05072", size = 5083769, upload-time = "2026-05-18T19:19:23.758Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/7e/161f33d463f6ffc1c7679104b65086dea120080d49dde4d238f015aaee2f/lxml-6.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:3ab541146f1f6968c462d6c2ac495148e8cdba2f8347700b2141b6ec5a75bf52", size = 4758936, upload-time = "2026-05-18T19:19:27.256Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fb/2369825e3f6ca99305bf9f7b7085fda91c8b0922a89e54d900974aa3ef85/lxml-6.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2a0217714657e023ef4293500f65aa20fce6164c8fd6b08fa5bd4a859fb14b9b", size = 5620296, upload-time = "2026-05-18T19:19:29.993Z" },
+    { url = "https://files.pythonhosted.org/packages/30/90/d61e383146f74c5ab683947ea14dc7b82778838ab9b95ea73a23b60d0191/lxml-6.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2", size = 5228598, upload-time = "2026-05-18T19:19:33.523Z" },
+    { url = "https://files.pythonhosted.org/packages/76/2d/2dafd8149e94b05bb070690efd5bb2680720681e03ff03fc57d2b70a1105/lxml-6.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9e36f163528fc50cbef305f02a5fd66d404edf7049cdaff211dbc2cba5a7013e", size = 5247845, upload-time = "2026-05-18T19:19:36.649Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/68/b30e913340c380ddac9580c6e6230991fc37240ec4f64704833e4f3e2769/lxml-6.1.1-cp314-cp314t-win32.whl", hash = "sha256:649dda677cf3bd6ac9ae14007ba0c824ded8ce5808b53fc7431d9140399118c1", size = 3897345, upload-time = "2026-05-18T19:17:33.562Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4e/9eb2af5335545f9fbcd7af57bcf87c6025d31eaa31b14ec184a6c8675328/lxml-6.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:793033d6c5cdf33a573f910d9bea14ef8f5771820411d118da8e1182edb53d5e", size = 4393350, upload-time = "2026-05-18T19:18:10.076Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/2c/0f1e93c636720e8a3eb59af2bfda99d98b55891e1c53bc30c2e0e865f01b/lxml-6.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:58bb955caba94e467d2a96da17660d2d704e0675894cba21ab8a775b8621fd1c", size = 3817223, upload-time = "2026-05-19T19:22:56.823Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/32/86a3f0f724a3a402d4627937a7fc27b160e45e7012b4adf47f6e1e844511/lxml-6.1.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:31033dc34636ea6b7d5cc11b1ddbda78a14de858ba9d3e1ed4b69a3085bc521e", size = 3930127, upload-time = "2026-05-18T19:19:02.27Z" },
+    { url = "https://files.pythonhosted.org/packages/40/44/d832e82af08723761556d004b1d04d281c09f9a8cecd7d3148548c9941a3/lxml-6.1.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3893c14c4b6ac5b2d54ba8cf03e99fe5104e592de491f19bd6b82756c09f8004", size = 4210769, upload-time = "2026-05-18T19:20:41.427Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/39/0dc5949f759ed7d951e0bb8c2f2d9d7aca1908d22352fa84a8afd2ea54af/lxml-6.1.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c07da4cebf6889f03ebac8d238f62318e29f495de0aa18a51ea14e61ae907e2e", size = 4318163, upload-time = "2026-05-18T19:20:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/fb/8ab3845fe046ba4cbf74536bcf6801a774b7caf4350de1c5d37f1f0a9e90/lxml-6.1.1-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6f0ce10945fab9c4c06ce14e22af9059d1a87493a9af4501a5b0b9187e21cf2", size = 4250945, upload-time = "2026-05-18T19:20:47.385Z" },
+    { url = "https://files.pythonhosted.org/packages/68/1b/7553ab136894374ffae8851ec06f98f511cd8e66246e41b6be059d0a7289/lxml-6.1.1-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f8844cd288697c6425c9beba919302241e3278871dc6519515e72b04e987abcf", size = 4401664, upload-time = "2026-05-18T19:20:50.489Z" },
+    { url = "https://files.pythonhosted.org/packages/db/a4/441aee36c6f6b249823d20fd91f9be9ab89d7c5a8ae542a4a4ca6d342d56/lxml-6.1.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:ed21202aec73cda4d55d1ce57b389aadb90ffb044e6cd1080b8347efe1b1ec84", size = 3508989, upload-time = "2026-05-18T19:18:38.158Z" },
+]
+
+[package.optional-dependencies]
+html-clean = [
+    { name = "lxml-html-clean" },
+]
+
+[[package]]
+name = "lxml-html-clean"
+version = "0.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/63/195dfdde380a84df309e3bccf4384b034b745dba43426886f7ae623b4fba/lxml_html_clean-0.4.5.tar.gz", hash = "sha256:e2a4c7d5beedd17cd7b484d848a0571e54baa239a4f9df5546e3acba7f990560", size = 24142, upload-time = "2026-05-20T12:17:53.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/bd/6e2b76a6c5dee10397db9c929f0c5066766ec1036046f0335b7ca7ca08b8/lxml_html_clean-0.4.5-py3-none-any.whl", hash = "sha256:c76fcadd1e5bfb9b8bafc2200d51e4e78eb0dad67f56881c21dfb6484c7e7746", size = 14573, upload-time = "2026-05-20T12:17:52.215Z" },
 ]
 
 [[package]]
@@ -2241,6 +2437,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pypdf"
+version = "6.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/72/7dfd5ff1c9c37de97a731701f51af091325f123d9d4270361c9c69e4431f/pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25", size = 6491182, upload-time = "2026-06-23T14:18:30.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/e6/136aa8993a2ae7214e0b0ef2edaa0d2e08d1d4e4982635b08a835ff31ec8/pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946", size = 349514, upload-time = "2026-06-23T14:18:28.867Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2317,6 +2525,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
 ]
 
 [[package]]
@@ -2649,6 +2866,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tld"
+version = "0.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5d/76b4383ac4e5b5e254e50c09807b3e13820bed6d6c11cd540264988d6802/tld-0.13.2.tar.gz", hash = "sha256:d983fa92b9d717400742fca844e29d5e18271079c7bcfabf66d01b39b4a14345", size = 467175, upload-time = "2026-03-06T23:50:34.498Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/90/39a85a4b63c84213e78b3c17d22e1bf45328acf8ebb33ef93be30d0a3911/tld-0.13.2-py2.py3-none-any.whl", hash = "sha256:9b8fdbdb880e7ba65b216a4937f2c94c49a7226723783d5838fc958ac76f4e0c", size = 296743, upload-time = "2026-03-06T23:50:32.465Z" },
+]
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2704,6 +2930,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/46/cc36c679f09f27ded940281c38607716c86cf8ba4a518d524e349c8b4874/tomli-2.3.0-cp314-cp314t-win32.whl", hash = "sha256:a1f7f282fe248311650081faafa5f4732bdbfef5d45fe3f2e702fbc6f2d496e0", size = 107563, upload-time = "2025-10-08T22:01:44.233Z" },
     { url = "https://files.pythonhosted.org/packages/84/ff/426ca8683cf7b753614480484f6437f568fd2fda2edbdf57a2d3d8b27a0b/tomli-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:70a251f8d4ba2d9ac2542eecf008b3c8a9fc5c3f9f02c56a9d7952612be2fdba", size = 119756, upload-time = "2025-10-08T22:01:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/77/b8/0135fadc89e73be292b473cb820b4f5a08197779206b33191e801feeae40/tomli-2.3.0-py3-none-any.whl", hash = "sha256:e95b1af3c5b07d9e643909b5abbec77cd9f1217e6d0bca72b0234736b9fb1f1b", size = 14408, upload-time = "2025-10-08T22:01:46.04Z" },
+]
+
+[[package]]
+name = "trafilatura"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "courlan" },
+    { name = "htmldate" },
+    { name = "justext" },
+    { name = "lxml" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/19/24833e905df2d80e3bb67424f95febcc17709a1f61a522120bc438afca70/trafilatura-2.1.0.tar.gz", hash = "sha256:f689e2116fc89c7bc0b9a296d01dcfe2eb0b5455f8c371a77dc0db1f06a05643", size = 263876, upload-time = "2026-06-07T17:43:31.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/78/4ad99d79aee2784f49f20fd0a29058ce4c032fe4439047924c43521cd211/trafilatura-2.1.0-py3-none-any.whl", hash = "sha256:0eded5207a806445ddebbe36eae30b9035fe6a2f233c36f6fe82663fca8b9d30", size = 134600, upload-time = "2026-06-07T17:43:28.404Z" },
 ]
 
 [[package]]
@@ -2806,6 +3050,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/5b/879b2f932adfa7a053c360d50bc896c977fa6426109185f7c12ebdd0cb9d/tzlocal-5.4.4.tar.gz", hash = "sha256:8dbb8660838688a7b6ba4fed31d18dedf842afb4d47ca050d6d891c2c15f3be4", size = 31170, upload-time = "2026-06-29T08:03:40.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/a4/017a7a6cbe387d961a688ec31364ae60a5c4e22c96ae9921b79a947c855d/tzlocal-5.4.4-py3-none-any.whl", hash = "sha256:aae09f0126a8a86fa736be266eb4a471380d26a0de3bc14844e7821fee3e2a15", size = 18115, upload-time = "2026-06-29T08:03:38.666Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add provider capability metadata and token-aware extraction routing.
- Add local article extraction, text-only PDF extraction, and short-content bypass controls.
- Add explicit transcript, extraction, and media cache lifecycle commands.
- Update docs, ADR 039, devlog, and GitHub issue status for the active roadmap.

## Deferred
- #105 remains freezer/someday.
- #111 remains future OCR/image PDF work.
- #112 remains future hosted article fallback work.

## Validation
- uv run pytest: 1359 passed, 9 skipped.
- uv run ruff check .
- uv run ruff format --check .
- uv run mypy src
- Pre-push hook passed, including pytest.

Updates #102.
Closes #103.
Closes #104.
Closes #106.
Closes #107.
Closes #108.
Closes #109.
Closes #110.