### PR TITLE
Release v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-08-14
+
 ### Added
 
 - Add first-class TikTok short and canonical URL ingestion with public embedded


### PR DESCRIPTION
## Summary

- promote the verified TikTok ingestion and artifact-contract changes from Unreleased to v0.26.0
- prepare the exact merge commit for tagging and trusted PyPI publication

## Validation

- feature PR #137: 1,481 tests passed, 9 skipped, 82.98% coverage; Ruff, formatting, mypy, strict docs, CodeQL, dependency audit, and CI passed
- release changelog: `uv run mkdocs build --strict`

## Post-Deploy Monitoring & Validation

- Monitor the GitHub `Publish to PyPI` workflow and PyPI project metadata for version `0.26.0`.
- Build and inspect artifacts from the verified `v0.26.0` tag.
- Install `inkwell-cli==0.26.0` in a clean context and verify `inkwell version`.
- Run the issue #136 TikTok capture with `--extractor codex`; validate canonical metadata and all required artifacts.
- Publication failure, version mismatch, signed URL persistence, or incomplete smoke artifacts blocks completion and triggers a follow-up patch/release.
- Validation window/owner: immediately after publication; Sergio/Codex.

Closes #136