### PR TITLE
Fix Codex item error lifecycle handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Accept non-fatal Codex item-level error notifications when the turn later
+  completes with valid structured output, while preserving terminal and output
+  validation failures.
+
 ## [0.25.1] - 2026-07-20
 
 ### Fixed

--- a/docs/reference/agent-runtime.md
+++ b/docs/reference/agent-runtime.md
@@ -63,9 +63,10 @@ grace period, sends KILL if needed, awaits the group leader and output drains,
 and removes the temporary workspace.
 
 Success requires exit code 0, a `turn.completed` JSONL event, a parseable final
-document, JSON Schema validation, and application validation. `turn.failed`,
-`error`, malformed/truncated output, oversized output, or missing terminal state
-fails the request and is never cached.
+document, JSON Schema validation, and application validation. Item-level error
+notifications remain lifecycle metadata and do not override a later successful
+turn. `turn.failed`, a top-level `error`, malformed/truncated output, oversized
+output, or missing terminal state fails the request and is never cached.
 
 ## Readiness JSON
 

--- a/src/inkwell/agent_runtime/codex.py
+++ b/src/inkwell/agent_runtime/codex.py
@@ -326,13 +326,9 @@ class CodexRuntimeBackend:
                     RuntimeErrorCode.MODEL_MISMATCH,
                     "Codex CLI reported an unexpected effective model.",
                 )
-            item = event.get("item")
-            item_failed = (
-                event_type == "item.completed"
-                and isinstance(item, dict)
-                and item.get("type") == "error"
-            )
-            if event_type in {"turn.failed", "error"} or item_failed:
+            # Error items are non-fatal notifications. The turn-level lifecycle
+            # events are authoritative for whether the invocation succeeded.
+            if event_type in {"turn.failed", "error"}:
                 raise RuntimeInvocationError(
                     RuntimeErrorCode.TURN_FAILED,
                     "Codex CLI reported a failed turn.",

--- a/tests/fixtures/codex_skill_budget_warning.jsonl
+++ b/tests/fixtures/codex_skill_budget_warning.jsonl
@@ -1,0 +1,4 @@
+{"type":"thread.started","thread_id":"fixture"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"type":"error","message":"Skill descriptions were shortened to fit the skills context budget. Codex can still see every skill, but some descriptions are shorter. Disable unused skills or plugins to leave more room for the rest."}}
+{"type":"turn.completed","usage":{"input_tokens":12,"cached_input_tokens":2,"output_tokens":4,"reasoning_output_tokens":1}}

--- a/tests/unit/agent_runtime/test_codex.py
+++ b/tests/unit/agent_runtime/test_codex.py
@@ -12,6 +12,8 @@ from inkwell.agent_runtime.codex import (
 )
 from inkwell.agent_runtime.models import RuntimeErrorCode, RuntimeInvocationError, RuntimeRequest
 
+FIXTURES_DIR = Path(__file__).parents[2] / "fixtures"
+
 
 def _fake_codex(
     path: Path,
@@ -286,6 +288,15 @@ def test_parser_rejects_malformed_failed_and_schema_invalid_output(tmp_path: Pat
             auth_class="chatgpt",
             duration_seconds=0.1,
         )
+    with pytest.raises(RuntimeInvocationError) as fatal:
+        backend._parse_response(
+            b'{"type":"error","message":"unrecoverable stream error"}\n',
+            result_file=result_file,
+            request=request,
+            version="0.144.6",
+            auth_class="chatgpt",
+            duration_seconds=0.1,
+        )
     with pytest.raises(RuntimeInvocationError) as schema:
         backend._parse_response(
             b'{"type":"turn.completed"}\n',
@@ -298,7 +309,41 @@ def test_parser_rejects_malformed_failed_and_schema_invalid_output(tmp_path: Pat
 
     assert malformed.value.code == RuntimeErrorCode.MALFORMED_PROTOCOL
     assert failed.value.code == RuntimeErrorCode.TURN_FAILED
+    assert fatal.value.code == RuntimeErrorCode.TURN_FAILED
     assert schema.value.code == RuntimeErrorCode.SCHEMA_INVALID
+
+
+def test_parser_accepts_nonfatal_error_item_when_turn_completes(tmp_path: Path) -> None:
+    backend = CodexRuntimeBackend("codex")
+    result_file = tmp_path / "result.json"
+    result_file.write_text('{"content":"safe result"}', encoding="utf-8")
+    request = RuntimeRequest(
+        prompt="task",
+        output_schema={
+            "type": "object",
+            "properties": {"content": {"type": "string"}},
+            "required": ["content"],
+        },
+        requested_model="expected-model",
+    )
+
+    response = backend._parse_response(
+        (FIXTURES_DIR / "codex_skill_budget_warning.jsonl").read_bytes(),
+        result_file=result_file,
+        request=request,
+        version="0.147.0",
+        auth_class="chatgpt",
+        duration_seconds=0.1,
+    )
+
+    assert response.terminal_status == "completed"
+    assert response.final_value == {"content": "safe result"}
+    assert response.lifecycle_events == [
+        "thread.started",
+        "turn.started",
+        "item.completed",
+        "turn.completed",
+    ]
 
 
 def test_parser_runs_application_validator(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- treat Codex `item.completed` error items as non-fatal lifecycle metadata
- continue failing closed on `turn.failed`, top-level `error`, missing completion, malformed protocol, and invalid final output
- add an exact Codex 0.147.0 skill-budget warning JSONL fixture and regression coverage
- document the lifecycle contract and changelog entry

## Root cause

The parser promoted every completed item whose type was `error` to `runtime_turn_failed`. Codex uses that item shape for recoverable warnings while the turn is still running, so Inkwell aborted before the later `turn.completed` event and schema-valid result could be accepted.

Codex's turn-level lifecycle is now authoritative: only terminal failure events fail the turn, while successful completion still requires process exit 0 plus parseable, schema-valid, application-valid output.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src/`
- `uv run pytest --cov=src/inkwell --cov-report=term-missing --cov-report=xml --cov-fail-under=75` (1,445 passed, 9 skipped; 81.27%)
- `uv run mkdocs build --strict`
- pre-commit and pre-push hooks

Closes #132