### PR TITLE
Release v0.25.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.2] - 2026-08-06
+
 ### Fixed
 
 - Accept non-fatal Codex item-level error notifications when the turn later


### PR DESCRIPTION
## Summary

- promote the Codex item-error lifecycle fix from `Unreleased` to `0.25.2`
- date the patch release for August 6, 2026
- prepare the tag-derived package for GitHub Release and PyPI publication

## Release scope

This patch release contains the fix from #132 / #133: Codex item-level error notifications no longer override a later successful `turn.completed`, while terminal failures and invalid output continue to fail closed.

## Validation

- `uv build`
- pre-commit hooks
- full pre-push pytest suite

After this PR merges, `v0.25.2` will be published as a GitHub Release, which triggers the repository's Trusted Publishing workflow for PyPI.