### PR TITLE
Fix Claude Keychain readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.1] - 2026-07-20
+
+### Fixed
+
+- Preserve the non-secret `USER` environment value required for Claude Code to
+  discover a macOS Keychain-backed subscription login while continuing to scrub
+  API keys, tokens, cloud credentials, and unrelated environment values.
+- Clarify that `runtime_not_authenticated` can mean the current sandbox cannot
+  access the saved login, so users are not incorrectly told to authenticate
+  again when the normal host CLI is already logged in.
+- Accept Claude's documented terminal result when it reports a uniquely
+  identifiable primary model plus auxiliary safe-mode model work, preserving
+  every reported model and total token usage while rejecting ambiguous fallback.
+
 ## [0.25.0] - 2026-07-20
 
 ### Added

--- a/docs/user-guide/local-claude-extraction.md
+++ b/docs/user-guide/local-claude-extraction.md
@@ -19,9 +19,12 @@ inkwell plugins validate claude-code --json
 ```
 
 The requested value may be a current Claude CLI alias or full model identifier.
-The result and cache provenance record both that requested value and the single
-effective model reported by Claude Code. Multiple reported models fail closed;
-Inkwell does not enable `--fallback-model`.
+The result and cache provenance record both that requested value and the primary
+effective model whose token usage matches Claude's terminal result. Claude may
+also report auxiliary model work, such as a safe-mode classifier; Inkwell keeps
+those model identifiers in the attempt record and includes their tokens in total
+usage. Ambiguous primary-model metadata fails closed. Inkwell does not enable
+`--fallback-model`.
 
 Optional bounded settings mirror Local Codex extraction:
 
@@ -36,6 +39,12 @@ Validation calls only `claude --version` and `claude auth status --json`. It
 records installed/authenticated/supported state and the sanitized auth class;
 it discards account, organization, subscription-tier, and credential fields.
 Validation does not perform inference or start an authentication flow.
+
+On macOS, Claude Code's saved login is Keychain-backed. A sandboxed launcher
+may be unable to see that login even when `claude auth status --json` succeeds
+in your normal terminal. Treat that as a process-isolation diagnostic, not a
+logout: run validation from the same unsandboxed host context, and do not log
+in again solely because a sandbox reports `runtime_not_authenticated`.
 
 ## Use Your Local Claude CLI
 

--- a/src/inkwell/agent_runtime/claude_code.py
+++ b/src/inkwell/agent_runtime/claude_code.py
@@ -73,6 +73,54 @@ def _int_field(value: Any) -> int:
     return max(0, value)
 
 
+def _parse_model_usage(
+    model_usage: Any,
+    raw_usage: Any,
+) -> tuple[str, RuntimeUsage, list[str]]:
+    """Identify the primary model and retain tokens from auxiliary model work."""
+    if not isinstance(model_usage, dict) or not model_usage or not isinstance(raw_usage, dict):
+        raise RuntimeInvocationError(
+            RuntimeErrorCode.MODEL_MISMATCH,
+            "Claude CLI did not report usable model provenance.",
+        )
+
+    primary_input_tokens = _int_field(raw_usage.get("input_tokens")) + _int_field(
+        raw_usage.get("cache_creation_input_tokens")
+    )
+    primary_output_tokens = _int_field(raw_usage.get("output_tokens"))
+    candidates: list[str] = []
+    parsed_entries: list[tuple[str, dict[str, Any]]] = []
+    for model, details in model_usage.items():
+        if not isinstance(model, str) or not model.strip() or not isinstance(details, dict):
+            raise RuntimeInvocationError(
+                RuntimeErrorCode.MODEL_MISMATCH,
+                "Claude CLI reported invalid model provenance.",
+            )
+        parsed_entries.append((model, details))
+        if (
+            _int_field(details.get("inputTokens")) == primary_input_tokens
+            and _int_field(details.get("outputTokens")) == primary_output_tokens
+        ):
+            candidates.append(model)
+
+    if len(candidates) != 1:
+        raise RuntimeInvocationError(
+            RuntimeErrorCode.MODEL_MISMATCH,
+            "Claude CLI did not identify one primary effective model.",
+        )
+
+    effective_model = candidates[0]
+    usage = RuntimeUsage(
+        input_tokens=sum(_int_field(details.get("inputTokens")) for _, details in parsed_entries),
+        cached_input_tokens=sum(
+            _int_field(details.get("cacheReadInputTokens")) for _, details in parsed_entries
+        ),
+        output_tokens=sum(_int_field(details.get("outputTokens")) for _, details in parsed_entries),
+    )
+    auxiliary_models = sorted(model for model, _ in parsed_entries if model != effective_model)
+    return effective_model, usage, auxiliary_models
+
+
 class ClaudeCodeRuntimeBackend:
     """Invoke a separately installed Claude CLI using saved subscription OAuth."""
 
@@ -158,10 +206,19 @@ class ClaudeCodeRuntimeBackend:
             reason=(
                 None
                 if ready
-                else "Claude CLI does not report a saved first-party subscription login."
+                else (
+                    "Claude CLI did not expose a saved first-party subscription login "
+                    "to this process."
+                )
             ),
             recovery_command=(
-                None if ready else "Authenticate Claude Code independently, then retry validation."
+                None
+                if ready
+                else (
+                    "Run `claude auth status --json` in the same host context. If it "
+                    "reports logged in, rerun Inkwell outside a sandbox with macOS "
+                    "Keychain access; do not re-authenticate solely from this diagnostic."
+                )
             ),
             required_capabilities=required,
         )
@@ -315,18 +372,10 @@ class ClaudeCodeRuntimeBackend:
                 "Claude CLI did not emit structured terminal output.",
             )
 
-        model_usage = payload.get("modelUsage")
-        if not isinstance(model_usage, dict) or len(model_usage) != 1:
-            raise RuntimeInvocationError(
-                RuntimeErrorCode.MODEL_MISMATCH,
-                "Claude CLI did not report exactly one effective model.",
-            )
-        effective_model = next(iter(model_usage))
-        if not isinstance(effective_model, str) or not effective_model.strip():
-            raise RuntimeInvocationError(
-                RuntimeErrorCode.MODEL_MISMATCH,
-                "Claude CLI reported an invalid effective model.",
-            )
+        raw_usage = payload.get("usage")
+        effective_model, usage, auxiliary_models = _parse_model_usage(
+            payload.get("modelUsage"), raw_usage
+        )
 
         final_value = payload["structured_output"]
         try:
@@ -345,16 +394,6 @@ class ClaudeCodeRuntimeBackend:
                     "Claude CLI final output failed application validation.",
                 ) from exc
 
-        raw_usage = payload.get("usage")
-        raw_usage = raw_usage if isinstance(raw_usage, dict) else {}
-        usage = RuntimeUsage(
-            input_tokens=(
-                _int_field(raw_usage.get("input_tokens"))
-                + _int_field(raw_usage.get("cache_creation_input_tokens"))
-            ),
-            cached_input_tokens=_int_field(raw_usage.get("cache_read_input_tokens")),
-            output_tokens=_int_field(raw_usage.get("output_tokens")),
-        )
         num_turns = _int_field(payload.get("num_turns"))
         if num_turns < 1:
             raise RuntimeInvocationError(
@@ -374,7 +413,10 @@ class ClaudeCodeRuntimeBackend:
             final_value=final_value,
             terminal_status="completed",
             lifecycle_events=["result.success"],
-            attempts=[f"claude-code:{effective_model}:turns={num_turns}"],
+            attempts=[
+                f"claude-code:{effective_model}:turns={num_turns}",
+                *(f"claude-code-auxiliary:{model}" for model in auxiliary_models),
+            ],
             usage=usage,
             provenance=provenance,
             billing=RuntimeBilling(mode="runtime_managed", amount_usd=None),

--- a/src/inkwell/agent_runtime/runner.py
+++ b/src/inkwell/agent_runtime/runner.py
@@ -14,6 +14,7 @@ from .models import RuntimeErrorCode, RuntimeInvocationError
 
 _ALLOWED_EXACT_ENV = {
     "HOME",
+    "USER",
     "CODEX_HOME",
     "PATH",
     "LANG",

--- a/tests/unit/agent_runtime/test_claude_code.py
+++ b/tests/unit/agent_runtime/test_claude_code.py
@@ -26,12 +26,14 @@ def _fake_claude(
     subtype: str = "success",
     model_usage: dict[str, object] | None = None,
     structured_output: dict[str, object] | None = None,
+    required_user: str | None = None,
 ) -> Path:
     auth_exit = 0 if logged_in else 1
     models = model_usage or {
         "claude-sonnet-4-5-20250929": {
             "inputTokens": 14,
-            "outputTokens": 5,
+            "cacheReadInputTokens": 3,
+            "outputTokens": 4,
             "costUSD": 0.01,
         }
     }
@@ -46,6 +48,7 @@ if args == ["--version"]:
     print("{version} (Claude Code)")
     raise SystemExit(0)
 if args == ["auth", "status", "--json"]:
+    assert {required_user!r} is None or os.environ.get("USER") == {required_user!r}
     print(json.dumps({{
         "loggedIn": {logged_in!r},
         "authMethod": {auth_method!r},
@@ -135,6 +138,18 @@ async def test_probe_reports_only_subscription_readiness(tmp_path: Path) -> None
 
 
 @pytest.mark.asyncio
+async def test_probe_preserves_user_for_keychain_auth_discovery(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("USER", "keychain-user")
+    readiness = await ClaudeCodeRuntimeBackend(
+        str(_fake_claude(tmp_path / "claude", required_user="keychain-user"))
+    ).probe()
+
+    assert readiness.ready is True
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("auth_method", "api_provider"),
     [("api_key", "firstParty"), ("oauth_token", "firstParty"), ("claude.ai", "bedrock")],
@@ -171,6 +186,7 @@ async def test_probe_distinguishes_missing_logged_out_and_version_drift(tmp_path
 
     assert missing.error_code == RuntimeErrorCode.MISSING_EXECUTABLE
     assert logged_out.error_code == RuntimeErrorCode.NOT_AUTHENTICATED
+    assert "do not re-authenticate solely" in (logged_out.recovery_command or "")
     assert old.error_code == RuntimeErrorCode.UNSUPPORTED_VERSION
 
 
@@ -260,12 +276,49 @@ async def test_success_subtype_with_is_error_is_rejected(tmp_path: Path) -> None
 
 
 @pytest.mark.asyncio
-async def test_multiple_effective_models_fail_closed(tmp_path: Path) -> None:
+async def test_auxiliary_model_usage_preserves_primary_and_total_tokens(tmp_path: Path) -> None:
     backend = ClaudeCodeRuntimeBackend(
         str(
             _fake_claude(
                 tmp_path / "claude",
-                model_usage={"primary": {}, "fallback": {}},
+                model_usage={
+                    "claude-haiku-4-5": {
+                        "inputTokens": 2,
+                        "cacheReadInputTokens": 0,
+                        "outputTokens": 1,
+                    },
+                    "claude-sonnet-5": {
+                        "inputTokens": 14,
+                        "cacheReadInputTokens": 3,
+                        "outputTokens": 4,
+                    },
+                },
+            )
+        )
+    )
+
+    response = await backend.invoke(_request())
+
+    assert response.provenance.effective_model == "claude-sonnet-5"
+    assert response.usage.input_tokens == 16
+    assert response.usage.cached_input_tokens == 3
+    assert response.usage.output_tokens == 5
+    assert response.attempts == [
+        "claude-code:claude-sonnet-5:turns=1",
+        "claude-code-auxiliary:claude-haiku-4-5",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_primary_model_fails_closed(tmp_path: Path) -> None:
+    backend = ClaudeCodeRuntimeBackend(
+        str(
+            _fake_claude(
+                tmp_path / "claude",
+                model_usage={
+                    "primary": {"inputTokens": 14, "outputTokens": 4},
+                    "fallback": {"inputTokens": 14, "outputTokens": 4},
+                },
             )
         )
     )

--- a/tests/unit/agent_runtime/test_runner.py
+++ b/tests/unit/agent_runtime/test_runner.py
@@ -24,6 +24,7 @@ def test_environment_is_allowlisted_and_secret_shaped_names_are_denied() -> None
     child = build_minimal_environment(
         {
             "HOME": "/safe/home",
+            "USER": "safe-user",
             "PATH": "/safe/bin",
             "LANG": "en_US.UTF-8",
             "HTTPS_PROXY": "http://proxy.invalid",
@@ -38,6 +39,7 @@ def test_environment_is_allowlisted_and_secret_shaped_names_are_denied() -> None
 
     assert child == {
         "HOME": "/safe/home",
+        "USER": "safe-user",
         "PATH": "/safe/bin",
         "LANG": "en_US.UTF-8",
         "HTTPS_PROXY": "http://proxy.invalid",


### PR DESCRIPTION
## What changed

- preserve the non-secret `USER` value in the bounded local-runtime environment so Claude Code can resolve a macOS Keychain-backed subscription login
- replace the misleading re-authentication instruction with sandbox-aware recovery guidance
- identify Claude's primary effective model by matching terminal token usage, while preserving auxiliary safe-mode model usage and rejecting ambiguous fallback metadata
- document the macOS sandbox boundary and add regression coverage

## Root cause

Inkwell v0.25.0 retained `HOME` but removed `USER`. On this host, `claude auth status --json` returned logged in in a normal process but returned logged out under Inkwell's minimal environment until `USER` was restored. The first authenticated smoke then showed that Claude can legitimately report a primary Sonnet model plus auxiliary Haiku safe-mode work, which the v0.25.0 parser incorrectly treated as an ambiguous fallback.

## User impact

Users with an existing Claude Code subscription login no longer receive a false `runtime_not_authenticated` result merely because Inkwell stripped the user identity needed for Keychain discovery. If a surrounding sandbox truly cannot expose the saved login, the diagnostic now says to compare the same host context rather than log in again.

## Verification

- focused runtime suite: 24 passed
- full Python suite: passed
- Ruff lint and format: passed
- mypy across 85 source files: passed
- strict MkDocs build: passed
- source distribution and wheel build: passed
- repository pre-push hook, including pytest: passed
- authenticated no-tools Claude smoke: passed using the existing login; requested `sonnet`, effective `claude-sonnet-5`, auxiliary `claude-haiku-4-5-20251001`; no login or credential handling attempted

## Release

Prepared as v0.25.1.
